### PR TITLE
feat: shuffle, 2-column pack grid, single-card review in vertical mod…

### DIFF
--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -46,7 +46,9 @@ struct CardStudyView: View {
             VStack(spacing: 0) {
                 topBar
 
-                if isVerticalScroll {
+                // Vertical scroll is for browsing in read mode only.
+                // Review mode always shows a single focused card.
+                if isVerticalScroll && !vm.isReviewMode {
                     verticalScrollCards(cardWidth: cardWidth, cardHeight: cardHeight)
                         .frame(maxHeight: .infinity)
                 } else {
@@ -57,11 +59,23 @@ struct CardStudyView: View {
                     Spacer(minLength: 12)
                 }
 
-                scrubberRow
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 20)
+                if !isVerticalScroll || vm.isReviewMode {
+                    scrubberRow
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 20)
+                }
 
                 bottomControls
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") {
+                    isInputFocused = false
+                    submitFocus    = nil
+                }
+                .fontWeight(.semibold)
             }
         }
         .background(Color(.systemGroupedBackground))
@@ -112,6 +126,9 @@ struct CardStudyView: View {
                     Button { vm.resetCurrentCard() } label: {
                         Image(systemName: "arrow.counterclockwise").topBarButton()
                     }
+                }
+                Button { vm.shuffle(); HapticEngine.light() } label: {
+                    Image(systemName: "shuffle").topBarButton()
                 }
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -168,7 +185,7 @@ struct CardStudyView: View {
 
     private func verticalScrollCards(cardWidth: CGFloat, cardHeight: CGFloat) -> some View {
         ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
+            ScrollView(.vertical, showsIndicators: true) {
                 LazyVStack(spacing: 20) {
                     ForEach(Array(vm.verses.enumerated()), id: \.offset) { index, verse in
                         makeCard(verse: verse, interactive: index == vm.currentIndex)
@@ -208,7 +225,10 @@ struct CardStudyView: View {
 
     @ViewBuilder
     private func makeCard(verse: Verse, interactive: Bool) -> some View {
-        if studyMode == .submit && vm.isReviewMode {
+        // In submit+review, show the submit card only for the active card or if a result exists.
+        // Non-active, unsubmitted cards show in read mode to avoid orphaned text fields.
+        let hasResult = vm.submitResults[verse.id] != nil
+        if studyMode == .submit && vm.isReviewMode && (interactive || hasResult) {
             SubmitCardView(
                 verse: verse,
                 cardLabel: vm.cardLabel(for: verse),
@@ -236,15 +256,21 @@ struct CardStudyView: View {
 
     private var scrubberRow: some View {
         HStack(spacing: 10) {
+            let canPrev = vm.currentIndex > 0
+            let canNext = vm.currentIndex < vm.verses.count - 1
+
             Button {
                 vm.goBackward(); HapticEngine.light()
             } label: {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(vm.currentIndex > 0 ? .primary.opacity(0.7) : .secondary.opacity(0.25))
-                    .frame(width: 28, height: 28)
+                    .foregroundColor(canPrev ? .primary.opacity(0.7) : .secondary.opacity(0.25))
+                    .frame(width: 32, height: 32)
+                    .background(Color(.tertiarySystemGroupedBackground))
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color(.separator).opacity(canPrev ? 0.4 : 0.15), lineWidth: 1))
             }
-            .disabled(vm.currentIndex == 0)
+            .disabled(!canPrev)
 
             scrubber
 
@@ -253,10 +279,13 @@ struct CardStudyView: View {
             } label: {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(vm.currentIndex < vm.verses.count - 1 ? .primary.opacity(0.7) : .secondary.opacity(0.25))
-                    .frame(width: 28, height: 28)
+                    .foregroundColor(canNext ? .primary.opacity(0.7) : .secondary.opacity(0.25))
+                    .frame(width: 32, height: 32)
+                    .background(Color(.tertiarySystemGroupedBackground))
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color(.separator).opacity(canNext ? 0.4 : 0.15), lineWidth: 1))
             }
-            .disabled(vm.currentIndex == vm.verses.count - 1)
+            .disabled(!canNext)
         }
     }
 

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -20,7 +20,7 @@ final class CardStudyViewModel: ObservableObject {
     // MARK: - Initialisation
 
     let packName: String
-    let verses:   [Verse]
+    @Published var verses: [Verse]
 
     init(packName: String, verses: [Verse]) {
         self.packName = packName
@@ -78,6 +78,20 @@ final class CardStudyViewModel: ObservableObject {
 
     func goForward()  { if currentIndex < verses.count - 1 { currentIndex += 1 } }
     func goBackward() { if currentIndex > 0                { currentIndex -= 1 } }
+
+    func shuffle() {
+        var t = Transaction(); t.disablesAnimations = true
+        withTransaction(t) {
+            verses.shuffle()
+            currentIndex          = 0
+            titleRevealedCounts   = [:]
+            verseRevealedCounts   = [:]
+            submitResults         = [:]
+            inputText  = ""
+            titleInput = ""
+            verseInput = ""
+        }
+    }
 
     /// Clears all text inputs. Call when the user navigates to a new card.
     func clearInputs() {

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -4,20 +4,22 @@ struct PackListView: View {
     @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
     @State private var selectedPack: Pack? = nil
 
+    private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+
     var body: some View {
         ScrollView {
-            VStack(spacing: 12) {
+            LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(bibleVersion.packs) { pack in
                     Button {
                         guard !pack.verses.isEmpty else { return }
                         selectedPack = pack
                     } label: {
-                        PackCover(pack: pack)
+                        PackCover(pack: pack, compact: true)
                     }
                     .buttonStyle(CardButtonStyle())
                 }
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 16)
             .padding(.vertical, 12)
         }
         .background(Color(.systemGroupedBackground))
@@ -31,7 +33,8 @@ struct PackListView: View {
 // MARK: - Pack Cover
 
 struct PackCover: View {
-    let pack: Pack
+    let pack:    Pack
+    var compact: Bool = false
 
     private var isDEP:        Bool  { pack.name.hasPrefix("DEP") }
     private var baseColor:    Color { (Color(hex: pack.color) ?? .gray).muted }
@@ -42,11 +45,14 @@ struct PackCover: View {
               : pack.name
     }
 
+    // Scale factor applied to all font sizes when shown in a compact 2-column grid.
+    private var s: CGFloat { compact ? 0.65 : 1.0 }
+
     var body: some View {
         Group {
-            if isDEP              { depCover   }
-            else if pack.name == "TMS 60" { tmsCover   }
-            else                  { genericCover }
+            if isDEP                      { depCover     }
+            else if pack.name == "TMS 60" { tmsCover     }
+            else                          { genericCover }
         }
     }
 
@@ -59,11 +65,13 @@ struct PackCover: View {
             VStack {
                 HStack {
                     Text(displayTitle)
-                        .font(.system(size: 24, weight: .semibold, design: .serif))
+                        .font(.system(size: 24 * s, weight: .semibold, design: .serif))
                         .foregroundColor(.white)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.8)
                     Spacer()
                 }
-                .padding(.leading, 18).padding(.top, 16)
+                .padding(.leading, 18 * s).padding(.top, 16 * s)
                 Spacer()
             }
 
@@ -71,22 +79,22 @@ struct PackCover: View {
                 Spacer()
                 HStack {
                     Spacer()
-                    VStack(alignment: .trailing, spacing: -8) {
+                    VStack(alignment: .trailing, spacing: -8 * s) {
                         HStack(alignment: .firstTextBaseline, spacing: 4) {
                             Text("DEP")
-                                .font(.system(size: 42, weight: .heavy, design: .serif))
+                                .font(.system(size: 42 * s, weight: .heavy, design: .serif))
                                 .italic()
                                 .foregroundColor(.white.opacity(0.8))
                             Text("NIV")
-                                .font(.system(size: 18, weight: .bold, design: .serif))
+                                .font(.system(size: 18 * s, weight: .bold, design: .serif))
                                 .foregroundColor(.white.opacity(0.5))
                         }
                         Text("242")
-                            .font(.system(size: 50, weight: .heavy, design: .serif))
+                            .font(.system(size: 50 * s, weight: .heavy, design: .serif))
                             .italic()
                             .foregroundColor(.white.opacity(0.25))
                     }
-                    .padding(.trailing, 18).padding(.bottom, 28)
+                    .padding(.trailing, 18 * s).padding(.bottom, 28 * s)
                 }
             }
 
@@ -96,18 +104,18 @@ struct PackCover: View {
                     HStack(spacing: 5) {
                         Image(systemName: "moon.fill")
                             .foregroundColor(.white.opacity(0.6))
-                            .font(.system(size: 12))
+                            .font(.system(size: 12 * s))
                         Text("THE NAVIGATORS")
-                            .font(.system(size: 12, weight: .medium, design: .serif))
+                            .font(.system(size: 12 * s, weight: .medium, design: .serif))
                             .foregroundColor(.white.opacity(0.6))
                             .tracking(0.5)
                     }
                     Spacer()
                     Text("\(pack.verses.count) cards")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: 12 * s, weight: .medium))
                         .foregroundColor(.white.opacity(0.5))
                 }
-                .padding(.horizontal, 18).padding(.bottom, 12)
+                .padding(.horizontal, 18 * s).padding(.bottom, 12 * s)
             }
         }
         .packCoverStyle(border: .white.opacity(0.08))
@@ -126,34 +134,34 @@ struct PackCover: View {
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("주제별 성경암송")
-                        .font(.system(size: 24, weight: .medium, design: .serif))
+                        .font(.system(size: 24 * s, weight: .medium, design: .serif))
                         .tracking(1)
-                        .padding(.leading, 40)
+                        .padding(.leading, 40 * s)
 
                     HStack(spacing: 4) {
                         Spacer()
                         Text("60")
-                            .font(.system(size: 140, weight: .black, design: .monospaced))
+                            .font(.system(size: 140 * s, weight: .black, design: .monospaced))
                             .foregroundColor(baseColor)
                         VStack(alignment: .center, spacing: 2) {
                             Text("개역한글판")
-                                .font(.system(size: 24, weight: .semibold))
+                                .font(.system(size: 24 * s, weight: .semibold))
                                 .foregroundColor(.white)
-                                .padding(.horizontal, 10).padding(.vertical, 5)
+                                .padding(.horizontal, 10 * s).padding(.vertical, 5 * s)
                                 .background(RoundedRectangle(cornerRadius: 6).fill(baseColor))
                             Text("구절")
-                                .font(.system(size: 80, weight: .bold, design: .monospaced))
+                                .font(.system(size: 80 * s, weight: .bold, design: .monospaced))
                                 .foregroundColor(baseColor)
                         }
                         Spacer()
                     }
                 }
-                .padding(.top, 16)
+                .padding(.top, 16 * s)
             }
 
             HStack {
                 Text("TO KNOW CHRIST AND TO MAKE HIM KNOWN")
-                    .font(.system(size: 10, weight: .medium, design: .serif))
+                    .font(.system(size: 10 * s, weight: .medium, design: .serif))
                 Spacer()
                 HStack(spacing: 5) {
                     Text("네비게이토").tracking(0.5)
@@ -161,9 +169,9 @@ struct PackCover: View {
                     Text("출판사").tracking(0.5)
                 }
                 .bold()
-                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .font(.system(size: 12 * s, weight: .medium, design: .rounded))
             }
-            .padding(.horizontal, 16).padding(.vertical, 10)
+            .padding(.horizontal, 16 * s).padding(.vertical, 10 * s)
             .background(Color.green.opacity(0.15))
         }
         .packCoverStyle(border: Color(.separator).opacity(0.3), shadowOpacity: 0.08)
@@ -177,31 +185,32 @@ struct PackCover: View {
 
             if !pack.accentText.isEmpty {
                 Text(pack.accentText)
-                    .font(.system(size: 64, weight: .black, design: .rounded))
+                    .font(.system(size: 64 * s, weight: .black, design: .rounded))
                     .foregroundColor(.white.opacity(0.1))
-                    .offset(x: 80)
+                    .offset(x: 80 * s)
             }
 
             HStack {
                 VStack(alignment: .leading, spacing: 5) {
                     Text(pack.name)
-                        .font(.system(size: 20, weight: .bold, design: .serif))
+                        .font(.system(size: 20 * s, weight: .bold, design: .serif))
                         .foregroundColor(.white)
-                        .lineLimit(1)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.8)
                     Spacer()
                     Text("\(pack.verses.count) cards")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: 12 * s, weight: .medium))
                         .foregroundColor(.white.opacity(0.6))
                 }
                 Spacer()
                 VStack {
                     Spacer()
                     Image(systemName: "chevron.right")
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.system(size: 14 * s, weight: .semibold))
                         .foregroundColor(.white.opacity(0.35))
                 }
             }
-            .padding(18)
+            .padding(18 * s)
         }
         .packCoverStyle(border: .clear)
     }


### PR DESCRIPTION
…e, keyboard dismiss

- Add shuffle button to top bar; randomises card order and resets all session state
- Vertical scroll mode now collapses to single-card view when Review is active, so input always targets the focused card
- Non-active, unsubmitted submit cards in vertical mode show verse (read mode) instead of orphaned text fields
- Pack list switches to 2-column LazyVGrid; PackCover gains a compact flag (0.65× scale) so all cover styles resize proportionally
- Keyboard toolbar "Done" button dismisses the keyboard from any text field in the study view