### PR TITLE
Add verse search and improve flashcard typography

### DIFF
--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -33,8 +33,8 @@ struct CardStudyView: View {
 
     // MARK: - Init
 
-    init(packName: String, verses: [Verse]) {
-        _vm = StateObject(wrappedValue: CardStudyViewModel(packName: packName, verses: verses))
+    init(packName: String, verses: [Verse], initialIndex: Int = 0) {
+        _vm = StateObject(wrappedValue: CardStudyViewModel(packName: packName, verses: verses, initialIndex: initialIndex))
     }
 
     // MARK: - Body

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -25,10 +25,11 @@ final class CardStudyViewModel: ObservableObject {
 
     private let originalVerses: [Verse]
 
-    init(packName: String, verses: [Verse]) {
+    init(packName: String, verses: [Verse], initialIndex: Int = 0) {
         self.packName       = packName
         self.verses         = verses
         self.originalVerses = verses
+        self.currentIndex   = initialIndex
     }
 
     // MARK: - Published State

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -11,6 +11,24 @@ struct FlashcardView: View {
 
     @AppStorage("hardMode") private var hardMode = false
 
+    // MARK: - Adaptive Typography
+
+    private var verseFontSize: CGFloat {
+        let count = verse.verseWords.count
+        if count > 55 { return 11.0 }
+        if count > 45 { return 12.0 }
+        if count > 35 { return 13.5 }
+        return 15.0
+    }
+
+    private var verseLineSpacing: CGFloat {
+        let count = verse.verseWords.count
+        if count > 55 { return 2.0 }
+        if count > 45 { return 3.0 }
+        if count > 35 { return 4.0 }
+        return 6.0
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if isReviewMode { reviewContent } else { readContent }
@@ -33,9 +51,8 @@ struct FlashcardView: View {
                 .font(.system(size: 15))
             Spacer().frame(height: 8)
             Text(verse.verse)
-                .font(.system(size: 15, design: .serif))
-                .lineSpacing(6)
-                .minimumScaleFactor(0.7)
+                .font(.system(size: verseFontSize, design: .serif))
+                .lineSpacing(verseLineSpacing)
         }
     }
 
@@ -61,7 +78,7 @@ struct FlashcardView: View {
             sectionView(.verse,
                          words: verse.verseWords,
                          revealed: verseRevealedCount,
-                         font: .system(size: 15, design: .serif))
+                         font: .system(size: verseFontSize, design: .serif))
 
             if !hardMode && activeRevealed < activeWords.count {
                 Spacer().frame(height: 10)
@@ -88,8 +105,7 @@ struct FlashcardView: View {
                     inactiveText(section: section, words: words, revealed: revealed, font: font)
                 }
             }
-            .lineSpacing(section == .verse ? 6 : 4)
-            .minimumScaleFactor(0.7)
+            .lineSpacing(section == .verse ? verseLineSpacing : 4)
 
             if isComplete {
                 Image(systemName: "checkmark.circle.fill")

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -3,38 +3,144 @@ import SwiftUI
 struct PackListView: View {
     @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
 
-    @State private var selectedPack: Pack? = nil
+    @State private var selectedPack:   Pack?             = nil
+    @State private var searchText:     String            = ""
+    @State private var searchSelected: VerseSearchResult? = nil
 
     private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+
+    // MARK: - Search Result Model
+
+    struct VerseSearchResult: Identifiable {
+        var id: String { "\(pack.name)-\(verse.id)" }
+        let verse:      Verse
+        let pack:       Pack
+        let verseIndex: Int
+    }
+
+    // MARK: - Search Logic
+
+    private var searchResults: [VerseSearchResult] {
+        guard !searchText.isEmpty else { return [] }
+        let query = searchText.lowercased()
+        var results: [VerseSearchResult] = []
+        for pack in bibleVersion.packs {
+            for (index, verse) in pack.verses.enumerated() {
+                let ref = "\(verse.book) \(verse.reference)".lowercased()
+                if ref.contains(query)
+                    || verse.title.lowercased().contains(query)
+                    || verse.verse.lowercased().contains(query) {
+                    results.append(VerseSearchResult(verse: verse, pack: pack, verseIndex: index))
+                    if results.count == 25 { return results }
+                }
+            }
+        }
+        return results
+    }
 
     // MARK: - Body
 
     var body: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: 12) {
-                ForEach(bibleVersion.packs) { pack in
-                    Button {
-                        guard !pack.verses.isEmpty else { return }
-                        selectedPack = pack
-                    } label: {
-                        PackCover(pack: pack)
+        Group {
+            if searchText.isEmpty {
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(bibleVersion.packs) { pack in
+                            Button {
+                                guard !pack.verses.isEmpty else { return }
+                                selectedPack = pack
+                            } label: {
+                                PackCover(pack: pack)
+                            }
+                            .buttonStyle(CardButtonStyle())
+                        }
                     }
-                    .buttonStyle(CardButtonStyle())
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
                 }
+            } else {
+                searchResultsView
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
         }
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Packs")
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Search verses…"
+        )
         .fullScreenCover(item: $selectedPack) { pack in
             NavigationStack {
                 CardStudyView(packName: pack.name, verses: pack.verses)
                     .toolbar(.hidden, for: .navigationBar)
             }
         }
+        .fullScreenCover(item: $searchSelected) { result in
+            NavigationStack {
+                CardStudyView(
+                    packName: result.pack.name,
+                    verses: result.pack.verses,
+                    initialIndex: result.verseIndex
+                )
+                .toolbar(.hidden, for: .navigationBar)
+            }
+        }
     }
 
+    // MARK: - Search Results View
+
+    private var searchResultsView: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if searchResults.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 32, weight: .light))
+                            .foregroundColor(.secondary.opacity(0.5))
+                        Text("No results for "\(searchText)"")
+                            .font(.system(size: 15))
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.top, 60)
+                    .frame(maxWidth: .infinity)
+                } else {
+                    ForEach(searchResults) { result in
+                        Button {
+                            searchSelected = result
+                        } label: {
+                            HStack(spacing: 14) {
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text("\(result.verse.book) \(result.verse.reference)")
+                                        .font(.system(size: 15, weight: .semibold))
+                                        .foregroundColor(.primary)
+                                    Text(result.verse.title)
+                                        .font(.system(size: 13))
+                                        .foregroundColor(.secondary)
+                                    Text(result.pack.name)
+                                        .font(.system(size: 11))
+                                        .foregroundColor(.secondary.opacity(0.6))
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundColor(.secondary.opacity(0.4))
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 11)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        Divider().padding(.leading, 16)
+                    }
+                }
+            }
+            .background(Color(.systemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+        }
+    }
 }
 
 // MARK: - Pack Cover

--- a/scripture memory/Views/TestSessionViewModel.swift
+++ b/scripture memory/Views/TestSessionViewModel.swift
@@ -268,6 +268,18 @@ final class TestSessionViewModel: ObservableObject {
         titleRevealedCounts = toIntKeys(sp.titleRevealedCounts)
         verseRevealedCounts = toIntKeys(sp.verseRevealedCounts)
         completedVerseIds   = Set(sp.completedVerseIds.compactMap { Int($0) })
+
+        // Reconstruct correct SubmitResults for previously completed verses so
+        // the diff view reappears correctly when returning to a completed card.
+        for verseId in completedVerseIds {
+            if let verse = verses.first(where: { $0.id == verseId }) {
+                submitResults[verseId] = SubmitResult(
+                    titleDiffs: verse.titleWords.map { DiffWord(text: $0, kind: .correct) },
+                    verseDiffs: verse.verseWords.map { DiffWord(text: $0, kind: .correct) }
+                )
+            }
+        }
+
         // Jump to the first incomplete card so the user picks up where they left off
         if let firstIncomplete = verses.indices.first(where: { !isComplete(verses[$0]) }) {
             currentIndex = firstIncomplete


### PR DESCRIPTION
This PR adds comprehensive search functionality to the pack list view and improves text rendering in flashcards with adaptive typography.

## Summary
Enhanced the scripture memory app with a new search feature that allows users to find verses across all packs, and improved the flashcard reading experience with responsive font sizing and line spacing based on verse length.

## Key Changes

**PackListView - Search Functionality**
- Added searchable modifier with navigation bar drawer placement
- Implemented `VerseSearchResult` model to track search matches with pack and verse index information
- Created `searchResults` computed property that searches across verse references, titles, and content (limited to 25 results)
- Added conditional UI that displays pack grid when search is empty, switches to search results list when active
- Search results display verse reference, title, and pack name with navigation to the specific verse
- Added full-screen cover for search results that opens CardStudyView at the correct verse index

**FlashcardView - Adaptive Typography**
- Implemented `verseFontSize` computed property that scales from 11pt to 15pt based on word count
- Implemented `verseLineSpacing` computed property that adjusts spacing from 2pt to 6pt based on verse length
- Replaced hardcoded font size (15pt) and line spacing (6pt) with adaptive values
- Removed `minimumScaleFactor` modifier as it's no longer needed with adaptive sizing
- Applied adaptive font size to both read and review modes

**CardStudyView & CardStudyViewModel**
- Added optional `initialIndex` parameter to allow opening study view at a specific verse
- Updated initializer to set `currentIndex` from the provided index

**TestSessionViewModel**
- Added logic to reconstruct `SubmitResult` objects for previously completed verses
- Ensures diff view reappears correctly when returning to completed cards during test sessions

## Implementation Details
- Search is case-insensitive and matches against verse references (e.g., "John 3:16"), titles, and verse text
- Search results are limited to 25 matches for performance
- Adaptive typography uses word count thresholds to determine optimal sizing for readability
- Search integration maintains existing pack navigation while adding new search-based navigation path

https://claude.ai/code/session_01995QzLiVForVJpnDzV8Rkz