### PR TITLE
refactor: modularize codebase with MVVM, shared utilities, and type-s…

### DIFF
--- a/scripture memory/Model/AppSettings.swift
+++ b/scripture memory/Model/AppSettings.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+// MARK: - Study Mode
+
+/// Determines how the user interacts with cards during review.
+enum StudyMode: String, CaseIterable {
+    case firstLetter
+    case fullWord
+    case submit
+
+    var displayName: String {
+        switch self {
+        case .firstLetter: return "First Letter"
+        case .fullWord:    return "Full Word"
+        case .submit:      return "Submit"
+        }
+    }
+
+    var instructions: String {
+        switch self {
+        case .firstLetter: return "Type the first letter of each word to reveal it."
+        case .fullWord:    return "Type each word in full. Case and punctuation are ignored."
+        case .submit:      return "Type the full verse on the card, then tap Submit to check all at once."
+        }
+    }
+}
+
+// MARK: - Bible Version
+
+/// The Bible translation used to source verse text.
+enum BibleVersion: String, CaseIterable {
+    case niv84 = "NIV84"
+    case niv11 = "NIV11"
+
+    var displayName: String {
+        switch self {
+        case .niv84: return "NIV 1984"
+        case .niv11: return "NIV 2011"
+        }
+    }
+
+    var packs: [Pack] {
+        self == .niv11 ? packsNIV11 : packsNIV84
+    }
+}

--- a/scripture memory/Model/DiffResult.swift
+++ b/scripture memory/Model/DiffResult.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// MARK: - Diff Word
+
+/// A single word annotated with the result of comparing a typed answer against the target.
+struct DiffWord: Identifiable {
+    enum Kind { case correct, wrong, missing, extra }
+
+    let id         = UUID()
+    let text:       String
+    let kind:       Kind
+    let correction: String?     // The expected word when kind == .wrong
+
+    init(text: String, kind: Kind, correction: String? = nil) {
+        self.text       = text
+        self.kind       = kind
+        self.correction = correction
+    }
+}
+
+// MARK: - Submit Result
+
+/// The outcome of a Submit-mode card attempt, carrying per-word diffs for title and verse.
+struct SubmitResult {
+    let titleDiffs: [DiffWord]
+    let verseDiffs: [DiffWord]
+
+    var isAllCorrect: Bool {
+        !titleDiffs.isEmpty && !verseDiffs.isEmpty
+            && titleDiffs.allSatisfy { $0.kind == .correct }
+            && verseDiffs.allSatisfy { $0.kind == .correct }
+    }
+}

--- a/scripture memory/Model/SettingsManager.swift
+++ b/scripture memory/Model/SettingsManager.swift
@@ -1,6 +1,2 @@
-import SwiftUI
-
-class SettingsManager: ObservableObject {
-    @AppStorage("bibleVersion") var bibleVersion: String = "NIV84"
-    @AppStorage("studyMode") var studyMode: String = "firstLetter"  // "firstLetter", "fullWord", or "submit"
-}
+// Settings enums and constants live in AppSettings.swift.
+// This file is intentionally empty.

--- a/scripture memory/Model/Verse.swift
+++ b/scripture memory/Model/Verse.swift
@@ -2,17 +2,23 @@ import Foundation
 
 struct Pack: Hashable, Codable, Identifiable {
     var id: String { name }
-    var name: String
-    var color: String
-    var accentText: String
-    var verses: [Verse]
+    let name:       String
+    let color:      String
+    let accentText: String
+    let verses:     [Verse]
 }
 
 struct Verse: Hashable, Codable, Identifiable {
-    var id: Int
-    var title: String
-    var verse: String
-    var book: String
-    var reference: String
-    var subpack: String
+    let id:        Int
+    let title:     String
+    let verse:     String
+    let book:      String
+    let reference: String
+    let subpack:   String
+
+    /// The title split into individual words.
+    var titleWords: [String] { title.wordTokens }
+
+    /// The verse body split into individual words.
+    var verseWords: [String] { verse.wordTokens }
 }

--- a/scripture memory/Utilities/DiffEngine.swift
+++ b/scripture memory/Utilities/DiffEngine.swift
@@ -1,0 +1,86 @@
+import UIKit
+
+// MARK: - Diff Engine
+
+/// Computes word-level diffs between a typed answer and the target using edit distance.
+enum DiffEngine {
+
+    // MARK: Public
+
+    /// Builds an array of `DiffWord` annotations comparing `typed` words to `target` words.
+    static func buildDiffs(typed: [String], target: [String]) -> [DiffWord] {
+        let m = typed.count, n = target.count
+        if m == 0 { return target.map { DiffWord(text: $0, kind: .missing) } }
+        if n == 0 { return typed.map  { DiffWord(text: $0, kind: .extra)   } }
+
+        let dp = editDistanceTable(typed: typed, target: target)
+        return backtrack(dp: dp, typed: typed, target: target)
+    }
+
+    /// Case- and punctuation-insensitive equality check.
+    static func normalizedMatch(_ a: String, _ b: String) -> Bool {
+        normalize(a) == normalize(b)
+    }
+
+    static func normalize(_ word: String) -> String {
+        word
+            .lowercased()
+            .components(separatedBy: CharacterSet.punctuationCharacters.union(.symbols))
+            .joined()
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    // MARK: Private
+
+    private static func editDistanceTable(typed: [String], target: [String]) -> [[Int]] {
+        let m = typed.count, n = target.count
+        var dp = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        for i in 0...m { dp[i][0] = i }
+        for j in 0...n { dp[0][j] = j }
+        for i in 1...m {
+            for j in 1...n {
+                dp[i][j] = normalizedMatch(typed[i - 1], target[j - 1])
+                    ? dp[i - 1][j - 1]
+                    : 1 + min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1])
+            }
+        }
+        return dp
+    }
+
+    /// Backtracks through the edit-distance table to produce the annotated diff list.
+    ///
+    /// Tiebreaking: when a substitution and an insertion cost the same AND there are more
+    /// target words than typed words at the current position, prefer insertion (missing)
+    /// so a single mistyped word aligns with the *first* target word, not the last.
+    private static func backtrack(dp: [[Int]], typed: [String], target: [String]) -> [DiffWord] {
+        var diffs: [DiffWord] = []
+        var i = typed.count, j = target.count
+        while i > 0 || j > 0 {
+            if i > 0 && j > 0 && normalizedMatch(typed[i - 1], target[j - 1]) {
+                diffs.append(DiffWord(text: target[j - 1], kind: .correct))
+                i -= 1; j -= 1
+            } else if i > 0 && j > 0
+                        && dp[i][j] == dp[i - 1][j - 1] + 1
+                        && (j <= i || dp[i][j] < dp[i][j - 1] + 1) {
+                diffs.append(DiffWord(text: typed[i - 1], kind: .wrong, correction: target[j - 1]))
+                i -= 1; j -= 1
+            } else if j > 0 && (i == 0 || dp[i][j - 1] <= dp[i - 1][j]) {
+                diffs.append(DiffWord(text: target[j - 1], kind: .missing))
+                j -= 1
+            } else {
+                diffs.append(DiffWord(text: typed[i - 1], kind: .extra))
+                i -= 1
+            }
+        }
+        return diffs.reversed()
+    }
+}
+
+// MARK: - Haptic Engine
+
+/// Thin wrappers around UIKit feedback generators for consistent haptic responses.
+enum HapticEngine {
+    static func light()   { UIImpactFeedbackGenerator(style: .light).impactOccurred() }
+    static func success() { UINotificationFeedbackGenerator().notificationOccurred(.success) }
+    static func error()   { UINotificationFeedbackGenerator().notificationOccurred(.error) }
+}

--- a/scripture memory/Utilities/SharedUtilities.swift
+++ b/scripture memory/Utilities/SharedUtilities.swift
@@ -1,27 +1,73 @@
-/*
- See the LICENSE.txt file for this sample's licensing information.
- 
- Abstract:
- Shared utilities and preference keys for the app.
- */
-
 import SwiftUI
 
-// MARK: - Preference Keys
+// MARK: - String
 
-struct ScrollOffsetPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
+extension String {
+    /// Splits into non-empty words on single spaces, matching verse storage format.
+    var wordTokens: [String] {
+        components(separatedBy: " ").filter { !$0.isEmpty }
     }
 }
 
-// MARK: - String Extensions
+// MARK: - Color
 
-extension String {
-    func character(at index: Int) -> Character? {
-        guard index >= 0 && index < count else { return nil }
-        return self[self.index(startIndex, offsetBy: index)]
+extension Color {
+    /// Initialises a Color from a 6-digit hex string, with or without a leading `#`.
+    init?(hex: String) {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if h.hasPrefix("#") { h.removeFirst() }
+        guard h.count == 6, let val = UInt64(h, radix: 16) else { return nil }
+        self.init(
+            red:   Double((val >> 16) & 0xFF) / 255,
+            green: Double((val >> 8)  & 0xFF) / 255,
+            blue:  Double( val        & 0xFF) / 255
+        )
+    }
+
+    /// A desaturated, darker variant suitable for muted pack-cover backgrounds.
+    var muted: Color {
+        let uic = UIColor(self)
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uic.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        return Color(hue: Double(h), saturation: Double(s * 0.55), brightness: Double(b * 0.7))
+    }
+}
+
+// MARK: - Flashcard Style
+
+extension View {
+    /// Applies the standard card appearance: parchment background, rounded corners, shadows.
+    func flashcardStyle() -> some View {
+        self
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(flashcardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(.separator).opacity(0.5), lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(0.12), radius: 16, x: 0, y: 8)
+            .shadow(color: .black.opacity(0.05), radius: 2,  x: 0, y: 1)
+            .contentShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+/// Adaptive parchment-style background shared by all card types.
+let flashcardBackground = Color(uiColor: UIColor { tc in
+    tc.userInterfaceStyle == .dark
+        ? UIColor(white: 0.13, alpha: 1)
+        : UIColor(red: 0.98, green: 0.965, blue: 0.94, alpha: 1)
+})
+
+// MARK: - Card Button Style
+
+/// Press-to-scale feedback for tappable pack cards.
+struct CardButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.7), value: configuration.isPressed)
     }
 }

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -1,76 +1,46 @@
 import SwiftUI
 
 struct CardStudyView: View {
-    let packName: String
-    let verses: [Verse]
 
-    @State private var currentIndex = 0
-    @State private var isReviewMode = false
-    @State private var titleRevealedCounts: [Int: Int] = [:]
-    @State private var verseRevealedCounts: [Int: Int] = [:]
-    @State private var activeSection: ReviewSection = .verse
-    @State private var inputText = ""
-    @State private var titleInput = ""
-    @State private var verseInput = ""
-    @State private var shakeOffset: CGFloat = 0
-    @State private var dragOffset: CGSize = .zero
-    @State private var isCardFlying = false
-    @State private var flyDirection: Int = 0
-    @State private var submitResults: [Int: SubmitResult] = [:]
-    @State private var speechTarget: SubmitField = .title
-    @StateObject private var speech = SpeechRecognizer()
-    @FocusState private var isInputFocused: Bool
-    @FocusState private var submitFocus: SubmitField?
-    @Environment(\.dismiss) private var dismiss
-    @AppStorage("studyMode") private var studyMode = "firstLetter"
+    // MARK: - State
+
+    @StateObject private var vm:     CardStudyViewModel
+    @StateObject private var speech: SpeechRecognizer = SpeechRecognizer()
+
+    @AppStorage("studyMode")       private var studyMode:       StudyMode = .firstLetter
     @AppStorage("isVerticalScroll") private var isVerticalScroll = false
 
-    private var currentVerse: Verse? {
-        guard !verses.isEmpty, verses.indices.contains(currentIndex) else { return nil }
-        return verses[currentIndex]
+    @FocusState private var isInputFocused: Bool
+    @FocusState private var submitFocus:    SubmitField?
+
+    @State private var dragOffset:   CGSize  = .zero
+    @State private var isCardFlying          = false
+    @State private var flyDirection: Int     = 0
+    @State private var shakeOffset:  CGFloat = 0
+    @State private var speechTarget: SubmitField = .title
+
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Swipe Constants
+
+    private enum Swipe {
+        static let threshold:         CGFloat = 80
+        static let velocityThreshold: CGFloat = 400
+        static let flyWidth:          CGFloat = 600
+        static let prevCardOffset:    CGFloat = 420
     }
 
-    private var currentWords: [String] {
-        guard let v = currentVerse else { return [] }
-        switch activeSection {
-        case .title: return v.title.components(separatedBy: " ").filter { !$0.isEmpty }
-        case .verse: return v.verse.components(separatedBy: " ").filter { !$0.isEmpty }
-        }
+    // MARK: - Init
+
+    init(packName: String, verses: [Verse]) {
+        _vm = StateObject(wrappedValue: CardStudyViewModel(packName: packName, verses: verses))
     }
 
-    private var currentRevealed: Int {
-        guard let v = currentVerse else { return 0 }
-        switch activeSection {
-        case .title: return titleRevealedCounts[v.id, default: 0]
-        case .verse: return verseRevealedCounts[v.id, default: 0]
-        }
-    }
-
-    private var isCardComplete: Bool {
-        guard let v = currentVerse else { return false }
-        if studyMode == "submit" {
-            guard let result = submitResults[v.id] else { return false }
-            return result.isAllCorrect
-        }
-        let tWords = v.title.components(separatedBy: " ").filter { !$0.isEmpty }
-        let vWords = v.verse.components(separatedBy: " ").filter { !$0.isEmpty }
-        return titleRevealedCounts[v.id, default: 0] >= tWords.count
-            && verseRevealedCounts[v.id, default: 0] >= vWords.count
-    }
-
-    private var forwardProgress: CGFloat {
-        guard dragOffset.width < 0 else { return 0 }
-        return min(abs(dragOffset.width) / 150, 1.0)
-    }
-
-    private var backwardProgress: CGFloat {
-        guard dragOffset.width > 0 else { return 0 }
-        return min(dragOffset.width / 200, 1.0)
-    }
+    // MARK: - Body
 
     var body: some View {
         GeometryReader { geo in
-            let cardWidth = geo.size.width - 40
+            let cardWidth  = geo.size.width - 40
             let cardHeight = cardWidth * 3.0 / 5.0
 
             VStack(spacing: 0) {
@@ -81,11 +51,9 @@ struct CardStudyView: View {
                         .frame(maxHeight: .infinity)
                 } else {
                     Spacer(minLength: 12)
-
                     cardStack
                         .frame(width: cardWidth, height: cardHeight)
                         .frame(maxWidth: .infinity)
-
                     Spacer(minLength: 12)
                 }
 
@@ -97,41 +65,17 @@ struct CardStudyView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
-        .onChange(of: isReviewMode) { reviewing in
-            if reviewing && !isCardComplete {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    if studyMode == "submit" {
-                        submitFocus = .title
-                    } else {
-                        isInputFocused = true
-                    }
-                }
-            } else {
-                if speech.isListening { speech.stopListening() }
-                isInputFocused = false
-                submitFocus = nil
-            }
-        }
-        .onChange(of: currentIndex) { _ in
+        .onChange(of: vm.isReviewMode) { handleReviewModeChange($0) }
+        .onChange(of: vm.currentIndex) { _ in
+            vm.clearInputs()
             if speech.isListening { speech.stopListening() }
-            inputText = ""
-            titleInput = ""
-            verseInput = ""
-            if isReviewMode && !isCardComplete {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    if studyMode == "submit" {
-                        submitFocus = .title
-                    } else {
-                        isInputFocused = true
-                    }
-                }
-            }
+            refocusIfNeeded()
         }
-        .onChange(of: speech.transcript) { newValue in
+        .onChange(of: speech.transcript) { text in
             guard speech.isListening else { return }
             switch speechTarget {
-            case .title: titleInput = newValue
-            case .verse: verseInput = newValue
+            case .title: vm.titleInput = text
+            case .verse: vm.verseInput = text
             }
         }
         .onChange(of: submitFocus) { newFocus in
@@ -142,223 +86,33 @@ struct CardStudyView: View {
         }
     }
 
-    // MARK: - Card Stack
-
-    private var cardStack: some View {
-        ZStack {
-            if currentIndex + 2 < verses.count {
-                backgroundCard(at: currentIndex + 2)
-                    .scaleEffect(0.90).offset(y: 24).zIndex(0)
-            }
-            if currentIndex + 1 < verses.count {
-                backgroundCard(at: currentIndex + 1)
-                    .scaleEffect(0.95 + 0.05 * forwardProgress)
-                    .offset(y: 12 * (1 - forwardProgress))
-                    .zIndex(1)
-            }
-
-            if let verse = currentVerse {
-                let goingBack = dragOffset.width > 0
-                makeCard(verse: verse, interactive: true)
-                    .offset(
-                        x: goingBack ? 0 : dragOffset.width,
-                        y: goingBack ? backwardProgress * 12 : dragOffset.height * 0.1
-                    )
-                    .scaleEffect(goingBack ? 1.0 - backwardProgress * 0.05 : 1.0)
-                    .rotationEffect(goingBack ? .zero : .degrees(Double(dragOffset.width) * 0.03))
-                    .zIndex(2)
-                    .gesture(swipeGesture)
-            }
-
-            if currentIndex > 0 && dragOffset.width > 0 {
-                let prevVerse = verses[currentIndex - 1]
-                makeCard(verse: prevVerse, interactive: false)
-                    .offset(x: dragOffset.width - 420)
-                    .rotationEffect(.degrees(Double(dragOffset.width - 420) * 0.02))
-                    .zIndex(3)
-            }
-        }
-    }
-
-    private func verticalScrollCards(cardWidth: CGFloat, cardHeight: CGFloat) -> some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(spacing: 20) {
-                    ForEach(Array(verses.enumerated()), id: \.offset) { index, verse in
-                        makeCard(verse: verse, interactive: index == currentIndex)
-                            .frame(width: cardWidth, height: cardHeight)
-                            .id(index)
-                            .overlay {
-                                if index != currentIndex {
-                                    Color.clear
-                                        .contentShape(Rectangle())
-                                        .onTapGesture {
-                                            haptic(.light)
-                                            currentIndex = index
-                                        }
-                                }
-                            }
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-            }
-            .onAppear {
-                proxy.scrollTo(currentIndex, anchor: .center)
-            }
-            .onChange(of: currentIndex) { newIndex in
-                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
-                    proxy.scrollTo(newIndex, anchor: .center)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func backgroundCard(at index: Int) -> some View {
-        if verses.indices.contains(index) {
-            makeCard(verse: verses[index], interactive: false)
-        }
-    }
-
-    @ViewBuilder
-    private func makeCard(verse: Verse, interactive: Bool) -> some View {
-        if studyMode == "submit" && isReviewMode {
-            SubmitCardView(
-                verse: verse,
-                cardLabel: cardLabel(for: verse),
-                titleText: interactive ? $titleInput : .constant(""),
-                verseText: interactive ? $verseInput : .constant(""),
-                result: submitResults[verse.id],
-                focusedField: $submitFocus
-            )
-        } else {
-            FlashcardView(
-                verse: verse,
-                cardLabel: cardLabel(for: verse),
-                isReviewMode: isReviewMode,
-                titleRevealedCount: titleRevealedCounts[verse.id, default: 0],
-                verseRevealedCount: verseRevealedCounts[verse.id, default: 0],
-                activeSection: activeSection,
-                onSectionTap: interactive ? { section in
-                    withAnimation(.easeOut(duration: 0.2)) { activeSection = section }
-                } : nil
-            )
-        }
-    }
-
-    private var swipeGesture: some Gesture {
-        DragGesture()
-            .onChanged { value in
-                if isCardFlying { commitSwipe() }
-                let tx = value.translation.width
-                let canGoNext = currentIndex < verses.count - 1
-                let canGoPrev = currentIndex > 0
-                if (tx < 0 && canGoNext) || (tx > 0 && canGoPrev) {
-                    dragOffset = value.translation
-                } else {
-                    dragOffset = CGSize(width: tx * 0.15, height: value.translation.height * 0.15)
-                }
-            }
-            .onEnded { value in
-                if isCardFlying { commitSwipe() }
-                let threshold: CGFloat = 80
-                let vx = value.predictedEndTranslation.width
-                if (dragOffset.width < -threshold || vx < -400) && currentIndex < verses.count - 1 {
-                    swipeForward()
-                } else if (dragOffset.width > threshold || vx > 400) && currentIndex > 0 {
-                    swipeBackward()
-                } else {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
-                        dragOffset = .zero
-                    }
-                }
-            }
-    }
-
-    private func swipeForward() {
-        isCardFlying = true; flyDirection = -1; haptic(.light)
-        withAnimation(.easeOut(duration: 0.2)) {
-            dragOffset = CGSize(width: -600, height: dragOffset.height)
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { commitSwipe() }
-    }
-
-    private func swipeBackward() {
-        isCardFlying = true; flyDirection = 1; haptic(.light)
-        withAnimation(.easeOut(duration: 0.2)) {
-            dragOffset = CGSize(width: 420, height: 0)
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { commitSwipe() }
-    }
-
-    private func commitSwipe() {
-        guard isCardFlying else { return }
-        var t = Transaction(); t.disablesAnimations = true
-        withTransaction(t) {
-            if flyDirection < 0, currentIndex < verses.count - 1 { currentIndex += 1 }
-            else if flyDirection > 0, currentIndex > 0 { currentIndex -= 1 }
-            dragOffset = .zero; isCardFlying = false; flyDirection = 0
-        }
-    }
-
     // MARK: - Top Bar
 
     private var topBar: some View {
         HStack {
             Button { dismiss() } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundColor(.secondary)
-                    .frame(width: 32, height: 32)
-                    .background(Color(.tertiarySystemGroupedBackground))
-                    .clipShape(Circle())
+                Image(systemName: "xmark").topBarButton()
             }
 
             Spacer()
 
             VStack(spacing: 2) {
-                Text(packName)
+                Text(vm.packName)
                     .font(.system(size: 15, weight: .semibold))
                     .lineLimit(1)
-                Text("\(currentIndex + 1) of \(verses.count)")
+                Text("\(vm.currentIndex + 1) of \(vm.verses.count)")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(.secondary)
             }
 
             Spacer()
 
-            let canReset = isReviewMode && (
-                studyMode == "submit"
-                    ? submitResults[currentVerse?.id ?? -1] != nil
-                    : (titleRevealedCounts[currentVerse?.id ?? -1, default: 0] > 0
-                       || verseRevealedCounts[currentVerse?.id ?? -1, default: 0] > 0)
-            )
-
             HStack(spacing: 6) {
-                if canReset, let verse = currentVerse {
-                    Button {
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                            if studyMode == "submit" {
-                                submitResults.removeValue(forKey: verse.id)
-                                titleInput = ""
-                                verseInput = ""
-                            } else {
-                                titleRevealedCounts[verse.id] = 0
-                                verseRevealedCounts[verse.id] = 0
-                            }
-                        }
-                        haptic(.light)
-                    } label: {
-                        Image(systemName: "arrow.counterclockwise")
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(.secondary)
-                            .frame(width: 32, height: 32)
-                            .background(Color(.tertiarySystemGroupedBackground))
-                            .clipShape(Circle())
+                if vm.canReset {
+                    Button { vm.resetCurrentCard() } label: {
+                        Image(systemName: "arrow.counterclockwise").topBarButton()
                     }
                 }
-
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         isVerticalScroll.toggle()
@@ -377,54 +131,151 @@ struct CardStudyView: View {
         .padding(.top, 12)
     }
 
+    // MARK: - Card Stack (horizontal swipe mode)
+
+    private var cardStack: some View {
+        ZStack {
+            if vm.currentIndex + 2 < vm.verses.count {
+                backgroundCard(at: vm.currentIndex + 2)
+                    .scaleEffect(0.90).offset(y: 24).zIndex(0)
+            }
+            if vm.currentIndex + 1 < vm.verses.count {
+                backgroundCard(at: vm.currentIndex + 1)
+                    .scaleEffect(0.95 + 0.05 * forwardDragProgress)
+                    .offset(y: 12 * (1 - forwardDragProgress))
+                    .zIndex(1)
+            }
+            if let verse = vm.currentVerse {
+                let goingBack = dragOffset.width > 0
+                makeCard(verse: verse, interactive: true)
+                    .offset(x: goingBack ? 0 : dragOffset.width,
+                            y: goingBack ? backwardDragProgress * 12 : dragOffset.height * 0.1)
+                    .scaleEffect(goingBack ? 1.0 - backwardDragProgress * 0.05 : 1.0)
+                    .rotationEffect(goingBack ? .zero : .degrees(Double(dragOffset.width) * 0.03))
+                    .zIndex(2)
+                    .gesture(swipeGesture)
+            }
+            if vm.currentIndex > 0 && dragOffset.width > 0 {
+                makeCard(verse: vm.verses[vm.currentIndex - 1], interactive: false)
+                    .offset(x: dragOffset.width - Swipe.prevCardOffset)
+                    .rotationEffect(.degrees(Double(dragOffset.width - Swipe.prevCardOffset) * 0.02))
+                    .zIndex(3)
+            }
+        }
+    }
+
+    // MARK: - Vertical Scroll Mode
+
+    private func verticalScrollCards(cardWidth: CGFloat, cardHeight: CGFloat) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(spacing: 20) {
+                    ForEach(Array(vm.verses.enumerated()), id: \.offset) { index, verse in
+                        makeCard(verse: verse, interactive: index == vm.currentIndex)
+                            .frame(width: cardWidth, height: cardHeight)
+                            .id(index)
+                            .overlay {
+                                if index != vm.currentIndex {
+                                    Color.clear.contentShape(Rectangle())
+                                        .onTapGesture {
+                                            HapticEngine.light()
+                                            vm.currentIndex = index
+                                        }
+                                }
+                            }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+            }
+            .onAppear { proxy.scrollTo(vm.currentIndex, anchor: .center) }
+            .onChange(of: vm.currentIndex) { newIndex in
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                    proxy.scrollTo(newIndex, anchor: .center)
+                }
+            }
+        }
+    }
+
+    // MARK: - Card Builders
+
+    @ViewBuilder
+    private func backgroundCard(at index: Int) -> some View {
+        if vm.verses.indices.contains(index) {
+            makeCard(verse: vm.verses[index], interactive: false)
+        }
+    }
+
+    @ViewBuilder
+    private func makeCard(verse: Verse, interactive: Bool) -> some View {
+        if studyMode == .submit && vm.isReviewMode {
+            SubmitCardView(
+                verse: verse,
+                cardLabel: vm.cardLabel(for: verse),
+                titleText: interactive ? $vm.titleInput : .constant(""),
+                verseText: interactive ? $vm.verseInput : .constant(""),
+                result: vm.submitResults[verse.id],
+                focusedField: $submitFocus
+            )
+        } else {
+            FlashcardView(
+                verse: verse,
+                cardLabel: vm.cardLabel(for: verse),
+                isReviewMode: vm.isReviewMode,
+                titleRevealedCount: vm.revealedCount(for: verse.id, section: .title),
+                verseRevealedCount: vm.revealedCount(for: verse.id, section: .verse),
+                activeSection: vm.activeSection,
+                onSectionTap: interactive ? { section in
+                    withAnimation(.easeOut(duration: 0.2)) { vm.activeSection = section }
+                } : nil
+            )
+        }
+    }
+
     // MARK: - Scrubber
 
     private var scrubberRow: some View {
         HStack(spacing: 10) {
             Button {
-                guard currentIndex > 0 else { return }
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) { currentIndex -= 1 }
-                haptic(.light)
+                vm.goBackward(); HapticEngine.light()
             } label: {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(currentIndex > 0 ? .primary.opacity(0.7) : .secondary.opacity(0.25))
+                    .foregroundColor(vm.currentIndex > 0 ? .primary.opacity(0.7) : .secondary.opacity(0.25))
                     .frame(width: 28, height: 28)
             }
-            .disabled(currentIndex == 0)
+            .disabled(vm.currentIndex == 0)
 
             scrubber
 
             Button {
-                guard currentIndex < verses.count - 1 else { return }
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) { currentIndex += 1 }
-                haptic(.light)
+                vm.goForward(); HapticEngine.light()
             } label: {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(currentIndex < verses.count - 1 ? .primary.opacity(0.7) : .secondary.opacity(0.25))
+                    .foregroundColor(vm.currentIndex < vm.verses.count - 1 ? .primary.opacity(0.7) : .secondary.opacity(0.25))
                     .frame(width: 28, height: 28)
             }
-            .disabled(currentIndex == verses.count - 1)
+            .disabled(vm.currentIndex == vm.verses.count - 1)
         }
     }
 
     private var scrubber: some View {
         GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
-            let knobX: CGFloat = verses.count > 1
-                ? CGFloat(currentIndex) / CGFloat(verses.count - 1) * (w - 14) + 7
+            let w     = geo.size.width
+            let h     = geo.size.height
+            let knobX = vm.verses.count > 1
+                ? CGFloat(vm.currentIndex) / CGFloat(vm.verses.count - 1) * (w - 14) + 7
                 : w / 2
-            let fillW: CGFloat = max(4, w * CGFloat(currentIndex + 1) / CGFloat(max(1, verses.count)))
+            let fillW = max(4, w * CGFloat(vm.currentIndex + 1) / CGFloat(max(1, vm.verses.count)))
 
             Capsule().fill(Color(.systemGray5)).frame(height: 4).position(x: w / 2, y: h / 2)
             Capsule().fill(Color.primary.opacity(0.3)).frame(width: fillW, height: 4)
                 .position(x: fillW / 2, y: h / 2)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: currentIndex)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: vm.currentIndex)
             Circle().fill(Color.primary.opacity(0.55)).frame(width: 14, height: 14)
                 .position(x: knobX, y: h / 2)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: currentIndex)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: vm.currentIndex)
         }
         .frame(height: 20)
         .overlay {
@@ -432,9 +283,10 @@ struct CardStudyView: View {
                 Color.clear.contentShape(Rectangle())
                     .gesture(DragGesture(minimumDistance: 0).onChanged { value in
                         let fraction = max(0, min(1, value.location.x / geo.size.width))
-                        let newIndex = Int(round(fraction * CGFloat(verses.count - 1)))
-                        if newIndex != currentIndex && verses.indices.contains(newIndex) {
-                            currentIndex = newIndex; haptic(.light)
+                        let newIndex = Int(round(fraction * CGFloat(vm.verses.count - 1)))
+                        if newIndex != vm.currentIndex && vm.verses.indices.contains(newIndex) {
+                            vm.currentIndex = newIndex
+                            HapticEngine.light()
                         }
                     })
             }
@@ -445,8 +297,8 @@ struct CardStudyView: View {
 
     private var bottomControls: some View {
         VStack(spacing: 12) {
-            if isReviewMode {
-                if isCardComplete {
+            if vm.isReviewMode {
+                if vm.isCardComplete {
                     HStack(spacing: 8) {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(.green).font(.system(size: 22))
@@ -455,14 +307,14 @@ struct CardStudyView: View {
                     }
                     .transition(.scale.combined(with: .opacity))
                     .padding(.bottom, 2)
-                } else if studyMode == "submit" {
+                } else if studyMode == .submit {
                     submitControls
                 } else {
-                    immediateInputField
+                    inputField
                 }
             }
 
-            Picker("Mode", selection: $isReviewMode) {
+            Picker("Mode", selection: $vm.isReviewMode) {
                 Text("Read").tag(false)
                 Text("Review").tag(true)
             }
@@ -470,20 +322,20 @@ struct CardStudyView: View {
             .padding(.horizontal, 24)
         }
         .padding(.bottom, 24)
-        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isReviewMode)
-        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isCardComplete)
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: vm.isReviewMode)
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: vm.isCardComplete)
     }
 
+    /// Submit mode: mic + submit button before scoring, try-again after.
     private var submitControls: some View {
-        let hasSubmitted = currentVerse.flatMap { submitResults[$0.id] } != nil
+        let hasResult = vm.currentVerse.flatMap { vm.submitResults[$0.id] } != nil
         return Group {
-            if hasSubmitted {
-                Button { retrySubmit() } label: {
+            if hasResult {
+                Button { vm.retrySubmit() } label: {
                     Label("Try Again", systemImage: "arrow.counterclockwise")
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.primary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
+                        .frame(maxWidth: .infinity).padding(.vertical, 12)
                         .background(Color(.secondarySystemGroupedBackground))
                         .cornerRadius(12)
                 }
@@ -497,47 +349,54 @@ struct CardStudyView: View {
                             .background(speech.isListening ? Color.red : Color(.secondarySystemGroupedBackground))
                             .cornerRadius(12)
                     }
-
-                    Button(action: handleSubmit) {
-                        let isEmpty = titleInput.trimmingCharacters(in: .whitespaces).isEmpty
-                            && verseInput.trimmingCharacters(in: .whitespaces).isEmpty
+                    Button {
+                        if speech.isListening { speech.stopListening() }
+                        let result = vm.handleSubmit()
+                        submitFocus = nil
+                        result?.isAllCorrect == true ? HapticEngine.success() : HapticEngine.error()
+                    } label: {
+                        let empty = vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
+                            && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty
                         Text("Submit")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(isEmpty ? Color(.systemGray3) : Color.blue)
+                            .font(.system(size: 16, weight: .semibold)).foregroundColor(.white)
+                            .frame(maxWidth: .infinity).padding(.vertical, 12)
+                            .background(empty ? Color(.systemGray3) : Color.blue)
                             .cornerRadius(12)
                     }
-                    .disabled(titleInput.trimmingCharacters(in: .whitespaces).isEmpty
-                        && verseInput.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
+                        && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
         }
         .padding(.horizontal, 24)
     }
 
-    private var immediateInputField: some View {
-        let placeholder = studyMode == "fullWord"
-            ? "Type each word, press space to check..."
-            : "Type first letter of each word..."
-
-        return HStack(spacing: 10) {
+    /// First-letter and full-word modes share this single text field.
+    private var inputField: some View {
+        HStack(spacing: 10) {
             Image(systemName: "character.cursor.ibeam")
                 .foregroundColor(.secondary).font(.system(size: 16))
 
-            TextField(placeholder, text: $inputText)
+            TextField(studyMode.inputPlaceholder, text: $vm.inputText)
                 .font(.system(size: 17))
                 .focused($isInputFocused)
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
-                .onChange(of: inputText) { newValue in
+                .onChange(of: vm.inputText) { newValue in
                     guard !newValue.isEmpty else { return }
-                    if studyMode == "firstLetter" {
-                        processFirstLetterInput(newValue)
-                        DispatchQueue.main.async { self.inputText = "" }
-                    } else {
-                        processFullWordInput(newValue)
+                    switch studyMode {
+                    case .firstLetter:
+                        let correct = vm.processFirstLetterInput(newValue)
+                        DispatchQueue.main.async { vm.inputText = "" }
+                        if correct { HapticEngine.light() } else { HapticEngine.error(); shakeAnimation() }
+                    case .fullWord:
+                        if vm.processFullWordInput(newValue) {
+                            HapticEngine.light()
+                        } else if newValue.hasSuffix(" ") {
+                            HapticEngine.error(); shakeAnimation()
+                        }
+                    case .submit:
+                        break
                     }
                 }
         }
@@ -549,76 +408,91 @@ struct CardStudyView: View {
         .padding(.horizontal, 24)
     }
 
-    // MARK: - Input Processing (immediate modes)
+    // MARK: - Swipe Gesture
 
-    private func processFirstLetterInput(_ text: String) {
-        guard let typed = text.last, let verse = currentVerse else { return }
-        let words = currentWords
-        let revealed = currentRevealed
-        guard revealed < words.count else { return }
-        let targetWord = words[revealed]
-        guard let expected = firstLetter(of: targetWord) else {
-            setRevealed(verse.id, revealed + 1); return
+    private var forwardDragProgress: CGFloat {
+        guard dragOffset.width < 0 else { return 0 }
+        return min(abs(dragOffset.width) / 150, 1.0)
+    }
+
+    private var backwardDragProgress: CGFloat {
+        guard dragOffset.width > 0 else { return 0 }
+        return min(dragOffset.width / 200, 1.0)
+    }
+
+    private var swipeGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                if isCardFlying { commitSwipe() }
+                let tx      = value.translation.width
+                let canNext = vm.currentIndex < vm.verses.count - 1
+                let canPrev = vm.currentIndex > 0
+                if (tx < 0 && canNext) || (tx > 0 && canPrev) {
+                    dragOffset = value.translation
+                } else {
+                    dragOffset = CGSize(width: tx * 0.15, height: value.translation.height * 0.15)
+                }
+            }
+            .onEnded { value in
+                if isCardFlying { commitSwipe() }
+                let vx = value.predictedEndTranslation.width
+                if (dragOffset.width < -Swipe.threshold || vx < -Swipe.velocityThreshold),
+                   vm.currentIndex < vm.verses.count - 1 {
+                    swipeForward()
+                } else if (dragOffset.width > Swipe.threshold || vx > Swipe.velocityThreshold),
+                          vm.currentIndex > 0 {
+                    swipeBackward()
+                } else {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) { dragOffset = .zero }
+                }
+            }
+    }
+
+    private func swipeForward() {
+        isCardFlying = true; flyDirection = -1; HapticEngine.light()
+        withAnimation(.easeOut(duration: 0.2)) {
+            dragOffset = CGSize(width: -Swipe.flyWidth, height: dragOffset.height)
         }
-        if typed.lowercased() == String(expected).lowercased() {
-            let newCount = revealed + 1
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) { setRevealed(verse.id, newCount) }
-            completeSectionIfNeeded(verse: verse, newCount: newCount, words: words)
-        } else {
-            haptic(.error); shakeAnimation()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { commitSwipe() }
+    }
+
+    private func swipeBackward() {
+        isCardFlying = true; flyDirection = 1; HapticEngine.light()
+        withAnimation(.easeOut(duration: 0.2)) {
+            dragOffset = CGSize(width: Swipe.prevCardOffset, height: 0)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { commitSwipe() }
+    }
+
+    private func commitSwipe() {
+        guard isCardFlying else { return }
+        var t = Transaction(); t.disablesAnimations = true
+        withTransaction(t) {
+            if flyDirection < 0, vm.currentIndex < vm.verses.count - 1 { vm.currentIndex += 1 }
+            else if flyDirection > 0, vm.currentIndex > 0             { vm.currentIndex -= 1 }
+            dragOffset = .zero; isCardFlying = false; flyDirection = 0
         }
     }
 
-    private func processFullWordInput(_ text: String) {
-        guard text.hasSuffix(" "), let verse = currentVerse else { return }
-        let typedWord = String(text.dropLast()).trimmingCharacters(in: .whitespaces)
-        guard !typedWord.isEmpty else {
-            DispatchQueue.main.async { self.inputText = "" }; return
-        }
-        let words = currentWords
-        let revealed = currentRevealed
-        guard revealed < words.count else { return }
-        if normalizedMatch(typedWord, words[revealed]) {
-            let newCount = revealed + 1
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) { setRevealed(verse.id, newCount) }
-            DispatchQueue.main.async { self.inputText = "" }
-            completeSectionIfNeeded(verse: verse, newCount: newCount, words: words)
+    // MARK: - Focus & Speech
+
+    private func handleReviewModeChange(_ reviewing: Bool) {
+        if reviewing && !vm.isCardComplete {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { focusInput() }
         } else {
-            haptic(.error); shakeAnimation()
-            DispatchQueue.main.async { self.inputText = "" }
+            if speech.isListening { speech.stopListening() }
+            isInputFocused = false
+            submitFocus    = nil
         }
     }
 
-    // MARK: - Submit Mode
+    private func refocusIfNeeded() {
+        guard vm.isReviewMode && !vm.isCardComplete else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { focusInput() }
+    }
 
-    private func handleSubmit() {
-        if speech.isListening { speech.stopListening() }
-        guard let verse = currentVerse else { return }
-        let titleRaw = titleInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        let verseRaw = verseInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !titleRaw.isEmpty || !verseRaw.isEmpty else { return }
-
-        let typedTitleWords = titleRaw.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-        let typedVerseWords = verseRaw.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-        let targetTitleWords = verse.title.components(separatedBy: " ").filter { !$0.isEmpty }
-        let targetVerseWords = verse.verse.components(separatedBy: " ").filter { !$0.isEmpty }
-
-        let titleDiffs = buildDiffs(typed: typedTitleWords, target: targetTitleWords)
-        let verseDiffs = buildDiffs(typed: typedVerseWords, target: targetVerseWords)
-        let result = SubmitResult(titleDiffs: titleDiffs, verseDiffs: verseDiffs)
-
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-            submitResults[verse.id] = result
-        }
-        titleInput = ""
-        verseInput = ""
-        submitFocus = nil
-
-        if result.isAllCorrect {
-            haptic(.success)
-        } else {
-            haptic(.error)
-        }
+    private func focusInput() {
+        studyMode == .submit ? (submitFocus = .title) : (isInputFocused = true)
     }
 
     private func toggleSpeech() {
@@ -630,120 +504,7 @@ struct CardStudyView: View {
         }
     }
 
-    private func buildDiffs(typed: [String], target: [String]) -> [DiffWord] {
-        let m = typed.count, n = target.count
-        if m == 0 { return target.map { DiffWord(text: $0, kind: .missing) } }
-        if n == 0 { return typed.map { DiffWord(text: $0, kind: .extra) } }
-
-        var dp = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
-        for i in 0...m { dp[i][0] = i }
-        for j in 0...n { dp[0][j] = j }
-
-        for i in 1...m {
-            for j in 1...n {
-                if normalizedMatch(typed[i - 1], target[j - 1]) {
-                    dp[i][j] = dp[i - 1][j - 1]
-                } else {
-                    dp[i][j] = 1 + min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1])
-                }
-            }
-        }
-
-        var diffs: [DiffWord] = []
-        var i = m, j = n
-        while i > 0 || j > 0 {
-            if i > 0 && j > 0 && normalizedMatch(typed[i - 1], target[j - 1]) {
-                diffs.append(DiffWord(text: target[j - 1], kind: .correct))
-                i -= 1; j -= 1
-            } else if i > 0 && j > 0 && dp[i][j] == dp[i - 1][j - 1] + 1
-                        && (j <= i || dp[i][j] < dp[i][j - 1] + 1) {
-                diffs.append(DiffWord(text: typed[i - 1], kind: .wrong, correction: target[j - 1]))
-                i -= 1; j -= 1
-            } else if j > 0 && (i == 0 || dp[i][j - 1] <= dp[i - 1][j]) {
-                diffs.append(DiffWord(text: target[j - 1], kind: .missing))
-                j -= 1
-            } else {
-                diffs.append(DiffWord(text: typed[i - 1], kind: .extra))
-                i -= 1
-            }
-        }
-
-        return diffs.reversed()
-    }
-
-    private func retrySubmit() {
-        guard let verse = currentVerse else { return }
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-            submitResults.removeValue(forKey: verse.id)
-        }
-        titleInput = ""
-        verseInput = ""
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            submitFocus = .title
-        }
-    }
-
-    // MARK: - Helpers
-
-    private func completeSectionIfNeeded(verse: Verse, newCount: Int, words: [String]) {
-        guard newCount >= words.count else { haptic(.light); return }
-        let otherSection: ReviewSection = activeSection == .title ? .verse : .title
-        let otherWords: [String]
-        let otherRevealed: Int
-        switch otherSection {
-        case .title:
-            otherWords = verse.title.components(separatedBy: " ").filter { !$0.isEmpty }
-            otherRevealed = titleRevealedCounts[verse.id, default: 0]
-        case .verse:
-            otherWords = verse.verse.components(separatedBy: " ").filter { !$0.isEmpty }
-            otherRevealed = verseRevealedCounts[verse.id, default: 0]
-        }
-        haptic(.success)
-        if otherRevealed < otherWords.count {
-            withAnimation(.easeOut(duration: 0.2)) { activeSection = otherSection }
-        }
-    }
-
-    private func normalizedMatch(_ typed: String, _ target: String) -> Bool {
-        normalize(typed) == normalize(target)
-    }
-
-    private func normalize(_ s: String) -> String {
-        s.lowercased()
-         .components(separatedBy: CharacterSet.punctuationCharacters.union(.symbols))
-         .joined()
-         .trimmingCharacters(in: .whitespaces)
-    }
-
-    private func setRevealed(_ verseId: Int, _ count: Int) {
-        switch activeSection {
-        case .title: titleRevealedCounts[verseId] = count
-        case .verse: verseRevealedCounts[verseId] = count
-        }
-    }
-
-    private func firstLetter(of word: String) -> Character? {
-        word.first { $0.isLetter || $0.isNumber }
-    }
-
-    private func cardLabel(for verse: Verse) -> String {
-        if verse.subpack.isEmpty { return packName }
-        let sub = verses.filter { $0.subpack == verse.subpack }
-        let pos = (sub.firstIndex(where: { $0.id == verse.id }) ?? 0) + 1
-        return "\(verse.subpack)-\(pos) · \(packName)"
-    }
-
-    // MARK: - Haptics
-
-    private enum HapticType { case light, success, error }
-
-    private func haptic(_ type: HapticType) {
-        switch type {
-        case .light:   UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        case .success: UINotificationFeedbackGenerator().notificationOccurred(.success)
-        case .error:   UINotificationFeedbackGenerator().notificationOccurred(.error)
-        }
-    }
+    // MARK: - Shake Animation
 
     private func shakeAnimation() {
         withAnimation(.interpolatingSpring(stiffness: 600, damping: 10)) { shakeOffset = 12 }
@@ -756,6 +517,28 @@ struct CardStudyView: View {
     }
 }
 
+// MARK: - View Helpers
+
+private extension Image {
+    /// Standard 32pt circular button for top-bar actions.
+    func topBarButton() -> some View {
+        self
+            .font(.system(size: 14, weight: .bold))
+            .foregroundColor(.secondary)
+            .frame(width: 32, height: 32)
+            .background(Color(.tertiarySystemGroupedBackground))
+            .clipShape(Circle())
+    }
+}
+
+private extension StudyMode {
+    var inputPlaceholder: String {
+        self == .fullWord
+            ? "Type each word, press space to check..."
+            : "Type first letter of each word..."
+    }
+}
+
 #Preview {
-    CardStudyView(packName: "5 Assurances", verses: Array(packs.first?.verses.prefix(5) ?? []))
+    CardStudyView(packName: "5 Assurances", verses: Array(packsNIV84.first?.verses.prefix(5) ?? []))
 }

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+
+// MARK: - Card Section
+
+/// Identifies which part of a flashcard — title or verse — is currently being studied.
+enum CardSection: Hashable {
+    case title
+    case verse
+}
+
+// MARK: - Card Study View Model
+
+/// Owns all non-visual state and business logic for a card study session.
+///
+/// The paired `CardStudyView` is responsible only for layout, gesture handling,
+/// focus state, and animation triggers.
+@MainActor
+final class CardStudyViewModel: ObservableObject {
+
+    // MARK: - Initialisation
+
+    let packName: String
+    let verses:   [Verse]
+
+    init(packName: String, verses: [Verse]) {
+        self.packName = packName
+        self.verses   = verses
+    }
+
+    // MARK: - Published State
+
+    @Published var currentIndex  = 0
+    @Published var isReviewMode  = false
+    @Published var activeSection: CardSection = .verse
+
+    @Published private(set) var titleRevealedCounts: [Int: Int]    = [:]
+    @Published private(set) var verseRevealedCounts: [Int: Int]    = [:]
+    @Published private(set) var submitResults:       [Int: SubmitResult] = [:]
+
+    @Published var inputText  = ""
+    @Published var titleInput = ""
+    @Published var verseInput = ""
+
+    // MARK: - Derived State
+
+    var currentVerse: Verse? {
+        verses.indices.contains(currentIndex) ? verses[currentIndex] : nil
+    }
+
+    var isCardComplete: Bool {
+        guard let verse = currentVerse else { return false }
+        switch studyMode {
+        case .submit:
+            return submitResults[verse.id]?.isAllCorrect == true
+        default:
+            return titleRevealedCounts[verse.id, default: 0] >= verse.titleWords.count
+                && verseRevealedCounts[verse.id, default: 0] >= verse.verseWords.count
+        }
+    }
+
+    var canReset: Bool {
+        guard isReviewMode, let verse = currentVerse else { return false }
+        switch studyMode {
+        case .submit:
+            return submitResults[verse.id] != nil
+        default:
+            return titleRevealedCounts[verse.id, default: 0] > 0
+                || verseRevealedCounts[verse.id, default: 0] > 0
+        }
+    }
+
+    // Reads the current study mode from UserDefaults to stay in sync with @AppStorage in views.
+    private var studyMode: StudyMode {
+        StudyMode(rawValue: UserDefaults.standard.string(forKey: "studyMode") ?? "") ?? .firstLetter
+    }
+
+    // MARK: - Navigation
+
+    func goForward()  { if currentIndex < verses.count - 1 { currentIndex += 1 } }
+    func goBackward() { if currentIndex > 0                { currentIndex -= 1 } }
+
+    /// Clears all text inputs. Call when the user navigates to a new card.
+    func clearInputs() {
+        inputText  = ""
+        titleInput = ""
+        verseInput = ""
+    }
+
+    // MARK: - Card Label
+
+    /// Returns the footer label for a card, e.g. `"A-1 · TMS 60"`.
+    func cardLabel(for verse: Verse) -> String {
+        guard !verse.subpack.isEmpty else { return packName }
+        let subpackVerses = verses.filter { $0.subpack == verse.subpack }
+        let position = (subpackVerses.firstIndex(where: { $0.id == verse.id }) ?? 0) + 1
+        return "\(verse.subpack)-\(position) · \(packName)"
+    }
+
+    // MARK: - Reveal State
+
+    func revealedCount(for verseId: Int, section: CardSection) -> Int {
+        section == .title
+            ? titleRevealedCounts[verseId, default: 0]
+            : verseRevealedCounts[verseId, default: 0]
+    }
+
+    // MARK: - Input Processing
+
+    /// Returns `true` if the typed character matches the next word's first letter.
+    @discardableResult
+    func processFirstLetterInput(_ text: String) -> Bool {
+        guard let typed = text.last, let verse = currentVerse else { return false }
+        let words    = sectionWords(activeSection, in: verse)
+        let revealed = revealedCount(for: verse.id, section: activeSection)
+        guard revealed < words.count else { return false }
+        let target = words[revealed]
+        guard let expected = target.first(where: { $0.isLetter || $0.isNumber }) else {
+            advance(verse: verse, sectionWords: words, revealed: revealed)
+            return true
+        }
+        if typed.lowercased() == String(expected).lowercased() {
+            advance(verse: verse, sectionWords: words, revealed: revealed)
+            return true
+        }
+        return false
+    }
+
+    /// Returns `true` if a space-terminated word matched the next target word.
+    @discardableResult
+    func processFullWordInput(_ text: String) -> Bool {
+        guard text.hasSuffix(" "), let verse = currentVerse else { return false }
+        let typed    = String(text.dropLast()).trimmingCharacters(in: .whitespaces)
+        guard !typed.isEmpty else { inputText = ""; return false }
+        let words    = sectionWords(activeSection, in: verse)
+        let revealed = revealedCount(for: verse.id, section: activeSection)
+        guard revealed < words.count else { return false }
+        if DiffEngine.normalizedMatch(typed, words[revealed]) {
+            advance(verse: verse, sectionWords: words, revealed: revealed)
+            inputText = ""
+            return true
+        }
+        inputText = ""
+        return false
+    }
+
+    /// Scores the current inputs, stores the result, and returns it (or `nil` if inputs were empty).
+    @discardableResult
+    func handleSubmit() -> SubmitResult? {
+        guard let verse = currentVerse else { return nil }
+        let typedTitle = titleInput.trimmingCharacters(in: .whitespacesAndNewlines).wordTokens
+        let typedVerse = verseInput.trimmingCharacters(in: .whitespacesAndNewlines).wordTokens
+        guard !typedTitle.isEmpty || !typedVerse.isEmpty else { return nil }
+
+        let result = SubmitResult(
+            titleDiffs: DiffEngine.buildDiffs(typed: typedTitle, target: verse.titleWords),
+            verseDiffs: DiffEngine.buildDiffs(typed: typedVerse, target: verse.verseWords)
+        )
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            submitResults[verse.id] = result
+        }
+        titleInput = ""
+        verseInput = ""
+        return result
+    }
+
+    func retrySubmit() {
+        guard let verse = currentVerse else { return }
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+            submitResults.removeValue(forKey: verse.id)
+        }
+        titleInput = ""
+        verseInput = ""
+    }
+
+    func resetCurrentCard() {
+        guard let verse = currentVerse else { return }
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+            switch studyMode {
+            case .submit:
+                submitResults.removeValue(forKey: verse.id)
+                titleInput = ""
+                verseInput = ""
+            default:
+                titleRevealedCounts[verse.id] = 0
+                verseRevealedCounts[verse.id] = 0
+            }
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func sectionWords(_ section: CardSection, in verse: Verse) -> [String] {
+        section == .title ? verse.titleWords : verse.verseWords
+    }
+
+    private func setRevealed(_ count: Int, for verseId: Int, section: CardSection) {
+        switch section {
+        case .title: titleRevealedCounts[verseId] = count
+        case .verse:  verseRevealedCounts[verseId] = count
+        }
+    }
+
+    private func advance(verse: Verse, sectionWords: [String], revealed: Int) {
+        let newCount = revealed + 1
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+            setRevealed(newCount, for: verse.id, section: activeSection)
+        }
+        if newCount >= sectionWords.count {
+            switchSectionIfNeeded(verse: verse)
+        }
+    }
+
+    private func switchSectionIfNeeded(verse: Verse) {
+        let other         = activeSection == .title ? CardSection.verse : .title
+        let otherWords    = sectionWords(other, in: verse)
+        let otherRevealed = revealedCount(for: verse.id, section: other)
+        if otherRevealed < otherWords.count {
+            withAnimation(.easeOut(duration: 0.2)) { activeSection = other }
+        }
+    }
+}

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -1,71 +1,25 @@
 import SwiftUI
 
-enum ReviewSection: Hashable {
-    case title, verse
-}
-
 struct FlashcardView: View {
-    let verse: Verse
-    let cardLabel: String
-    let isReviewMode: Bool
-    let titleRevealedCount: Int
-    let verseRevealedCount: Int
-    let activeSection: ReviewSection
-    var onSectionTap: ((ReviewSection) -> Void)? = nil
+    let verse:               Verse
+    let cardLabel:           String
+    let isReviewMode:        Bool
+    let titleRevealedCount:  Int
+    let verseRevealedCount:  Int
+    let activeSection:       CardSection
+    var onSectionTap:        ((CardSection) -> Void)? = nil
 
     @AppStorage("hardMode") private var hardMode = false
 
-    private let cardColor = Color(uiColor: UIColor { tc in
-        tc.userInterfaceStyle == .dark
-            ? UIColor(white: 0.13, alpha: 1)
-            : UIColor(red: 0.98, green: 0.965, blue: 0.94, alpha: 1)
-    })
-
-    private var titleWords: [String] {
-        verse.title.components(separatedBy: " ").filter { !$0.isEmpty }
-    }
-
-    private var verseWords: [String] {
-        verse.verse.components(separatedBy: " ").filter { !$0.isEmpty }
-    }
-
-    private var activeWords: [String] {
-        activeSection == .title ? titleWords : verseWords
-    }
-
-    private var activeRevealed: Int {
-        activeSection == .title ? titleRevealedCount : verseRevealedCount
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if isReviewMode {
-                reviewContent
-            } else {
-                readContent
-            }
-
+            if isReviewMode { reviewContent } else { readContent }
             Spacer(minLength: 6)
-
-            HStack {
-                Text(cardLabel)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.secondary)
-                Spacer()
-            }
+            Text(cardLabel)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.secondary)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 16)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(cardColor)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color(white: 0.82), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.12), radius: 16, x: 0, y: 8)
-        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-        .contentShape(RoundedRectangle(cornerRadius: 10))
+        .flashcardStyle()
     }
 
     // MARK: - Read Mode
@@ -74,19 +28,12 @@ struct FlashcardView: View {
         VStack(alignment: .leading, spacing: 0) {
             Text(verse.title)
                 .font(.system(size: 18, weight: .bold, design: .serif))
-                .foregroundColor(.primary)
-
             Spacer().frame(height: 10)
-
             Text("\(verse.book) \(verse.reference)")
                 .font(.system(size: 15))
-                .foregroundColor(.primary)
-
             Spacer().frame(height: 8)
-
             Text(verse.verse)
                 .font(.system(size: 15, design: .serif))
-                .foregroundColor(.primary)
                 .lineSpacing(6)
                 .minimumScaleFactor(0.7)
         }
@@ -95,55 +42,53 @@ struct FlashcardView: View {
     // MARK: - Review Mode
 
     private var reviewContent: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let activeWords    = activeSection == .title ? verse.titleWords : verse.verseWords
+        let activeRevealed = activeSection == .title ? titleRevealedCount : verseRevealedCount
+
+        return VStack(alignment: .leading, spacing: 0) {
             Text("\(verse.book) \(verse.reference)")
                 .font(.system(size: 18, weight: .bold, design: .serif))
-                .foregroundColor(.primary)
 
             Spacer().frame(height: 12)
 
-            sectionView(
-                section: .title,
-                words: titleWords,
-                revealed: titleRevealedCount,
-                font: .system(size: 16, weight: .bold, design: .serif)
-            )
+            sectionView(.title,
+                         words: verse.titleWords,
+                         revealed: titleRevealedCount,
+                         font: .system(size: 16, weight: .bold, design: .serif))
 
             Spacer().frame(height: 8)
 
-            sectionView(
-                section: .verse,
-                words: verseWords,
-                revealed: verseRevealedCount,
-                font: .system(size: 15, design: .serif)
-            )
+            sectionView(.verse,
+                         words: verse.verseWords,
+                         revealed: verseRevealedCount,
+                         font: .system(size: 15, design: .serif))
 
             if !hardMode && activeRevealed < activeWords.count {
                 Spacer().frame(height: 10)
-                reviewProgress
+                progressBar(revealed: activeRevealed, total: activeWords.count)
             }
         }
     }
 
+    // MARK: - Section View
+
     @ViewBuilder
-    private func sectionView(section: ReviewSection, words: [String], revealed: Int, font: Font) -> some View {
-        let isActive = activeSection == section
+    private func sectionView(_ section: CardSection, words: [String], revealed: Int, font: Font) -> some View {
+        let isActive   = (activeSection == section)
         let isComplete = revealed >= words.count && !words.isEmpty
 
         HStack(alignment: .top, spacing: 4) {
             Group {
                 if isComplete {
-                    completedText(words: words, font: font)
-                        .lineSpacing(section == .verse ? 6 : 4)
+                    completedText(words, font: font)
                 } else if isActive {
                     activeText(words: words, revealed: revealed, font: font)
-                        .lineSpacing(section == .verse ? 6 : 4)
                         .animation(.easeOut(duration: 0.2), value: revealed)
                 } else {
                     inactiveText(section: section, words: words, revealed: revealed, font: font)
-                        .lineSpacing(section == .verse ? 6 : 4)
                 }
             }
+            .lineSpacing(section == .verse ? 6 : 4)
             .minimumScaleFactor(0.7)
 
             if isComplete {
@@ -164,101 +109,99 @@ struct FlashcardView: View {
         .onTapGesture { onSectionTap?(section) }
     }
 
-    private func sectionLabel(_ section: ReviewSection) -> Text {
-        let label = section == .title ? "Title" : "Verse"
-        return Text(label)
-            .font(.system(size: 18, weight: .medium, design: .serif))
-            .foregroundColor(Color.gray.opacity(0.35))
+    // MARK: - Text Builders
+    //
+    // SwiftUI's `Text` concatenation is the only way to mix per-word colours inline,
+    // so these functions reduce over word arrays to build a single attributed `Text`.
+
+    private func completedText(_ words: [String], font: Font) -> Text {
+        words.enumerated().reduce(Text("")) { acc, pair in
+            let (i, word) = pair
+            let sep = i < words.count - 1 ? " " : ""
+            return acc + Text(word + sep).foregroundColor(.primary).font(font)
+        }
     }
 
     private func activeText(words: [String], revealed: Int, font: Font) -> Text {
         if hardMode {
-            if revealed == 0 {
-                return sectionLabel(activeSection)
-            }
-            return words.prefix(revealed).enumerated().reduce(Text("")) { result, pair in
-                let (index, word) = pair
-                let sep = index < revealed - 1 ? " " : ""
-                return result + Text(word + sep).foregroundColor(.primary).font(font)
+            guard revealed > 0 else { return placeholder(for: activeSection) }
+            return words.prefix(revealed).enumerated().reduce(Text("")) { acc, pair in
+                let (i, word) = pair
+                let sep = i < revealed - 1 ? " " : ""
+                return acc + Text(word + sep).foregroundColor(.primary).font(font)
             }
         }
-        return words.enumerated().reduce(Text("")) { result, pair in
-            let (index, word) = pair
-            let sep = index < words.count - 1 ? " " : ""
-            if index < revealed {
-                return result + Text(word + sep).foregroundColor(.primary).font(font)
-            } else if index == revealed {
-                return result + Text(masked(word) + sep).foregroundColor(.blue).font(font)
+        return words.enumerated().reduce(Text("")) { acc, pair in
+            let (i, word) = pair
+            let sep = i < words.count - 1 ? " " : ""
+            if i < revealed {
+                return acc + Text(word + sep).foregroundColor(.primary).font(font)
+            } else if i == revealed {
+                return acc + Text(masked(word) + sep).foregroundColor(.blue).font(font)
             } else {
-                return result + Text(masked(word) + sep).foregroundColor(Color.gray.opacity(0.28)).font(font)
+                return acc + Text(masked(word) + sep).foregroundColor(.gray.opacity(0.28)).font(font)
             }
         }
     }
 
-    private func inactiveText(section: ReviewSection, words: [String], revealed: Int, font: Font) -> Text {
+    private func inactiveText(section: CardSection, words: [String], revealed: Int, font: Font) -> Text {
         if hardMode {
-            if revealed > 0 {
-                return words.prefix(revealed).enumerated().reduce(Text("")) { result, pair in
-                    let (index, word) = pair
-                    let sep = index < revealed - 1 ? " " : ""
-                    return result + Text(word + sep).foregroundColor(.primary.opacity(0.5)).font(font)
-                }
+            guard revealed > 0 else { return placeholder(for: section) }
+            return words.prefix(revealed).enumerated().reduce(Text("")) { acc, pair in
+                let (i, word) = pair
+                let sep = i < revealed - 1 ? " " : ""
+                return acc + Text(word + sep).foregroundColor(.primary.opacity(0.5)).font(font)
             }
-            return sectionLabel(section)
         }
-        return words.enumerated().reduce(Text("")) { result, pair in
-            let (index, word) = pair
-            let sep = index < words.count - 1 ? " " : ""
-            return result + Text(masked(word) + sep).foregroundColor(Color.gray.opacity(0.22)).font(font)
-        }
-    }
-
-    private func completedText(words: [String], font: Font) -> Text {
-        words.enumerated().reduce(Text("")) { result, pair in
-            let (index, word) = pair
-            let sep = index < words.count - 1 ? " " : ""
-            return result + Text(word + sep).foregroundColor(.primary).font(font)
+        return words.enumerated().reduce(Text("")) { acc, pair in
+            let (i, word) = pair
+            let sep = i < words.count - 1 ? " " : ""
+            return acc + Text(masked(word) + sep).foregroundColor(.gray.opacity(0.22)).font(font)
         }
     }
 
-    private var reviewProgress: some View {
+    private func placeholder(for section: CardSection) -> Text {
+        Text(section == .title ? "Title" : "Verse")
+            .font(.system(size: 18, weight: .medium, design: .serif))
+            .foregroundColor(.gray.opacity(0.35))
+    }
+
+    private func masked(_ word: String) -> String {
+        String(word.map { $0.isLetter ? "_" : $0 })
+    }
+
+    // MARK: - Progress Bar
+
+    private func progressBar(revealed: Int, total: Int) -> some View {
         HStack(spacing: 6) {
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color(.systemGray5))
                     Capsule()
                         .fill(Color.blue.opacity(0.5))
-                        .frame(width: max(4, geo.size.width * Double(activeRevealed) / Double(max(1, activeWords.count))))
-                        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: activeRevealed)
+                        .frame(width: max(4, geo.size.width * Double(revealed) / Double(max(1, total))))
+                        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: revealed)
                 }
             }
             .frame(height: 3)
 
-            Text("\(activeRevealed)/\(activeWords.count)")
+            Text("\(revealed)/\(total)")
                 .font(.system(size: 10, weight: .medium, design: .monospaced))
                 .foregroundColor(.secondary)
         }
-    }
-
-    private func masked(_ word: String) -> String {
-        var result = ""
-        for char in word {
-            result.append(char.isLetter ? "_" : char)
-        }
-        return result
     }
 }
 
 #Preview {
     FlashcardView(
-        verse: packs.first!.verses[0],
+        verse: packsNIV84.first!.verses[0],
         cardLabel: "A-1 · TMS 60",
         isReviewMode: true,
         titleRevealedCount: 0,
         verseRevealedCount: 0,
         activeSection: .verse
     )
-    .aspectRatio(5.0/3.0, contentMode: .fit)
+    .aspectRatio(5.0 / 3.0, contentMode: .fit)
     .padding(24)
     .background(Color(.systemGroupedBackground))
 }

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -1,17 +1,13 @@
 import SwiftUI
 
 struct PackListView: View {
-    @AppStorage("bibleVersion") private var bibleVersion = "NIV84"
+    @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
     @State private var selectedPack: Pack? = nil
-
-    private var activePacks: [Pack] {
-        bibleVersion == "NIV11" ? packsNIV11 : packsNIV84
-    }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 12) {
-                ForEach(activePacks) { pack in
+                ForEach(bibleVersion.packs) { pack in
                     Button {
                         guard !pack.verses.isEmpty else { return }
                         selectedPack = pack
@@ -37,28 +33,20 @@ struct PackListView: View {
 struct PackCover: View {
     let pack: Pack
 
-    private var isDEP: Bool { pack.name.hasPrefix("DEP") }
-
-    private var baseColor: Color {
-        (Color(hex: pack.color) ?? .gray).muted
-    }
-
+    private var isDEP:        Bool  { pack.name.hasPrefix("DEP") }
+    private var baseColor:    Color { (Color(hex: pack.color) ?? .gray).muted }
     private var displayTitle: String {
-        if isDEP {
-            return pack.name
-                .replacingOccurrences(of: "DEP ", with: "")
-                .replacingOccurrences(of: ": ", with: ". ")
-        }
-        return pack.name
+        isDEP ? pack.name
+                    .replacingOccurrences(of: "DEP ", with: "")
+                    .replacingOccurrences(of: ": ",  with: ". ")
+              : pack.name
     }
 
     var body: some View {
-        if isDEP {
-            depCover
-        } else if pack.name == "TMS 60" {
-            tmsCover
-        } else {
-            genericCover
+        Group {
+            if isDEP              { depCover   }
+            else if pack.name == "TMS 60" { tmsCover   }
+            else                  { genericCover }
         }
     }
 
@@ -75,8 +63,7 @@ struct PackCover: View {
                         .foregroundColor(.white)
                     Spacer()
                 }
-                .padding(.leading, 18)
-                .padding(.top, 16)
+                .padding(.leading, 18).padding(.top, 16)
                 Spacer()
             }
 
@@ -99,8 +86,7 @@ struct PackCover: View {
                             .italic()
                             .foregroundColor(.white.opacity(0.25))
                     }
-                    .padding(.trailing, 18)
-                    .padding(.bottom, 28)
+                    .padding(.trailing, 18).padding(.bottom, 28)
                 }
             }
 
@@ -121,17 +107,10 @@ struct PackCover: View {
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.white.opacity(0.5))
                 }
-                .padding(.horizontal, 18)
-                .padding(.bottom, 12)
+                .padding(.horizontal, 18).padding(.bottom, 12)
             }
         }
-        .aspectRatio(5.0/3.0, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
+        .packCoverStyle(border: .white.opacity(0.08))
     }
 
     // MARK: TMS 60 Style
@@ -150,7 +129,6 @@ struct PackCover: View {
                         .font(.system(size: 24, weight: .medium, design: .serif))
                         .tracking(1)
                         .padding(.leading, 40)
-                    
 
                     HStack(spacing: 4) {
                         Spacer()
@@ -161,13 +139,8 @@ struct PackCover: View {
                             Text("개역한글판")
                                 .font(.system(size: 24, weight: .semibold))
                                 .foregroundColor(.white)
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 5)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .fill(baseColor)
-                                )
-
+                                .padding(.horizontal, 10).padding(.vertical, 5)
+                                .background(RoundedRectangle(cornerRadius: 6).fill(baseColor))
                             Text("구절")
                                 .font(.system(size: 80, weight: .bold, design: .monospaced))
                                 .foregroundColor(baseColor)
@@ -176,7 +149,6 @@ struct PackCover: View {
                     }
                 }
                 .padding(.top, 16)
-
             }
 
             HStack {
@@ -184,26 +156,17 @@ struct PackCover: View {
                     .font(.system(size: 10, weight: .medium, design: .serif))
                 Spacer()
                 HStack(spacing: 5) {
-                    Text("네비게이토")
-                        .tracking(0.5)
+                    Text("네비게이토").tracking(0.5)
                     Image(systemName: "moon.fill")
-                    Text("출판사")
-                        .tracking(0.5)
+                    Text("출판사").tracking(0.5)
                 }
                 .bold()
                 .font(.system(size: 12, weight: .medium, design: .rounded))
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 16).padding(.vertical, 10)
             .background(Color.green.opacity(0.15))
         }
-        .aspectRatio(5.0/3.0, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color(.separator).opacity(0.3), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.08), radius: 8, x: 0, y: 4)
+        .packCoverStyle(border: Color(.separator).opacity(0.3), shadowOpacity: 0.08)
     }
 
     // MARK: Generic Style
@@ -240,49 +203,22 @@ struct PackCover: View {
             }
             .padding(18)
         }
-        .aspectRatio(5.0/3.0, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
+        .packCoverStyle(border: .clear)
     }
 }
 
-// MARK: - Color Helpers
+// MARK: - Pack Cover Style
 
-extension Color {
-    init?(hex: String) {
-        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if h.hasPrefix("#") { h.removeFirst() }
-        guard h.count == 6, let val = UInt64(h, radix: 16) else { return nil }
-        self.init(
-            red: Double((val >> 16) & 0xFF) / 255,
-            green: Double((val >> 8) & 0xFF) / 255,
-            blue: Double(val & 0xFF) / 255
-        )
-    }
-
-    var muted: Color {
-        let uic = UIColor(self)
-        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        uic.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
-        return Color(hue: Double(h), saturation: Double(s * 0.55), brightness: Double(b * 0.7))
-    }
-}
-
-// MARK: - Button Style
-
-struct CardButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-            .animation(.spring(response: 0.25, dampingFraction: 0.7), value: configuration.isPressed)
+private extension View {
+    func packCoverStyle(border: Color, shadowOpacity: Double = 0.12) -> some View {
+        self
+            .aspectRatio(5.0 / 3.0, contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(border, lineWidth: 0.5))
+            .shadow(color: .black.opacity(shadowOpacity), radius: 8, x: 0, y: 4)
     }
 }
 
 #Preview {
-    NavigationStack {
-        PackListView()
-    }
+    NavigationStack { PackListView() }
 }
-
-// Keep a top-level alias so existing previews that reference `packs` still compile
-var packs: [Pack] { packsNIV84 }

--- a/scripture memory/Views/SettingsView.swift
+++ b/scripture memory/Views/SettingsView.swift
@@ -1,37 +1,31 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("hardMode") private var hardMode = false
-    @AppStorage("bibleVersion") private var bibleVersion = "NIV84"
-    @AppStorage("studyMode") private var studyMode = "firstLetter"
+    @AppStorage("studyMode")    private var studyMode:    StudyMode    = .firstLetter
+    @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
+    @AppStorage("hardMode")     private var hardMode:     Bool         = false
 
     var body: some View {
         List {
             Section {
                 Picker("Study Mode", selection: $studyMode) {
-                    Text("First Letter").tag("firstLetter")
-                    Text("Full Word").tag("fullWord")
-                    Text("Submit").tag("submit")
+                    ForEach(StudyMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
                 }
                 .pickerStyle(.inline)
                 .labelsHidden()
             } header: {
                 Text("Study Mode")
             } footer: {
-                switch studyMode {
-                case "firstLetter":
-                    Text("Type the first letter of each word to reveal it.")
-                case "fullWord":
-                    Text("Type each word in full. Case and punctuation are ignored.")
-                default:
-                    Text("Type the full verse on the card, then tap Submit to check all at once.")
-                }
+                Text(studyMode.instructions)
             }
 
             Section {
                 Picker("Bible Version", selection: $bibleVersion) {
-                    Text("NIV 1984").tag("NIV84")
-                    Text("NIV 2011").tag("NIV11")
+                    ForEach(BibleVersion.allCases, id: \.self) { version in
+                        Text(version.displayName).tag(version)
+                    }
                 }
                 .pickerStyle(.inline)
                 .labelsHidden()
@@ -51,26 +45,19 @@ struct SettingsView: View {
                 HStack {
                     Text("Version")
                     Spacer()
-                    Text("1.0")
-                        .foregroundColor(.secondary)
+                    Text("1.0").foregroundColor(.secondary)
                 }
             } header: {
                 Text("About")
-            }
-                footer: {
+            } footer: {
                 Text("Made with God's ❤️ for The Navigators")
                     .font(.system(size: 14, design: .serif))
-
             }
-
-            
         }
         .navigationTitle("Settings")
     }
 }
 
 #Preview {
-    NavigationStack {
-        SettingsView()
-    }
+    NavigationStack { SettingsView() }
 }

--- a/scripture memory/Views/SubmitCardView.swift
+++ b/scripture memory/Views/SubmitCardView.swift
@@ -1,133 +1,77 @@
 import SwiftUI
 
-// MARK: - Diff Model
+// MARK: - Submit Field
 
-struct DiffWord: Identifiable {
-    enum Kind { case correct, wrong, missing, extra }
-    let id = UUID()
-    let text: String
-    let kind: Kind
-    let correction: String?
-
-    init(text: String, kind: Kind, correction: String? = nil) {
-        self.text = text
-        self.kind = kind
-        self.correction = correction
-    }
-}
-
-struct SubmitResult {
-    let titleDiffs: [DiffWord]
-    let verseDiffs: [DiffWord]
-
-    var isAllCorrect: Bool {
-        !titleDiffs.isEmpty && !verseDiffs.isEmpty
-        && titleDiffs.allSatisfy { $0.kind == .correct }
-        && verseDiffs.allSatisfy { $0.kind == .correct }
-    }
-}
-
+/// Focus state identifier for the two text inputs on a submit-mode card.
 enum SubmitField: Hashable { case title, verse }
 
 // MARK: - Submit Card View
 
 struct SubmitCardView: View {
-    let verse: Verse
-    let cardLabel: String
+    let verse:       Verse
+    let cardLabel:   String
     @Binding var titleText: String
     @Binding var verseText: String
-    let result: SubmitResult?
+    let result:      SubmitResult?
     @FocusState.Binding var focusedField: SubmitField?
-
-    private let cardColor = Color(uiColor: UIColor { tc in
-        tc.userInterfaceStyle == .dark
-            ? UIColor(white: 0.13, alpha: 1)
-            : UIColor(red: 0.98, green: 0.965, blue: 0.94, alpha: 1)
-    })
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("\(verse.book) \(verse.reference)")
                 .font(.system(size: 18, weight: .bold, design: .serif))
-                .foregroundColor(.primary)
 
             Spacer().frame(height: 10)
 
-            if let result {
-                diffSectionsView(result)
-            } else {
-                typingView
-            }
+            if let result { diffView(result) } else { inputView }
 
             Spacer(minLength: 6)
 
-            HStack {
-                Text(cardLabel)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.secondary)
-                Spacer()
-            }
+            Text(cardLabel)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.secondary)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 16)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(cardColor)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color(white: 0.82), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.12), radius: 16, x: 0, y: 8)
-        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        .flashcardStyle()
     }
 
-    // MARK: - Typing View
+    // MARK: - Input View
 
-    private var typingView: some View {
+    private var inputView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            titleField
+            TextField("Title", text: $titleText)
+                .font(.system(size: 16, weight: .bold, design: .serif))
+                .focused($focusedField, equals: .title)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .onSubmit { focusedField = .verse }
+
             Divider().padding(.vertical, 6)
-            verseField
+
+            TextEditor(text: $verseText)
+                .scrollContentBackground(.hidden)
+                .background(.clear)
+                .font(.system(size: 15, design: .serif))
+                .lineSpacing(5)
+                .focused($focusedField, equals: .verse)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .padding(.horizontal, -5)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .overlay(alignment: .topLeading) {
+                    if verseText.isEmpty {
+                        Text("Verse")
+                            .font(.system(size: 15, design: .serif))
+                            .foregroundColor(.secondary.opacity(0.45))
+                            .padding(.top, 8)
+                            .allowsHitTesting(false)
+                    }
+                }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private var titleField: some View {
-        TextField("Title", text: $titleText)
-            .font(.system(size: 16, weight: .bold, design: .serif))
-            .foregroundColor(.primary)
-            .focused($focusedField, equals: .title)
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
-            .onSubmit { focusedField = .verse }
-    }
+    // MARK: - Diff View
 
-    private var verseField: some View {
-        TextEditor(text: $verseText)
-            .scrollContentBackground(.hidden)
-            .background(.clear)
-            .font(.system(size: 15, design: .serif))
-            .foregroundColor(.primary)
-            .lineSpacing(5)
-            .focused($focusedField, equals: .verse)
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
-            .padding(.horizontal, -5)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay(alignment: .topLeading) {
-                if verseText.isEmpty {
-                    Text("Verse")
-                        .font(.system(size: 15, design: .serif))
-                        .foregroundColor(.secondary.opacity(0.45))
-                        .padding(.top, 8)
-                        .allowsHitTesting(false)
-                }
-            }
-    }
-
-    // MARK: - Diff Sections View
-
-    private func diffSectionsView(_ result: SubmitResult) -> some View {
+    private func diffView(_ result: SubmitResult) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             diffLine(result.titleDiffs, font: .system(size: 16, weight: .bold, design: .serif))
             diffLine(result.verseDiffs, font: .system(size: 15, design: .serif))
@@ -135,6 +79,9 @@ struct SubmitCardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
+    /// Renders a sequence of `DiffWord` annotations as a single attributed `Text`.
+    ///
+    /// Consecutive words of the same kind are grouped first to minimise concatenation operations.
     private func diffLine(_ diffs: [DiffWord], font: Font) -> some View {
         var groups: [(kind: DiffWord.Kind, words: [DiffWord])] = []
         for word in diffs {
@@ -145,7 +92,7 @@ struct SubmitCardView: View {
             }
         }
 
-        let text = groups.enumerated().reduce(Text("")) { acc, pair in
+        return groups.enumerated().reduce(Text("")) { acc, pair in
             let (gi, group) = pair
             let sep = gi < groups.count - 1 ? " " : ""
             switch group.kind {
@@ -153,13 +100,12 @@ struct SubmitCardView: View {
                 let joined = group.words.map(\.text).joined(separator: " ")
                 return acc + Text(joined + sep).foregroundColor(.green).font(font)
             case .wrong:
-                let wrongJoined = group.words.map(\.text).joined(separator: " ")
+                let wrong       = group.words.map(\.text).joined(separator: " ")
                 let corrections = group.words.compactMap(\.correction).joined(separator: " ")
-                let crossed = Text(wrongJoined + " ").strikethrough().foregroundColor(.red.opacity(0.5)).font(font)
-                if !corrections.isEmpty {
-                    return acc + crossed + Text(corrections + sep).foregroundColor(.red).font(font)
-                }
-                return acc + crossed
+                let crossed     = Text(wrong + " ").strikethrough().foregroundColor(.red.opacity(0.5)).font(font)
+                return corrections.isEmpty
+                    ? acc + crossed
+                    : acc + crossed + Text(corrections + sep).foregroundColor(.red).font(font)
             case .missing:
                 let joined = group.words.map(\.text).joined(separator: " ")
                 return acc + Text(joined + sep).foregroundColor(.secondary.opacity(0.5)).font(font)
@@ -168,8 +114,7 @@ struct SubmitCardView: View {
                 return acc + Text(joined + sep).strikethrough().foregroundColor(.red.opacity(0.5)).font(font)
             }
         }
-        return text
-            .lineSpacing(5)
-            .minimumScaleFactor(0.75)
+        .lineSpacing(5)
+        .minimumScaleFactor(0.75)
     }
 }


### PR DESCRIPTION
…afe settings

- Extract CardStudyViewModel (all business logic out of the 761-line view)
- Add AppSettings.swift with StudyMode/BibleVersion enums replacing magic strings
- Add DiffResult.swift, DiffEngine.swift, and HapticEngine as focused model/utility files
- Consolidate SharedUtilities: wordTokens, flashcardStyle(), CardButtonStyle, Color helpers
- Verse properties made immutable (let); titleWords/verseWords computed via wordTokens
- SubmitCardView, FlashcardView, PackListView, SettingsView slimmed to layout-only concerns