### PR TITLE
Clean up: extract shared peek/shake, dedupe placeholder, modernize onChange

### DIFF
--- a/scripture memory/Model/AppSettings.swift
+++ b/scripture memory/Model/AppSettings.swift
@@ -23,6 +23,13 @@ enum StudyMode: String, CaseIterable {
         case .submit:      return "Type the full verse on the card, then tap Submit to check all at once."
         }
     }
+
+    /// Placeholder text for the single text field used in first-letter / full-word input.
+    var inputPlaceholder: String {
+        self == .fullWord
+            ? "Type each word, press space to check..."
+            : "Type first letter of each word..."
+    }
 }
 
 // MARK: - Bible Version

--- a/scripture memory/Model/SettingsManager.swift
+++ b/scripture memory/Model/SettingsManager.swift
@@ -1,2 +1,0 @@
-// Settings enums and constants live in AppSettings.swift.
-// This file is intentionally empty.

--- a/scripture memory/Utilities/SharedUtilities.swift
+++ b/scripture memory/Utilities/SharedUtilities.swift
@@ -138,3 +138,88 @@ struct CardButtonStyle: ButtonStyle {
             .animation(.spring(response: 0.25, dampingFraction: 0.7), value: configuration.isPressed)
     }
 }
+
+// MARK: - Peek Components
+
+/// Compact hold-to-peek eye icon — inline with input controls.
+/// Uses `DragGesture(minimumDistance: 0)` so press-down triggers reveal and release hides it.
+struct PeekEyeButton: View {
+    @Binding var isPeeking: Bool
+
+    var body: some View {
+        Image(systemName: isPeeking ? "eye.fill" : "eye")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundColor(isPeeking ? .blue : .secondary)
+            .frame(width: 48, height: 48)
+            .background(isPeeking ? Color.blue.opacity(0.12) : Color(.secondarySystemGroupedBackground))
+            .cornerRadius(12)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        if !isPeeking {
+                            withAnimation(.easeInOut(duration: 0.1)) { isPeeking = true }
+                        }
+                    }
+                    .onEnded { _ in
+                        withAnimation(.easeInOut(duration: 0.1)) { isPeeking = false }
+                    }
+            )
+    }
+}
+
+/// Card-style overlay matching the real card but with all text in secondary color.
+/// Shown while the user holds a `PeekEyeButton`.
+struct PeekOverlayCard: View {
+    let verse:     Verse
+    let cardLabel: String
+    let width:     CGFloat
+    let height:    CGFloat
+    let isPeeking: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("\(verse.book) \(verse.reference)")
+                .font(.system(size: 18, weight: .bold, design: .serif))
+                .foregroundColor(.secondary)
+
+            Spacer().frame(height: 10)
+
+            Text(verse.title)
+                .font(.system(size: 16, weight: .bold, design: .serif))
+                .foregroundColor(.secondary)
+                .padding(.bottom, 6)
+
+            Text(verse.verse)
+                .font(.system(size: 15, design: .serif))
+                .lineSpacing(5)
+                .foregroundColor(.secondary)
+                .minimumScaleFactor(0.75)
+
+            Spacer(minLength: 6)
+
+            Text(cardLabel)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.secondary.opacity(0.5))
+        }
+        .flashcardStyle()
+        .frame(width: width, height: height)
+        .transition(.opacity)
+        .animation(.easeInOut(duration: 0.1), value: isPeeking)
+    }
+}
+
+// MARK: - Shake Animation
+
+/// Fires a three-step horizontal shake by animating a `CGFloat` binding.
+/// Used to signal wrong input. Runs on the main actor; timings match across the app.
+@MainActor
+func triggerShake(_ offset: Binding<CGFloat>) {
+    withAnimation(.interpolatingSpring(stiffness: 600, damping: 10)) { offset.wrappedValue = 12 }
+    Task { @MainActor in
+        try? await Task.sleep(for: .milliseconds(70))
+        withAnimation(.interpolatingSpring(stiffness: 600, damping: 12)) { offset.wrappedValue = -8 }
+        try? await Task.sleep(for: .milliseconds(70))
+        withAnimation(.spring()) { offset.wrappedValue = 0 }
+    }
+}

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -50,7 +50,13 @@ struct CardStudyView: View {
                         cardStack
                             .frame(width: cardWidth, height: cardHeight)
                         if isPeeking, let verse = vm.currentVerse {
-                            peekOverlay(verse: verse, width: cardWidth, height: cardHeight)
+                            PeekOverlayCard(
+                                verse: verse,
+                                cardLabel: vm.cardLabel(for: verse),
+                                width: cardWidth,
+                                height: cardHeight,
+                                isPeeking: isPeeking
+                            )
                         }
                     }
                     .frame(width: cardWidth, height: cardHeight)
@@ -68,8 +74,8 @@ struct CardStudyView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
-        .onChange(of: vm.isReviewMode) { handleReviewModeChange($0) }
-        .onChange(of: vm.currentIndex) { _ in
+        .onChange(of: vm.isReviewMode) { _, reviewing in handleReviewModeChange(reviewing) }
+        .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
             if speech.isListening { speech.stopListening() }
             if isScrubbing {
@@ -78,14 +84,14 @@ struct CardStudyView: View {
                 refocusIfNeeded()
             }
         }
-        .onChange(of: speech.transcript) { text in
+        .onChange(of: speech.transcript) { _, text in
             guard speech.isListening else { return }
             switch speechTarget {
             case .title: vm.titleInput = text
             case .verse: vm.verseInput = text
             }
         }
-        .onChange(of: submitFocus) { newFocus in
+        .onChange(of: submitFocus) { _, newFocus in
             guard speech.isListening, let newFocus else { return }
             speech.stopListening()
             speechTarget = newFocus
@@ -283,62 +289,6 @@ struct CardStudyView: View {
         }
     }
 
-    // MARK: - Peek
-
-    /// Card-style overlay matching the real card but with all text in secondary color.
-    private func peekOverlay(verse: Verse, width: CGFloat, height: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("\(verse.book) \(verse.reference)")
-                .font(.system(size: 18, weight: .bold, design: .serif))
-                .foregroundColor(.secondary)
-
-            Spacer().frame(height: 10)
-
-            Text(verse.title)
-                .font(.system(size: 16, weight: .bold, design: .serif))
-                .foregroundColor(.secondary)
-                .padding(.bottom, 6)
-
-            Text(verse.verse)
-                .font(.system(size: 15, design: .serif))
-                .lineSpacing(5)
-                .foregroundColor(.secondary)
-                .minimumScaleFactor(0.75)
-
-            Spacer(minLength: 6)
-
-            Text(vm.cardLabel(for: verse))
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(.secondary.opacity(0.5))
-        }
-        .flashcardStyle()
-        .frame(width: width, height: height)
-        .transition(.opacity)
-        .animation(.easeInOut(duration: 0.1), value: isPeeking)
-    }
-
-    /// Compact hold-to-peek eye icon — inline with input controls.
-    private var peekIconButton: some View {
-        Image(systemName: isPeeking ? "eye.fill" : "eye")
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundColor(isPeeking ? .blue : .secondary)
-            .frame(width: 48, height: 48)
-            .background(isPeeking ? Color.blue.opacity(0.12) : Color(.secondarySystemGroupedBackground))
-            .cornerRadius(12)
-            .contentShape(Rectangle())
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { _ in
-                        if !isPeeking {
-                            withAnimation(.easeInOut(duration: 0.1)) { isPeeking = true }
-                        }
-                    }
-                    .onEnded { _ in
-                        withAnimation(.easeInOut(duration: 0.1)) { isPeeking = false }
-                    }
-            )
-    }
-
     // MARK: - Scrubber
 
     private var scrubberRow: some View {
@@ -423,7 +373,7 @@ struct CardStudyView: View {
                             .background(speech.isListening ? Color.red : Color(.secondarySystemGroupedBackground))
                             .cornerRadius(12)
                     }
-                    peekIconButton
+                    PeekEyeButton(isPeeking: $isPeeking)
                     let isEmpty = vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
                               && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty
                     Button {
@@ -467,18 +417,18 @@ struct CardStudyView: View {
                     .focused($isInputFocused)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
-                    .onChange(of: vm.inputText) { newValue in
+                    .onChange(of: vm.inputText) { _, newValue in
                         guard !newValue.isEmpty else { return }
                         switch studyMode {
                         case .firstLetter:
                             let correct = vm.processFirstLetterInput(newValue)
                             DispatchQueue.main.async { vm.inputText = "" }
-                            if correct { HapticEngine.light() } else { HapticEngine.error(); shakeAnimation() }
+                            if correct { HapticEngine.light() } else { HapticEngine.error(); triggerShake($shakeOffset) }
                         case .fullWord:
                             if vm.processFullWordInput(newValue) {
                                 HapticEngine.light()
                             } else if newValue.hasSuffix(" ") {
-                                HapticEngine.error(); shakeAnimation()
+                                HapticEngine.error(); triggerShake($shakeOffset)
                             }
                         case .submit:
                             break
@@ -491,7 +441,7 @@ struct CardStudyView: View {
             .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color(.separator).opacity(0.5), lineWidth: 0.5))
             .offset(x: shakeOffset)
 
-            peekIconButton
+            PeekEyeButton(isPeeking: $isPeeking)
             if isInputFocused {
                 Button { isInputFocused = false } label: {
                     Image(systemName: "keyboard.chevron.compact.down")
@@ -612,25 +562,6 @@ struct CardStudyView: View {
         }
     }
 
-    // MARK: - Shake Animation
-
-    private func shakeAnimation() {
-        withAnimation(.interpolatingSpring(stiffness: 600, damping: 10)) { shakeOffset = 12 }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.07) {
-            withAnimation(.interpolatingSpring(stiffness: 600, damping: 12)) { shakeOffset = -8 }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) {
-            withAnimation(.spring()) { shakeOffset = 0 }
-        }
-    }
-}
-
-private extension StudyMode {
-    var inputPlaceholder: String {
-        self == .fullWord
-            ? "Type each word, press space to check..."
-            : "Type first letter of each word..."
-    }
 }
 
 #Preview {

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -387,18 +387,6 @@ struct PackCover: View {
     }
 }
 
-// MARK: - Pack Cover Style
-
-private extension View {
-    func packCoverStyle(border: Color, shadowOpacity: Double = 0.12) -> some View {
-        self
-            .aspectRatio(5.0 / 3.0, contentMode: .fit)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(border, lineWidth: 0.5))
-            .shadow(color: .black.opacity(shadowOpacity), radius: 8, x: 0, y: 4)
-    }
-}
-
 #Preview {
     NavigationStack { PackListView() }
 }

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -55,7 +55,13 @@ struct TestSessionView: View {
                     cardStack
                         .frame(width: cardWidth, height: cardHeight)
                     if isPeeking, let verse = vm.currentVerse {
-                        peekOverlay(verse: verse, width: cardWidth, height: cardHeight)
+                        PeekOverlayCard(
+                            verse: verse,
+                            cardLabel: vm.cardLabel(for: verse),
+                            width: cardWidth,
+                            height: cardHeight,
+                            isPeeking: isPeeking
+                        )
                     }
                 }
                 .frame(width: cardWidth, height: cardHeight)
@@ -70,7 +76,7 @@ struct TestSessionView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
-        .onChange(of: vm.currentIndex) { _ in
+        .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
             if speech.isListening { speech.stopListening() }
             if isScrubbing {
@@ -82,14 +88,14 @@ struct TestSessionView: View {
                 refocusIfNeeded()
             }
         }
-        .onChange(of: speech.transcript) { text in
+        .onChange(of: speech.transcript) { _, text in
             guard speech.isListening else { return }
             switch speechTarget {
             case .title: vm.titleInput = text
             case .verse: vm.verseInput = text
             }
         }
-        .onChange(of: submitFocus) { newFocus in
+        .onChange(of: submitFocus) { _, newFocus in
             guard speech.isListening, let newFocus else { return }
             speech.stopListening()
             speechTarget = newFocus
@@ -488,62 +494,6 @@ struct TestSessionView: View {
         .transition(.scale.combined(with: .opacity))
     }
 
-    // MARK: - Peek
-
-    /// Card-style overlay matching the real card but with all text in secondary color.
-    private func peekOverlay(verse: Verse, width: CGFloat, height: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("\(verse.book) \(verse.reference)")
-                .font(.system(size: 18, weight: .bold, design: .serif))
-                .foregroundColor(.secondary)
-
-            Spacer().frame(height: 10)
-
-            Text(verse.title)
-                .font(.system(size: 16, weight: .bold, design: .serif))
-                .foregroundColor(.secondary)
-                .padding(.bottom, 6)
-
-            Text(verse.verse)
-                .font(.system(size: 15, design: .serif))
-                .lineSpacing(5)
-                .foregroundColor(.secondary)
-                .minimumScaleFactor(0.75)
-
-            Spacer(minLength: 6)
-
-            Text(vm.cardLabel(for: verse))
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(.secondary.opacity(0.5))
-        }
-        .flashcardStyle()
-        .frame(width: width, height: height)
-        .transition(.opacity)
-        .animation(.easeInOut(duration: 0.1), value: isPeeking)
-    }
-
-    /// Compact hold-to-peek eye icon — inline with input controls.
-    private var peekIconButton: some View {
-        Image(systemName: isPeeking ? "eye.fill" : "eye")
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundColor(isPeeking ? .blue : .secondary)
-            .frame(width: 48, height: 48)
-            .background(isPeeking ? Color.blue.opacity(0.12) : Color(.secondarySystemGroupedBackground))
-            .cornerRadius(12)
-            .contentShape(Rectangle())
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { _ in
-                        if !isPeeking {
-                            withAnimation(.easeInOut(duration: 0.1)) { isPeeking = true }
-                        }
-                    }
-                    .onEnded { _ in
-                        withAnimation(.easeInOut(duration: 0.1)) { isPeeking = false }
-                    }
-            )
-    }
-
     // MARK: - Submit Controls
 
     private var submitControls: some View {
@@ -588,7 +538,7 @@ struct TestSessionView: View {
                             .background(speech.isListening ? Color.red : Color(.secondarySystemGroupedBackground))
                             .cornerRadius(12)
                     }
-                    peekIconButton
+                    PeekEyeButton(isPeeking: $isPeeking)
                     let isEmpty = vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
                               && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty
                     Button {
@@ -628,23 +578,23 @@ struct TestSessionView: View {
                 Image(systemName: "character.cursor.ibeam")
                     .foregroundColor(.secondary).font(.system(size: 16))
 
-                TextField(studyMode.testInputPlaceholder, text: $vm.inputText)
+                TextField(studyMode.inputPlaceholder, text: $vm.inputText)
                     .font(.system(size: 17))
                     .focused($isInputFocused)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
-                    .onChange(of: vm.inputText) { newValue in
+                    .onChange(of: vm.inputText) { _, newValue in
                         guard !newValue.isEmpty else { return }
                         switch studyMode {
                         case .firstLetter:
                             let correct = vm.processFirstLetterInput(newValue)
                             DispatchQueue.main.async { vm.inputText = "" }
-                            if correct { HapticEngine.light() } else { HapticEngine.error(); shakeAnimation() }
+                            if correct { HapticEngine.light() } else { HapticEngine.error(); triggerShake($shakeOffset) }
                         case .fullWord:
                             if vm.processFullWordInput(newValue) {
                                 HapticEngine.light()
                             } else if newValue.hasSuffix(" ") {
-                                HapticEngine.error(); shakeAnimation()
+                                HapticEngine.error(); triggerShake($shakeOffset)
                             }
                         case .submit:
                             break
@@ -657,7 +607,7 @@ struct TestSessionView: View {
             .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color(.separator).opacity(0.5), lineWidth: 0.5))
             .offset(x: shakeOffset)
 
-            peekIconButton
+            PeekEyeButton(isPeeking: $isPeeking)
             if isInputFocused {
                 Button { isInputFocused = false } label: {
                     Image(systemName: "keyboard.chevron.compact.down")
@@ -768,25 +718,5 @@ struct TestSessionView: View {
         }
     }
 
-    // MARK: - Shake Animation
-
-    private func shakeAnimation() {
-        withAnimation(.interpolatingSpring(stiffness: 600, damping: 10)) { shakeOffset = 12 }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.07) {
-            withAnimation(.interpolatingSpring(stiffness: 600, damping: 12)) { shakeOffset = -8 }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) {
-            withAnimation(.spring()) { shakeOffset = 0 }
-        }
-    }
 }
 
-// MARK: - StudyMode Extension
-
-private extension StudyMode {
-    var testInputPlaceholder: String {
-        self == .fullWord
-            ? "Type each word, press space to check..."
-            : "Type first letter of each word..."
-    }
-}


### PR DESCRIPTION
## Summary
- Extract `PeekEyeButton`, `PeekOverlayCard`, and `triggerShake(_:)` into `SharedUtilities.swift` so `CardStudyView` and `TestSessionView` no longer duplicate the peek/shake implementations.
- Promote `StudyMode.inputPlaceholder` to `AppSettings.swift` (previously two private extensions with slightly different names — `inputPlaceholder` and `testInputPlaceholder`).
- Replace chained `DispatchQueue.main.asyncAfter` in the shake animation with `Task { @MainActor in ... Task.sleep(for: .milliseconds(70)) }`.
- Migrate nine deprecated single-parameter `.onChange(of:) { value in }` call sites to the iOS 17 two-parameter form `{ _, newValue in }`.
- Delete unused `packCoverStyle(border:shadowOpacity:)` `View` extension from `PackListView.swift`.
- Delete empty `SettingsManager.swift` stub (not referenced in `project.pbxproj`; project uses `PBXFileSystemSynchronizedRootGroup`).

Net -61 lines across six files. No behavior changes.

## Test plan
- [ ] Build on iOS 17 simulator — no deprecation warnings remain for `.onChange`.
- [ ] Review mode (CardStudyView): hold peek button → secondary-colored overlay shows full verse; release → hides.
- [ ] Test mode (TestSessionView): same peek behavior still works.
- [ ] First-letter and full-word placeholders read correctly in both views.
- [ ] Wrong-input shake still animates smoothly in both views.

https://claude.ai/code/session_01SXgLE8Dg8sAghjFxR6mfiy