### PR TITLE
Add hold-to-peek eye button to CardStudyView review mode

### DIFF
--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -19,6 +19,7 @@ struct CardStudyView: View {
     @State private var shakeOffset:  CGFloat = 0
     @State private var speechTarget: SubmitField = .title
     @State private var isScrubbing           = false
+    @State private var isPeeking             = false
 
     @Environment(\.dismiss) private var dismiss
 
@@ -45,9 +46,15 @@ struct CardStudyView: View {
                         .frame(maxHeight: .infinity)
                 } else {
                     Spacer(minLength: 12)
-                    cardStack
-                        .frame(width: cardWidth, height: cardHeight)
-                        .frame(maxWidth: .infinity)
+                    ZStack {
+                        cardStack
+                            .frame(width: cardWidth, height: cardHeight)
+                        if isPeeking, let verse = vm.currentVerse {
+                            peekOverlay(verse: verse, width: cardWidth, height: cardHeight)
+                        }
+                    }
+                    .frame(width: cardWidth, height: cardHeight)
+                    .frame(maxWidth: .infinity)
                     Spacer(minLength: 12)
                 }
 
@@ -276,6 +283,62 @@ struct CardStudyView: View {
         }
     }
 
+    // MARK: - Peek
+
+    /// Card-style overlay matching the real card but with all text in secondary color.
+    private func peekOverlay(verse: Verse, width: CGFloat, height: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("\(verse.book) \(verse.reference)")
+                .font(.system(size: 18, weight: .bold, design: .serif))
+                .foregroundColor(.secondary)
+
+            Spacer().frame(height: 10)
+
+            Text(verse.title)
+                .font(.system(size: 16, weight: .bold, design: .serif))
+                .foregroundColor(.secondary)
+                .padding(.bottom, 6)
+
+            Text(verse.verse)
+                .font(.system(size: 15, design: .serif))
+                .lineSpacing(5)
+                .foregroundColor(.secondary)
+                .minimumScaleFactor(0.75)
+
+            Spacer(minLength: 6)
+
+            Text(vm.cardLabel(for: verse))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.secondary.opacity(0.5))
+        }
+        .flashcardStyle()
+        .frame(width: width, height: height)
+        .transition(.opacity)
+        .animation(.easeInOut(duration: 0.1), value: isPeeking)
+    }
+
+    /// Compact hold-to-peek eye icon — inline with input controls.
+    private var peekIconButton: some View {
+        Image(systemName: isPeeking ? "eye.fill" : "eye")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundColor(isPeeking ? .blue : .secondary)
+            .frame(width: 48, height: 48)
+            .background(isPeeking ? Color.blue.opacity(0.12) : Color(.secondarySystemGroupedBackground))
+            .cornerRadius(12)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        if !isPeeking {
+                            withAnimation(.easeInOut(duration: 0.1)) { isPeeking = true }
+                        }
+                    }
+                    .onEnded { _ in
+                        withAnimation(.easeInOut(duration: 0.1)) { isPeeking = false }
+                    }
+            )
+    }
+
     // MARK: - Scrubber
 
     private var scrubberRow: some View {
@@ -360,6 +423,7 @@ struct CardStudyView: View {
                             .background(speech.isListening ? Color.red : Color(.secondarySystemGroupedBackground))
                             .cornerRadius(12)
                     }
+                    peekIconButton
                     let isEmpty = vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
                               && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty
                     Button {
@@ -427,6 +491,7 @@ struct CardStudyView: View {
             .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color(.separator).opacity(0.5), lineWidth: 0.5))
             .offset(x: shakeOffset)
 
+            peekIconButton
             if isInputFocused {
                 Button { isInputFocused = false } label: {
                     Image(systemName: "keyboard.chevron.compact.down")


### PR DESCRIPTION
## Summary

- Ports the hold-to-peek eye button from `TestSessionView` to `CardStudyView`'s review mode so pack-study sessions get the same peek affordance as the Review-tab scored sessions.
- Identical implementation: a `DragGesture(minimumDistance: 0)` on an `Image(systemName: "eye"/"eye.fill")` toggles `isPeeking`, and a secondary-color overlay is rendered on top of the card stack while held. This preserves the same incidental keyboard-drop-while-peeking behavior the user reported seeing in the Review-tab session.
- Peek button is added in both bottom-control paths: `submitControls` (Entire Verse mode, between mic and Submit) and `inputField` (First Letter / Full Word modes, to the right of the text field).

## Test plan

- [ ] Open a pack from the Packs tab, switch to Review segment, pick First Letter mode — press and hold the eye button, full verse should appear in secondary color; release to hide.
- [ ] Same as above in Full Word mode.
- [ ] Switch to Entire Verse mode — peek button appears between mic and Submit; hold/release works identically.
- [ ] Verify read mode (Read segment) is unaffected — no peek button, no overlay.
- [ ] Confirm peek button does NOT appear in vertical-scroll read mode.
- [ ] Compare side-by-side with Review-tab peek button to verify keyboard-drop-while-held behavior matches.

## Note

This branch (`claude/analyze-test-coverage-RGhW6`) was originally named for a test-coverage analysis request; the peek-button commit was added on the same branch per user instruction. The test-coverage analysis itself was delivered in-chat and not committed.

https://claude.ai/code/session_01SXgLE8Dg8sAghjFxR6mfiy