### PR TITLE
Surface the current learning verse; refine SRS, streak, and study input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Xcode / SwiftPM build artifacts
 .build/
+build/
 DerivedData/
 *.xcuserstate
+*.xcresult
 **/xcuserdata/

--- a/Scripture Memory.xcodeproj/project.pbxproj
+++ b/Scripture Memory.xcodeproj/project.pbxproj
@@ -385,11 +385,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
@@ -434,11 +434,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;

--- a/Scripture Memory.xcodeproj/xcshareddata/xcschemes/ScriptureWidgetExtension.xcscheme
+++ b/Scripture Memory.xcodeproj/xcshareddata/xcschemes/ScriptureWidgetExtension.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F600000000A003"
+               BuildableName = "ScriptureWidgetExtension.appex"
+               BlueprintName = "ScriptureWidgetExtension"
+               ReferencedContainer = "container:Scripture Memory.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "53709C072DBE80FE000BA559"
+               BuildableName = "Scripture Memory.app"
+               BlueprintName = "Scripture Memory"
+               ReferencedContainer = "container:Scripture Memory.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53709C072DBE80FE000BA559"
+            BuildableName = "Scripture Memory.app"
+            BlueprintName = "Scripture Memory"
+            ReferencedContainer = "container:Scripture Memory.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53709C072DBE80FE000BA559"
+            BuildableName = "Scripture Memory.app"
+            BlueprintName = "Scripture Memory"
+            ReferencedContainer = "container:Scripture Memory.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ScriptureWidget/DailyVerseWidget.swift
+++ b/ScriptureWidget/DailyVerseWidget.swift
@@ -4,48 +4,40 @@ import SwiftUI
 // MARK: - Timeline
 
 struct VerseEntry: TimelineEntry {
-    let date:      Date
-    let verse:     WidgetVerse?
-    /// True when showing the live "current learning verse" (vs a pinned one).
-    let isCurrent: Bool
-    let streak:    Int
-    let dueToday:  Int
-    let learned:   Int
-    let week:      [SharedStore.WeekDay]
+    let date:     Date
+    let verse:    WidgetVerse?
+    /// True when `verse` is a user-pinned spotlight (vs the live cursor).
+    let isPinned: Bool
+    let streak:   Int
+    let dueToday: Int
+    let learned:  Int
+    let week:     [SharedStore.WeekDay]
 }
 
-struct VerseProvider: AppIntentTimelineProvider {
+struct VerseProvider: TimelineProvider {
     func placeholder(in context: Context) -> VerseEntry {
-        VerseEntry(date: Date(), verse: VerseLibrary.allVerses.first, isCurrent: true,
+        VerseEntry(date: Date(), verse: VerseLibrary.allVerses.first, isPinned: false,
                    streak: 0, dueToday: 0, learned: 0, week: [])
     }
 
-    func snapshot(for configuration: VerseConfigIntent, in context: Context) async -> VerseEntry {
-        resolve(configuration)
+    func getSnapshot(in context: Context, completion: @escaping (VerseEntry) -> Void) {
+        completion(resolve())
     }
 
-    func timeline(for configuration: VerseConfigIntent, in context: Context) async -> Timeline<VerseEntry> {
-        // The app reloads us whenever the cursor moves; this re-poll is a safety net.
+    func getTimeline(in context: Context, completion: @escaping (Timeline<VerseEntry>) -> Void) {
+        // The app reloads us whenever the featured verse changes; this re-poll is a safety net.
         let next = Calendar.current.date(byAdding: .hour, value: 6, to: Date()) ?? Date().addingTimeInterval(21_600)
-        return Timeline(entries: [resolve(configuration)], policy: .after(next))
+        completion(Timeline(entries: [resolve()], policy: .after(next)))
     }
 
-    private func resolve(_ config: VerseConfigIntent) -> VerseEntry {
-        let snap    = SharedStore.snapshot()
-        let streak  = snap?.streak ?? 0
-        let due     = snap?.dueToday ?? 0
-        let learned = snap?.learned ?? 0
-        let week    = snap?.week ?? []
-        // A pinned verse wins — unless it's the "Current learning verse" sentinel
-        // (the picker entry that lets the user reset to following their cursor).
-        if let picked = config.verse, picked.id != VerseEntity.currentSentinelID,
-           let v = VerseLibrary.verse(id: picked.id) {
-            return VerseEntry(date: Date(), verse: v, isCurrent: false,
-                              streak: streak, dueToday: due, learned: learned, week: week)
-        }
-        let current = SharedStore.currentLearningVerse()
-        return VerseEntry(date: Date(), verse: current ?? VerseLibrary.allVerses.first,
-                          isCurrent: current != nil, streak: streak, dueToday: due, learned: learned, week: week)
+    /// The widget mirrors whatever the app is featuring — a pinned verse or the
+    /// live cursor — both chosen in-app, so the widget itself has no configuration.
+    private func resolve() -> VerseEntry {
+        let snap  = SharedStore.snapshot()
+        let verse = SharedStore.displayedVerse() ?? VerseLibrary.allVerses.first
+        return VerseEntry(date: Date(), verse: verse, isPinned: SharedStore.isPinned(),
+                          streak: snap?.streak ?? 0, dueToday: snap?.dueToday ?? 0,
+                          learned: snap?.learned ?? 0, week: snap?.week ?? [])
     }
 }
 
@@ -121,10 +113,17 @@ struct VerseEntryView: View {
                 .lineSpacing(verseSpacing)
                 .minimumScaleFactor(0.5)
             Spacer(minLength: 4)
-            Text(v.packName)
-                .font(.system(size: packSize, weight: .medium))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+            HStack(spacing: 3) {
+                if entry.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: packSize, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Text(v.packName)
+                    .font(.system(size: packSize, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
         }
     }
 
@@ -152,10 +151,17 @@ struct VerseEntryView: View {
                     .lineLimit(5)
                     .minimumScaleFactor(0.7)
                 Spacer(minLength: 4)
-                Text(v.packName)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
+                HStack(spacing: 3) {
+                    if entry.isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                    Text(v.packName)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
@@ -286,11 +292,11 @@ struct ScriptureVerseWidget: Widget {
     let kind = "ScriptureVerseWidget"
 
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: VerseConfigIntent.self, provider: VerseProvider()) { entry in
+        StaticConfiguration(kind: kind, provider: VerseProvider()) { entry in
             VerseEntryView(entry: entry)
         }
         .configurationDisplayName("Scripture Verse")
-        .description("Your current learning verse — or one you pin.")
+        .description("Your current learning verse — or one you pin in the app.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
@@ -315,7 +321,7 @@ struct ProgressProvider: TimelineProvider {
     private func entry() -> ProgressEntry {
         let snap = SharedStore.snapshot()
         return ProgressEntry(date: Date(),
-                             verse: SharedStore.currentLearningVerse() ?? VerseLibrary.allVerses.first,
+                             verse: SharedStore.displayedVerse() ?? VerseLibrary.allVerses.first,
                              streak: snap?.streak ?? 0,
                              dueToday: snap?.dueToday ?? 0,
                              learned: snap?.learned ?? 0)

--- a/ScriptureWidget/WidgetVerse.swift
+++ b/ScriptureWidget/WidgetVerse.swift
@@ -72,6 +72,7 @@ enum SharedStore {
     }
     struct Snapshot: Codable {
         var verse:    SharedVerse?
+        var isPinned: Bool = false
         var streak:   Int
         var dueToday: Int
         var learned:  Int
@@ -84,10 +85,15 @@ enum SharedStore {
         return s
     }
 
-    static func currentLearningVerse() -> WidgetVerse? {
+    /// The verse the app is featuring — pinned if the user pinned one, otherwise
+    /// the live current-learning verse. The app writes whichever into the snapshot.
+    static func displayedVerse() -> WidgetVerse? {
         guard let s = snapshot()?.verse else { return nil }
         var v = WidgetVerse(title: s.title, verse: s.verse, book: s.book, reference: s.reference)
         v.packName = s.packName
         return v
     }
+
+    /// Whether `displayedVerse()` is a user-pinned spotlight (vs the live cursor).
+    static func isPinned() -> Bool { snapshot()?.isPinned ?? false }
 }

--- a/Tests/SRSCoreTests/SRSAlgorithmTests.swift
+++ b/Tests/SRSCoreTests/SRSAlgorithmTests.swift
@@ -43,6 +43,13 @@ final class SRSAlgorithmTests: XCTestCase {
         XCTAssertEqual(dueOffset(s), 60, accuracy: 0.001)      // 1 min step
     }
 
+    func testNewCardHardSitsBetweenAgainAndGood() {
+        let s = updateSRS(state: .newCard(key: "k", now: now), grade: .hard, now: now)
+        XCTAssertEqual(s.phase, .learning)
+        XCTAssertEqual(s.learningStep, 0)                      // stays on the same step
+        XCTAssertEqual(dueOffset(s), 330, accuracy: 0.001)     // (60 + 600) / 2 = 5 min
+    }
+
     // MARK: - Review phase
 
     func testReviewGoodMultipliesByEase() {
@@ -89,6 +96,7 @@ final class SRSAlgorithmTests: XCTestCase {
     func testPredictedIntervalLabelsForFreshCard() {
         let fresh = SRSCardState.newCard(key: "k", now: now)
         XCTAssertEqual(predictedIntervalLabel(state: fresh, grade: .again, now: now), "1m")
+        XCTAssertEqual(predictedIntervalLabel(state: fresh, grade: .hard, now: now), "5m")
         XCTAssertEqual(predictedIntervalLabel(state: fresh, grade: .good, now: now), "10m")
         XCTAssertEqual(predictedIntervalLabel(state: fresh, grade: .easy, now: now), "4d")
     }

--- a/scripture memory/App.swift
+++ b/scripture memory/App.swift
@@ -9,15 +9,24 @@ import SwiftUI
 
 @main
 struct ScriptureMemoryApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .task {
+                    // Opening the app counts toward today's streak — just viewing the
+                    // verse on Home keeps it alive (the scenePhase handler below covers
+                    // returning from the background later the same day).
+                    StreakStore.shared.recordToday()
                     // Re-arm the daily reminder from saved settings on every
                     // launch (the OS keeps the repeating trigger, but this keeps
                     // it in sync if permission or the time changed out of band).
                     await NotificationManager.refreshFromSettings()
                 }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { StreakStore.shared.recordToday() }
         }
     }
 }

--- a/scripture memory/Model/LearningStore.swift
+++ b/scripture memory/Model/LearningStore.swift
@@ -12,14 +12,29 @@ final class LearningStore: ObservableObject {
 
     static let shared = LearningStore()
 
-    /// `srsKey`s of verses the user has marked learnt.
-    @Published private(set) var learntKeys: Set<String>
+    /// `srsKey`s of verses the user has marked learnt. Mutating it invalidates the
+    /// cached current-verse key so badges/shortcuts recompute on the next read.
+    @Published private(set) var learntKeys: Set<String> {
+        didSet { cachedCurrent = nil }
+    }
+
+    /// Memoized current verse, tagged with the cheap input token it was computed
+    /// for — recomputing `visibleOrdered` (a 480-verse flatMap) on every card
+    /// frame would stutter swipes, so we only rebuild when an input actually moves.
+    private var cachedCurrent: (token: Int, verse: Verse?)?
+
+    /// `srsKey` of a verse the user pinned to feature on Home + the widget,
+    /// overriding the live "current learning verse". Non-destructive: pinning
+    /// never touches `learntKeys`, so clearing it returns to the cursor.
+    @Published private(set) var pinnedKey: String?
 
     private let defaults = UserDefaults.standard
-    private static let storageKey = "learning.learntKeys.v1"
+    private static let storageKey    = "learning.learntKeys.v1"
+    private static let pinStorageKey = "learning.pinnedKey.v1"
 
     private init() {
         learntKeys = Set(defaults.stringArray(forKey: Self.storageKey) ?? [])
+        pinnedKey  = defaults.string(forKey: Self.pinStorageKey)
     }
 
     func isLearnt(_ verse: Verse) -> Bool { learntKeys.contains(verse.srsKey) }
@@ -29,6 +44,77 @@ final class LearningStore: ObservableObject {
     func current(in ordered: [Verse]) -> (verse: Verse, index: Int)? {
         guard let i = ordered.firstIndex(where: { !learntKeys.contains($0.srsKey) }) else { return nil }
         return (ordered[i], i)
+    }
+
+    // MARK: - Current verse, resolved globally
+
+    /// The visible verse sequence — the same flattening Home uses — rebuilt from
+    /// the model layer (pack order/visibility + Bible version) so *any* screen can
+    /// ask "is this the current verse?" without the dashboard plumbing it through.
+    var visibleOrdered: [Verse] {
+        let version = BibleVersion(rawValue: defaults.string(forKey: "bibleVersion") ?? "") ?? .niv84
+        return PackPreferencesStore.shared.visible(from: version.packs).flatMap(\.verses)
+    }
+
+    /// Cheap fingerprint of everything `visibleOrdered` depends on except
+    /// `learntKeys` (which invalidates via its `didSet`): Bible version + pack
+    /// order/visibility. Hashing ~12 pack names is far cheaper than rebuilding the
+    /// verse list, so this gates the cache without the heavy recompute.
+    private var currentInputToken: Int {
+        var h = Hasher()
+        h.combine(defaults.string(forKey: "bibleVersion") ?? "")
+        h.combine(PackPreferencesStore.shared.order)
+        h.combine(PackPreferencesStore.shared.hidden)
+        return h.finalize()
+    }
+
+    /// The current stopped verse (the learning cursor, ignoring any pin), or `nil`
+    /// once every visible verse is learnt. Memoized (see `cachedCurrent`) so the
+    /// per-card `isCurrent` checks during a swipe stay cheap.
+    var currentVerse: Verse? {
+        let token = currentInputToken
+        if let c = cachedCurrent, c.token == token { return c.verse }
+        let v = current(in: visibleOrdered)?.verse
+        cachedCurrent = (token, v)
+        return v
+    }
+
+    /// `srsKey` of the current stopped verse — drives the cross-surface checks.
+    var currentKey: String? { currentVerse?.srsKey }
+
+    /// Is `verse` the current stopped verse (the learning cursor)? Drives the
+    /// "Current" badge and the Mark-as-Learnt button across every study surface.
+    func isCurrent(_ verse: Verse) -> Bool {
+        guard !verse.srsKey.isEmpty, let key = currentKey else { return false }
+        return key == verse.srsKey
+    }
+
+    // MARK: - Pinned verse (Home + widget spotlight)
+
+    /// The verse to feature on Home and in the widget: the pinned one if it's
+    /// still visible, otherwise the current learning verse. `isPinned` lets the
+    /// UI (and widget) label the two states differently.
+    func displayed(in ordered: [Verse]) -> (verse: Verse, isPinned: Bool)? {
+        if let key = pinnedKey, let v = ordered.first(where: { $0.srsKey == key }) {
+            return (v, true)
+        }
+        return current(in: ordered).map { ($0.verse, false) }
+    }
+
+    func isPinned(_ verse: Verse) -> Bool { pinnedKey != nil && pinnedKey == verse.srsKey }
+
+    /// Pin `verse` to Home/widget. Does not change learning progress.
+    func pin(_ verse: Verse) {
+        guard !verse.srsKey.isEmpty else { return }
+        pinnedKey = verse.srsKey
+        defaults.set(verse.srsKey, forKey: Self.pinStorageKey)
+    }
+
+    /// Clear the pin — Home/widget return to the current learning verse.
+    func unpin() {
+        guard pinnedKey != nil else { return }
+        pinnedKey = nil
+        defaults.removeObject(forKey: Self.pinStorageKey)
     }
 
     /// How many of `ordered` are learnt (for progress display).

--- a/scripture memory/Model/SRSAlgorithm.swift
+++ b/scripture memory/Model/SRSAlgorithm.swift
@@ -4,8 +4,9 @@ import Foundation
 ///
 /// Behavior summary:
 /// - **Learning phase** walks through `config.learningSteps`. Again resets to step 0;
-///   Hard repeats the current step; Good advances; Easy graduates immediately
-///   with `easyInterval`.
+///   Hard waits midway between the current and next step (so it doesn't coincide
+///   with Again on step 0); Good advances; Easy graduates immediately with
+///   `easyInterval`.
 /// - **Review phase**: Again sends the card back to learning (lapse). Hard scales
 ///   the interval by `hardIntervalMultiplier` and trims ease. Good multiplies by
 ///   ease (unchanged). Easy multiplies by ease × `easyMultiplier` and boosts ease.
@@ -50,8 +51,13 @@ private func applyLearning(
         return s
 
     case .hard:
-        let i = min(s.learningStep, steps.count - 1)
-        s.due = now.addingTimeInterval(steps[i])
+        // Land Hard between "repeat this step" and the next step, so on step 0 it
+        // doesn't collapse onto Again (both would be steps[0]). On the last step
+        // there's no next, so it just repeats the current step.
+        let i        = min(s.learningStep, steps.count - 1)
+        let cur      = steps[i]
+        let nextStep = i + 1 < steps.count ? steps[i + 1] : cur
+        s.due = now.addingTimeInterval((cur + nextStep) / 2)
         return s
 
     case .good:

--- a/scripture memory/Utilities/WidgetBridge.swift
+++ b/scripture memory/Utilities/WidgetBridge.swift
@@ -28,6 +28,8 @@ enum WidgetBridge {
 
     struct Snapshot: Codable, Equatable {
         var verse:    SharedVerse?
+        /// True when `verse` is a user-pinned spotlight rather than the live cursor.
+        var isPinned: Bool = false
         var streak:   Int
         var dueToday: Int
         var learned:  Int
@@ -36,15 +38,16 @@ enum WidgetBridge {
 
     private static var defaults: UserDefaults? { UserDefaults(suiteName: appGroup) }
 
-    /// Persist the current learning verse + stats. Reloads widget timelines only
-    /// when the snapshot changes.
-    static func update(verse: Verse?, streak: Int, dueToday: Int, learned: Int, week: [WeekDay]) {
+    /// Persist the verse to feature (pinned or current) + stats. Reloads widget
+    /// timelines only when the snapshot changes.
+    static func update(verse: Verse?, isPinned: Bool, streak: Int, dueToday: Int, learned: Int, week: [WeekDay]) {
         guard let defaults else { return }
         let snap = Snapshot(
             verse: verse.map {
                 SharedVerse(title: $0.title, verse: $0.verse, book: $0.book,
                             reference: $0.reference, packName: $0.packName)
             },
+            isPinned: isPinned,
             streak: streak,
             dueToday: dueToday,
             learned: learned,

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -6,6 +6,7 @@ struct CardStudyView: View {
 
     @StateObject private var vm:     CardStudyViewModel
     @StateObject private var speech: SpeechRecognizer = SpeechRecognizer()
+    @ObservedObject private var learning = LearningStore.shared
 
     @AppStorage("studyMode")       private var studyMode:       StudyMode = .firstLetter
     @AppStorage("isVerticalScroll") private var isVerticalScroll = false
@@ -20,6 +21,13 @@ struct CardStudyView: View {
     @State private var speechTarget: SubmitField = .title
     @State private var isScrubbing           = false
     @State private var isPeeking             = false
+    /// The "Jump to current verse" pill shows its full label briefly, then collapses
+    /// to just the icon so it stops dominating the corner.
+    @State private var jumpExpanded          = true
+    /// Raw vertical scroll offset of the read-mode list — lets the jump button track
+    /// whether the cursor card is actually on screen, not just `currentIndex` (which
+    /// only changes on tap, so scrolling away after a jump never brought it back).
+    @State private var listScrollOffset: CGFloat = 0
 
     /// Live continuous scroll position (0 = top, 1 = bottom) in vertical-scroll
     /// browse mode, measured from the content's offset. Drives the fast-scroll
@@ -72,6 +80,91 @@ struct CardStudyView: View {
         }
     }
 
+    // MARK: - Current learning verse
+
+    /// The current stopped verse's index *within the loaded pack*, if it lives here.
+    private var currentVerseIndexInPack: Int? {
+        guard let key = learning.currentKey else { return nil }
+        return vm.verses.firstIndex { $0.srsKey == key }
+    }
+
+    /// Is the card on screen the current stopped verse? Gates the Mark-as-Learnt
+    /// button so completing it *anywhere* lets you advance the cursor.
+    private var isCurrentLearningVerse: Bool {
+        guard let v = vm.currentVerse, let key = learning.currentKey else { return false }
+        return v.srsKey == key
+    }
+
+    /// Offer "Mark as Learnt" in the Continue-Learning flow (explicit hook) or
+    /// whenever the card on screen is the current stopped verse.
+    private var offersMarkLearnt: Bool { onMarkLearnt != nil || isCurrentLearningVerse }
+
+    /// Float the "Current verse" shortcut when this pack holds the current stopped
+    /// verse, we're parked on a different card, and the keyboard isn't up.
+    private var showGoToCurrent: Bool {
+        guard let i = currentVerseIndexInPack else { return false }
+        return i != vm.currentIndex && !isEditing
+    }
+
+    private func jumpToCurrentVerse() {
+        guard let i = currentVerseIndexInPack, i != vm.currentIndex else { return }
+        isScrubbing = true
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) { vm.currentIndex = i }
+        HapticEngine.light()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
+    }
+
+    private func goToCurrentButton(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: "bookmark.fill")
+                    .font(.system(size: jumpExpanded ? 12 : 15, weight: .bold))
+                if jumpExpanded {
+                    Text("Jump to current verse")
+                        .font(.system(size: 13, weight: .semibold))
+                        .fixedSize()
+                }
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, jumpExpanded ? 14 : 0)
+            .padding(.vertical, jumpExpanded ? 10 : 0)
+            // Collapsed form stays a 44pt circular tap target (Apple minimum).
+            .frame(minWidth: jumpExpanded ? 0 : 44, minHeight: jumpExpanded ? 0 : 44)
+            .background(Capsule().fill(Color.accentColor))
+            .shadow(color: .black.opacity(0.22), radius: 6, x: 0, y: 3)
+        }
+        .accessibilityLabel("Jump to current verse")
+        .transition(.scale.combined(with: .opacity))
+        // Flash the full label, then shrink to the icon. `.task` restarts every time
+        // the button reappears (new view identity), so it re-expands on each show and
+        // auto-cancels if it's dismissed before the second is up.
+        .task {
+            jumpExpanded = true
+            try? await Task.sleep(for: .seconds(1))
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { jumpExpanded = false }
+        }
+    }
+
+    /// List (vertical-scroll read) variant of the jump: just move the cursor
+    /// index — the scroll view's `onChange` animates to it. No `isScrubbing`, so
+    /// that scroll actually fires (it's guarded by `!isScrubbing`).
+    /// List (vertical-scroll read) visibility: show the jump shortcut whenever the
+    /// cursor card's centre has scrolled out of the viewport. Cards are a fixed
+    /// height here, so the centre is `topPadding + index·(card+spacing) + card/2`.
+    private func showJumpInList(cardHeight: CGFloat, viewportHeight: CGFloat) -> Bool {
+        guard let ci = currentVerseIndexInPack, !isEditing else { return false }
+        let cardCentre = 12 + CGFloat(ci) * (cardHeight + 20) + cardHeight / 2
+        let onScreen = cardCentre > listScrollOffset && cardCentre < listScrollOffset + viewportHeight
+        return !onScreen
+    }
+
+    /// Mark a verse complete from its read-mode card. No advance — the cursor moves
+    /// to the next unlearnt verse on its own and the on-card button hides itself.
+    private func markVerseComplete(_ verse: Verse) {
+        if let cb = onMarkLearnt { cb(verse) } else { LearningStore.shared.markLearnt(verse) }
+        HapticEngine.success()
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -88,34 +181,53 @@ struct CardStudyView: View {
                     verticalScrollCards(cardWidth: cardWidth, cardHeight: cardHeight)
                         .frame(maxHeight: .infinity)
                 } else {
-                    Spacer(minLength: 12)
-                    ZStack {
-                        cardStack
-                            .frame(width: cardWidth, height: cardHeight)
-                        // Peek renders as an OVERLAY in every mode so the
-                        // SubmitCardView (and its focused TextField) stays
-                        // mounted — otherwise the keyboard dismisses — and so
-                        // the reveal is identical across all study modes.
-                        if vm.isReviewMode, isPeeking,
-                           let verse = vm.currentVerse {
-                            PeekOverlayCard(
-                                verse: verse,
-                                cardLabel: vm.cardLabel(for: verse),
-                                width: cardWidth,
-                                height: cardHeight,
-                                isPeeking: isPeeking
-                            )
-                            .allowsHitTesting(false)
-                            .transition(.opacity)
-                            .zIndex(100)
+                    // Read mode keeps the original 5:3 card. Review mode grows the
+                    // card into the otherwise-empty vertical space (capped so it
+                    // stays card-shaped) — the masked underscores need the extra
+                    // room — and as the flexible middle it also absorbs the keyboard
+                    // inset, shrinking to fit when typing rather than overflowing.
+                    GeometryReader { area in
+                        let cardH = vm.isReviewMode
+                            ? max(cardHeight, min(cardWidth * 0.82, area.size.height - 16))
+                            : cardHeight
+                        ZStack {
+                            cardStack
+                                .frame(width: cardWidth, height: cardH)
+                            // Peek renders as an OVERLAY in every mode so the
+                            // SubmitCardView (and its focused TextField) stays
+                            // mounted — otherwise the keyboard dismisses — and so
+                            // the reveal is identical across all study modes.
+                            if vm.isReviewMode, isPeeking,
+                               let verse = vm.currentVerse {
+                                PeekOverlayCard(
+                                    verse: verse,
+                                    cardLabel: vm.cardLabel(for: verse),
+                                    width: cardWidth,
+                                    height: cardH,
+                                    isPeeking: isPeeking
+                                )
+                                .allowsHitTesting(false)
+                                .transition(.opacity)
+                                .zIndex(100)
+                            }
                         }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .overlay(alignment: .bottomTrailing) {
+                            if showGoToCurrent {
+                                goToCurrentButton(action: jumpToCurrentVerse)
+                                    // Align the trailing edge with the card (and the
+                                    // app's layout margin) instead of the screen edge.
+                                    .padding(.trailing, AppLayout.screenMargin)
+                                    .padding(.bottom, 12)
+                                    .zIndex(200)
+                            }
+                        }
+                        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: showGoToCurrent)
                     }
-                    .frame(width: cardWidth, height: cardHeight)
-                    .frame(maxWidth: .infinity)
-                    Spacer(minLength: 12)
                 }
 
-                if !isVerticalScroll || vm.isReviewMode {
+                if (!isVerticalScroll || vm.isReviewMode),
+                   vm.verses.count > 1 || canCrossBackward || canCrossForward {
                     scrubberRow
                         .padding(.horizontal, AppLayout.screenMargin)
                         .padding(.bottom, 6)
@@ -276,7 +388,9 @@ struct CardStudyView: View {
                                     .frame(width: cardWidth, height: cardHeight)
                                     .id(index)
                                     .overlay {
-                                        if index != vm.currentIndex {
+                                        // Skip the focus-tap on the cursor card so its
+                                        // on-card "Mark as Complete" button stays tappable.
+                                        if index != vm.currentIndex, !learning.isCurrent(verse) {
                                             Color.clear.contentShape(Rectangle())
                                                 .onTapGesture {
                                                     HapticEngine.light()
@@ -305,6 +419,7 @@ struct CardStudyView: View {
                         let maxScroll = max(1, m.contentHeight - outerGeo.size.height)
                         let f = Double(min(max(m.offset / maxScroll, 0), 1))
                         if abs(f - scrollFraction) > 0.0001 { scrollFraction = f }
+                        if abs(listScrollOffset - m.offset) > 0.5 { listScrollOffset = m.offset }
                     }
 
                     if vm.verses.count >= 2 {
@@ -343,6 +458,28 @@ struct CardStudyView: View {
                     guard !isScrubbing else { return }
                     withAnimation(.easeInOut(duration: 0.22)) { proxy.scrollTo(newIndex, anchor: .center) }
                 }
+                // Bottom-trailing to match the single-card view (aligned to the layout
+                // margin). Visibility tracks the cursor card's scroll position, so the
+                // button returns after you scroll away from a jump.
+                .overlay(alignment: .bottomTrailing) {
+                    if showJumpInList(cardHeight: cardHeight, viewportHeight: outerGeo.size.height) {
+                        goToCurrentButton(action: {
+                            // Scroll via the proxy directly (not by mutating currentIndex)
+                            // so a re-jump still works when currentIndex is already the
+                            // cursor from a previous jump.
+                            guard let i = currentVerseIndexInPack else { return }
+                            HapticEngine.light()
+                            isScrubbing = true
+                            if vm.currentIndex != i { vm.currentIndex = i }
+                            withAnimation(.easeInOut(duration: 0.3)) { proxy.scrollTo(i, anchor: .center) }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
+                        })
+                        .padding(.trailing, AppLayout.screenMargin)
+                        .padding(.bottom, 12)
+                    }
+                }
+                .animation(.spring(response: 0.35, dampingFraction: 0.8),
+                           value: showJumpInList(cardHeight: cardHeight, viewportHeight: outerGeo.size.height))
             }
         }
     }
@@ -378,7 +515,8 @@ struct CardStudyView: View {
                 titleText: interactive ? $vm.titleInput : .constant(""),
                 verseText: interactive ? $vm.verseInput : .constant(""),
                 result: interactive ? vm.submitResults[verse.id] : nil,
-                focusedField: $submitFocus
+                focusedField: $submitFocus,
+                isCurrentLearning: learning.isCurrent(verse)
             )
             .allowsHitTesting(interactive)
         } else {
@@ -399,7 +537,9 @@ struct CardStudyView: View {
                 onSectionTap: interactive && vm.isReviewMode && !isPeeking ? { section in
                     vm.activeSection = section
                     DispatchQueue.main.async { focusInput() }
-                } : nil
+                } : nil,
+                isCurrentLearning: learning.isCurrent(verse),
+                onMarkComplete: vm.isReviewMode ? nil : { markVerseComplete(verse) }
             )
         }
     }
@@ -459,14 +599,22 @@ struct CardStudyView: View {
     private var cardControlBand: some View {
         HStack(alignment: .center, spacing: StudyControlMetrics.rowSpacing) {
             // Peeking only makes sense while the verse is still hidden — once the
-            // card is complete the full text is already shown, so drop the button.
-            if !vm.isCardComplete {
+            // card is answered (revealed, or submitted right or wrong) the text is
+            // already on the card, so drop the button.
+            if !vm.isCardAnswered {
                 PeekHoldButton(isPeeking: $isPeeking)
                     .transition(.opacity)
             }
             Group {
                 if vm.isCardComplete {
-                    if onMarkLearnt != nil { markLearntButton } else { completeLabel }
+                    if offersMarkLearnt {
+                        HStack(spacing: 10) {
+                            tryAgainButton
+                            markLearntButton
+                        }
+                    } else {
+                        completeLabel
+                    }
                 } else if studyMode == .submit {
                     submitControls
                 } else {
@@ -494,20 +642,35 @@ struct CardStudyView: View {
     /// boundary). Streak/test progress is handled separately on submit.
     private var markLearntButton: some View {
         Button {
-            if let v = vm.currentVerse { onMarkLearnt?(v) }
+            if let v = vm.currentVerse {
+                if let cb = onMarkLearnt { cb(v) } else { LearningStore.shared.markLearnt(v) }
+            }
             HapticEngine.success()
             isScrubbing = true
             stepForward()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
         } label: {
-            Label("Mark as Learnt", systemImage: "checkmark.circle.fill")
+            Label("Mark as Complete", systemImage: "checkmark.circle.fill")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity).padding(.vertical, 12)
                 .background(Color.green)
                 .roundedRect(12)
         }
-        .accessibilityLabel("Mark verse as learnt and continue")
+        .accessibilityLabel("Mark verse as complete and continue")
+    }
+
+    /// Resets the current card so the user can attempt it again (clears revealed
+    /// words / submitted answer for whichever study mode is active).
+    private var tryAgainButton: some View {
+        Button { vm.resetCurrentCard() } label: {
+            Label("Try Again", systemImage: "arrow.counterclockwise")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.primary)
+                .frame(maxWidth: .infinity).padding(.vertical, 12)
+                .background(Color(.secondarySystemGroupedBackground))
+                .roundedRect(12)
+        }
     }
 
     /// Submit mode: mic + submit button before scoring, try-again after.
@@ -524,7 +687,7 @@ struct CardStudyView: View {
                             .background(Color(.secondarySystemGroupedBackground))
                             .roundedRect(12)
                     }
-                    if onMarkLearnt != nil { markLearntButton }
+                    if offersMarkLearnt { markLearntButton }
                 }
             } else {
                 HStack(spacing: 10) {

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -64,6 +64,16 @@ final class CardStudyViewModel: ObservableObject {
         }
     }
 
+    /// True once the current card has been answered — submitted in entire-verse
+    /// mode (right *or* wrong) or fully revealed in first-letter / full-word mode.
+    /// Unlike `isCardComplete` (perfect-only in submit mode), a submitted-but-
+    /// imperfect card counts as answered, so peek can hide once the answer is shown.
+    var isCardAnswered: Bool {
+        guard let verse = currentVerse else { return false }
+        if studyMode == .submit { return submitResults[verse.id] != nil }
+        return isCardComplete
+    }
+
     var canReset: Bool {
         guard isReviewMode, let verse = currentVerse else { return false }
         switch studyMode {
@@ -246,7 +256,14 @@ final class CardStudyViewModel: ObservableObject {
     }
 
     private func advance(verse: Verse, sectionWords: [String], revealed: Int) {
-        let newCount = revealed + 1
+        var newCount = revealed + 1
+        // Auto-skip pure-punctuation tokens (e.g. a standalone "-" with spaces around
+        // it) — they have no first letter to type, so they must not swallow the
+        // keystroke meant for the next real word.
+        while newCount < sectionWords.count,
+              !sectionWords[newCount].contains(where: { $0.isLetter || $0.isNumber }) {
+            newCount += 1
+        }
         withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
             setRevealed(newCount, for: verse.id, section: activeSection)
         }

--- a/scripture memory/Views/ContentView.swift
+++ b/scripture memory/Views/ContentView.swift
@@ -86,6 +86,7 @@ struct ContentView: View {
             }
         }
         .onChange(of: learning.learntKeys) { _, _ in syncWidget() }
+        .onChange(of: learning.pinnedKey)  { _, _ in syncWidget() }
         .onChange(of: bibleVersion)        { _, _ in syncWidget() }
         .onChange(of: hasOnboarded)        { _, _ in syncWidget() }
         // Refresh the widget snapshot when leaving/returning — catches streak and
@@ -98,12 +99,13 @@ struct ContentView: View {
 
     /// Mirror the current learning verse + streak + due-count + week into the App Group.
     private func syncWidget() {
-        let visible = packPrefs.visible(from: bibleVersion.packs)
-        let verse   = learning.current(in: visible.flatMap(\.verses))?.verse
-        let week    = StreakStore.shared.thisWeek().map {
+        let visible   = packPrefs.visible(from: bibleVersion.packs)
+        let displayed = learning.displayed(in: visible.flatMap(\.verses))
+        let week      = StreakStore.shared.thisWeek().map {
             WidgetBridge.WeekDay(letter: $0.initial, done: $0.done, today: $0.isToday)
         }
-        WidgetBridge.update(verse: verse,
+        WidgetBridge.update(verse: displayed?.verse,
+                            isPinned: displayed?.isPinned ?? false,
                             streak: StreakStore.shared.current,
                             dueToday: dailyQueueSize(packs: visible),
                             learned: learning.learntKeys.count,

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -9,6 +9,15 @@ struct FlashcardView: View {
     let activeSection:       CardSection
     var onSectionTap:        ((CardSection) -> Void)? = nil
 
+    /// Marks this card as the "current stopped verse" (the learning cursor) with a
+    /// small badge — shown wherever the verse appears: study card and test card.
+    var isCurrentLearning:   Bool = false
+
+    /// When set (read mode, on the cursor card) the badge becomes a tappable
+    /// "Mark as Complete" button so the current verse can be marked right on the
+    /// card — read mode has no test-completion event to surface it otherwise.
+    var onMarkComplete:      (() -> Void)? = nil
+
     @AppStorage("hardMode") private var hardMode = false
 
     // MARK: - Adaptive Typography
@@ -39,13 +48,59 @@ struct FlashcardView: View {
             VStack(alignment: .leading, spacing: 0) {
                 if isReviewMode { reviewContent(cardSize: geo.size) } else { readContent(cardSize: geo.size) }
                 Spacer(minLength: 16)
-                Text(cardLabel)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.secondary)
+                HStack(spacing: 6) {
+                    Text(cardLabel)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.secondary)
+                    Spacer(minLength: 8)
+                    if isCurrentLearning {
+                        if let onMarkComplete {
+                            markCompleteButton(onMarkComplete)
+                        } else {
+                            currentBadge
+                        }
+                    }
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .flashcardStyle()
+    }
+
+    /// Green "Mark as Complete" pill — the on-card action for the current verse in
+    /// read mode. Replaces the badge (which it implies) when an action is provided.
+    private func markCompleteButton(_ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 11, weight: .bold))
+                Text("Mark as Complete")
+                    .font(.system(size: 11, weight: .bold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(Capsule().fill(Color.green))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Mark current verse as complete")
+    }
+
+    /// Small "Current" chip marking the learning-cursor verse on any flashcard —
+    /// a bookmark (distinct from the pin used for the Home spotlight) so it reads
+    /// as "this is where you stopped."
+    private var currentBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "bookmark.fill")
+                .font(.system(size: 8, weight: .bold))
+            Text("Current")
+                .font(.system(size: 9, weight: .bold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color.accentColor))
+        .accessibilityLabel("Current verse")
     }
 
     // MARK: - Read Mode
@@ -85,10 +140,14 @@ struct FlashcardView: View {
         let refH    = VerseFit.height("\(verse.book) \(verse.reference)", width: cardWidth, size: refSize, weight: .bold, lineSpacing: 0)
         let titleH  = VerseFit.height(verse.title, width: cardWidth, size: titleSectionSize, weight: .bold, lineSpacing: 4)
         let showsProgress = !hardMode && activeRevealed < activeWords.count
-        let reserved = refH + 12 + titleH + 8 + (showsProgress ? 22 : 0) + 22   // +label/bottom slack
+        // Count everything below the verse so the fit target matches the space
+        // that's actually free: the progress block (spacer + bar) and the card's
+        // own bottom spacer + label. Undercounting here picks a font one step too
+        // big — which is exactly what made long verses overflow and truncate.
+        let reserved = refH + 12 + titleH + 8 + (showsProgress ? 24 : 0) + 34
         let avail = max(48, cardSize.height - reserved)
         let verseSize = VerseFit.fontSize(verse.verse, width: cardWidth, height: avail,
-                                          lineSpacing: verseGap, minSize: 11, maxSize: 14)
+                                          lineSpacing: verseGap, minSize: 10, maxSize: 16)
 
         return VStack(alignment: .leading, spacing: 0) {
             Text("\(verse.book) \(verse.reference)")
@@ -234,8 +293,11 @@ struct FlashcardView: View {
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color(.systemGray5))
+                    // Green (matching the completion check) so it reads as
+                    // "progress made" and doesn't blur into the blue active-section
+                    // bar / next-word accent sitting right above it.
                     Capsule()
-                        .fill(Color.accentColor)
+                        .fill(Color.green)
                         .frame(width: max(4, geo.size.width * Double(revealed) / Double(max(1, total))))
                         .animation(.spring(response: 0.4, dampingFraction: 0.7), value: revealed)
                 }

--- a/scripture memory/Views/LearningSetupView.swift
+++ b/scripture memory/Views/LearningSetupView.swift
@@ -40,7 +40,6 @@ struct LearningSetupView: View {
                         packs:        packs,
                         ordered:      ordered,
                         isOnboarding: isOnboarding,
-                        showIntroNote: isOnboarding && !showsWelcome,
                         currentKey:   learning.current(in: ordered)?.verse.srsKey,
                         onPick: { verse in
                             learning.setProgress(startingAt: verse, in: ordered)
@@ -85,13 +84,16 @@ private struct WelcomeScreen: View {
                 VStack(alignment: .leading, spacing: 30) {
                     FeatureRow(icon: "text.book.closed.fill",
                                title: "Memorize Scripture",
-                               subtitle: "Learn verses one at a time, in order, at your own pace.")
+                               subtitle: "Learn verses one at a time, in order, at your own pace.",
+                               tint: .blue)
                     FeatureRow(icon: "flame.fill",
                                title: "Build a daily streak",
-                               subtitle: "A verse a day keeps your momentum going.")
+                               subtitle: "A verse a day keeps your momentum going.",
+                               tint: .orange)
                     FeatureRow(icon: "arrow.triangle.2.circlepath",
                                title: "Reviews that stick",
-                               subtitle: "Spaced repetition brings verses back right before you'd forget.")
+                               subtitle: "Spaced repetition brings verses back right before you'd forget.",
+                               tint: .green)
                 }
                 .padding(.horizontal, 30)
                 .padding(.bottom, 24)
@@ -119,12 +121,13 @@ private struct FeatureRow: View {
     let icon: String
     let title: String
     let subtitle: String
+    var tint: Color = .accentColor
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
             Image(systemName: icon)
                 .font(.system(size: 30))
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(tint)
                 .frame(width: 42, alignment: .center)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).font(.headline)
@@ -144,66 +147,74 @@ private struct StartingPointScreen: View {
     let packs:   [Pack]
     let ordered: [Verse]
     var isOnboarding: Bool
-    var showIntroNote: Bool
-    var currentKey: String?
     var onPick:   (Verse) -> Void
     var onCancel: () -> Void
 
+    /// The starting point the user has tapped but not yet confirmed. Seeded from
+    /// the existing progress so re-opening shows the current pick.
+    @State private var pending: Verse?
+
+    init(packs: [Pack], ordered: [Verse], isOnboarding: Bool, currentKey: String?,
+         onPick: @escaping (Verse) -> Void, onCancel: @escaping () -> Void) {
+        self.packs        = packs
+        self.ordered      = ordered
+        self.isOnboarding = isOnboarding
+        self.onPick       = onPick
+        self.onCancel     = onCancel
+        _pending = State(initialValue: ordered.first { $0.srsKey == currentKey })
+    }
+
     var body: some View {
         List {
-            if showIntroNote {
-                Section {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("One quick thing")
-                            .font(.headline)
-                        Text("Pick the verse you're currently on so your Home screen and widget start in the right place. You can change this any time in Settings.")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 4)
-                    .listRowBackground(Color.clear)
-                }
-            }
-
             Section {
                 Button {
-                    if let first = ordered.first { onPick(first) }
+                    guard let first = ordered.first else { return }
+                    pending = first
+                    HapticEngine.light()
                 } label: {
                     HStack {
                         Label("Start from the beginning", systemImage: "flag.fill")
                             .foregroundStyle(.primary)
                         Spacer()
-                        if let first = ordered.first, first.srsKey == currentKey { checkmark }
+                        if isSelected(ordered.first) { checkmark }
                     }
                 }
-            } header: {
-                Text("New here?")
             }
 
             Section {
                 ForEach(packs) { pack in
                     NavigationLink {
-                        VerseListScreen(pack: pack, currentKey: currentKey, onPick: onPick)
+                        VerseListScreen(pack: pack,
+                                        selectedKey: pending?.srsKey,
+                                        onSelect: { pending = $0 })
                     } label: {
                         HStack {
-                            Text(pack.name).foregroundStyle(.primary)
+                            Text(pack.name)
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
                             Spacer()
-                            if pack.verses.contains(where: { $0.srsKey == currentKey }) {
-                                Text("Current")
+                            // The first verse is represented by "Start from the beginning"
+                            // above (which carries its own check), so only badge a pack for
+                            // a specific, non-first verse — otherwise both would show a check.
+                            if let v = pending,
+                               v.srsKey != ordered.first?.srsKey,
+                               pack.verses.contains(where: { $0.srsKey == v.srsKey }) {
+                                Text("\(v.book) \(v.reference)")
                                     .font(.footnote.weight(.semibold))
                                     .foregroundStyle(Color.accentColor)
+                                    .lineLimit(1)
+                                checkmark
                             }
                         }
                     }
                 }
             } header: {
-                Text("Already learning? Pick where you're up to")
-            } footer: {
-                Text("Choose the exact verse you last stopped at. Everything before it is treated as already learnt.")
+                Text("Already memorizing? Pick where you stopped")
             }
         }
-        .navigationTitle("Where Are You Up To?")
+        .navigationTitle(isOnboarding ? "Your Starting Point" : "Current Verse")
         .navigationBarTitleDisplayMode(.inline)
+        .safeAreaInset(edge: .bottom, spacing: 0) { confirmBar }
         .toolbar {
             if !isOnboarding {
                 ToolbarItem(placement: .cancellationAction) {
@@ -211,6 +222,38 @@ private struct StartingPointScreen: View {
                 }
             }
         }
+    }
+
+    private var confirmBar: some View {
+        // A pinned footer bar (hairline + frosted material) rather than a bare
+        // floating button, so list rows scroll under a clear bar instead of
+        // bleeding behind the button — the standard Apple bottom-CTA pattern.
+        VStack(spacing: 0) {
+            Divider()
+            Button {
+                guard let pending else { return }
+                HapticEngine.light()
+                onPick(pending)
+            } label: {
+                Text("Confirm")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+            .tint(.accentColor)
+            .disabled(pending == nil)
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+        }
+        .background(.bar)
+    }
+
+    private func isSelected(_ verse: Verse?) -> Bool {
+        guard let verse, let pending else { return false }
+        return verse.srsKey == pending.srsKey
     }
 
     private var checkmark: some View {
@@ -222,15 +265,18 @@ private struct StartingPointScreen: View {
 
 private struct VerseListScreen: View {
     let pack: Pack
-    var currentKey: String?
-    var onPick: (Verse) -> Void
+    var selectedKey: String?
+    var onSelect: (Verse) -> Void
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         List {
             Section {
                 ForEach(pack.verses) { verse in
                     Button {
-                        onPick(verse)
+                        HapticEngine.light()
+                        onSelect(verse)
+                        dismiss()
                     } label: {
                         HStack(alignment: .top, spacing: 12) {
                             VStack(alignment: .leading, spacing: 3) {
@@ -246,7 +292,7 @@ private struct VerseListScreen: View {
                                     .lineLimit(2)
                             }
                             Spacer(minLength: 8)
-                            if verse.srsKey == currentKey {
+                            if verse.srsKey == selectedKey {
                                 Image(systemName: "checkmark")
                                     .font(.system(size: 16, weight: .semibold))
                                     .foregroundStyle(Color.accentColor)
@@ -258,7 +304,7 @@ private struct VerseListScreen: View {
                     .buttonStyle(.plain)
                 }
             } footer: {
-                Text("Tap the verse you're currently learning.")
+                Text("Tap the verse you last memorized up to.")
             }
         }
         .navigationTitle(pack.name)

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PackListView: View {
     @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
     @ObservedObject private var packPrefs = PackPreferencesStore.shared
+    @ObservedObject private var learning  = LearningStore.shared
 
     @State private var selectedPack:   Pack?             = nil
     @State private var searchText:     String            = ""
@@ -11,6 +12,10 @@ struct PackListView: View {
 
     /// Visible packs in the user's custom order (hidden removed).
     private var visiblePacks: [Pack] { packPrefs.visible(from: bibleVersion.packs) }
+
+    /// Name of the pack holding the current stopped verse — badged in the grid so
+    /// the user can spot where to resume at a glance.
+    private var currentPackName: String? { learning.currentVerse?.packName }
 
     private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
 
@@ -55,7 +60,7 @@ struct PackListView: View {
                                 guard !pack.verses.isEmpty else { return }
                                 selectedPack = pack
                             } label: {
-                                PackCover(pack: pack)
+                                PackCover(pack: pack, isCurrentPack: pack.name == currentPackName)
                             }
                             .buttonStyle(CardButtonStyle())
                             .accessibilityElement(children: .ignore)
@@ -177,6 +182,7 @@ struct PackListView: View {
 /// Font sizes and layout are written once — no compact/full variants needed.
 struct PackCover: View {
     let pack: Pack
+    var isCurrentPack: Bool = false
 
     private static let designWidth:  CGFloat = 340
     private static let designHeight: CGFloat = designWidth * 3 / 5  // 5:3
@@ -214,6 +220,24 @@ struct PackCover: View {
             .clipShape(RoundedRectangle(cornerRadius: AppLayout.cardRadius, style: .continuous))
             .overlay(RoundedRectangle(cornerRadius: AppLayout.cardRadius, style: .continuous).stroke(borderColor, lineWidth: 0.5))
             .shadow(color: .black.opacity(shadowOpacity), radius: 8, x: 0, y: 4)
+            .overlay(alignment: .topTrailing) {
+                if isCurrentPack { currentPackBadge.padding(8) }
+            }
+    }
+
+    /// "Current" chip marking the pack that holds the learning cursor. White
+    /// capsule so it reads on any cover colour.
+    private var currentPackBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "bookmark.fill").font(.system(size: 9, weight: .bold))
+            Text("Current").font(.system(size: 10, weight: .bold))
+        }
+        .foregroundStyle(Color.accentColor)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(.white))
+        .shadow(color: .black.opacity(0.18), radius: 3, x: 0, y: 1)
+        .accessibilityLabel("Current pack")
     }
 
     @ViewBuilder

--- a/scripture memory/Views/PackOrganizerView.swift
+++ b/scripture memory/Views/PackOrganizerView.swift
@@ -45,9 +45,7 @@ struct PackOrganizerView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .confirmationDialog("Reset pack order?",
-                                isPresented: $showResetConfirm,
-                                titleVisibility: .visible) {
+            .alert("Reset pack order?", isPresented: $showResetConfirm) {
                 Button("Reset", role: .destructive) {
                     store.reset()
                     HapticEngine.light()
@@ -70,14 +68,9 @@ struct PackOrganizerView: View {
                         .strokeBorder(Color(.separator).opacity(0.4), lineWidth: 0.5)
                 )
 
-            VStack(alignment: .leading, spacing: 1) {
-                Text(pack.name)
-                    .font(.body)
-                    .foregroundStyle(.primary)
-                Text("\(pack.verses.count) verses")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            Text(pack.name)
+                .font(.body)
+                .foregroundStyle(.primary)
 
             Spacer()
 

--- a/scripture memory/Views/SRSDashboardView.swift
+++ b/scripture memory/Views/SRSDashboardView.swift
@@ -17,17 +17,18 @@ struct SRSDashboardView: View {
     @ObservedObject private var streak    = StreakStore.shared
 
     @State private var cover: ActiveCover?
+    @State private var showPinPicker = false
 
     /// One full-screen presentation at a time — review session OR the linear
     /// learning session. (Two separate `.fullScreenCover` modifiers on one view
     /// conflict in SwiftUI, so they're unified here.)
     private enum ActiveCover: Identifiable {
         case review(TestSession)
-        case learning
+        case learning(forceCurrent: Bool)
         var id: String {
             switch self {
-            case .review(let s): return "review-\(s.id)"
-            case .learning:      return "learning"
+            case .review(let s):       return "review-\(s.id)"
+            case .learning(let force): return force ? "learning-current" : "learning"
             }
         }
     }
@@ -55,14 +56,15 @@ struct SRSDashboardView: View {
     /// All visible verses flattened in pack order — the linear "learning" sequence.
     private var ordered:      [Verse] { packs.flatMap(\.verses) }
 
-    /// The current learning verse resolved to its pack + index within that pack,
-    /// so Continue opens just that pack and progress reads within-pack.
-    private func currentLearning() -> (verse: Verse, pack: Pack, indexInPack: Int)? {
-        guard let cur = learning.current(in: ordered),
-              let pack = packs.first(where: { $0.name == cur.verse.packName }),
-              let idx  = pack.verses.firstIndex(where: { $0.srsKey == cur.verse.srsKey })
+    /// The verse to feature on Home — the pinned one if the user pinned one, else
+    /// the current learning verse — resolved to its pack + index, plus whether
+    /// it's pinned (so the card and practice session can adapt).
+    private func displayedLearning() -> (verse: Verse, pack: Pack, indexInPack: Int, isPinned: Bool)? {
+        guard let d = learning.displayed(in: ordered),
+              let pack = packs.first(where: { $0.name == d.verse.packName }),
+              let idx  = pack.verses.firstIndex(where: { $0.srsKey == d.verse.srsKey })
         else { return nil }
-        return (cur.verse, pack, idx)
+        return (d.verse, pack, idx, d.isPinned)
     }
 
     /// The pack before/after `name` — lets a Continue session roll into the next
@@ -96,6 +98,7 @@ struct SRSDashboardView: View {
             VStack(spacing: Layout.sectionSpacing) {
                 streakCard
                 continueLearningCard
+                goToCurrentVerseCard
                 Text("Daily Review")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.secondary)
@@ -115,8 +118,11 @@ struct SRSDashboardView: View {
         .fullScreenCover(item: $cover) { c in
             switch c {
             case .review(let s): TestSessionView(session: s, onSessionEnded: { cover = nil })
-            case .learning:      learningSession
+            case .learning(let force): learningSession(forceCurrent: force)
             }
+        }
+        .sheet(isPresented: $showPinPicker) {
+            PinVersePicker(packs: packs, pinnedKey: learning.pinnedKey) { learning.pin($0) }
         }
     }
 
@@ -168,71 +174,144 @@ struct SRSDashboardView: View {
 
     @ViewBuilder
     private var continueLearningCard: some View {
-        if let cur = currentLearning() {
+        if let cur = displayedLearning() {
             let v = cur.verse
-            Button {
-                cover = .learning
-            } label: {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack {
-                        Text("Continue Learning")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(.secondary)
-                            .textCase(.uppercase)
-                        Spacer()
-                        Text("\(cur.indexInPack + 1) of \(cur.pack.verses.count)")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-                    }
-                    // The verse itself, shown like a flashcard — a one-look review.
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(v.title)
-                            .font(.system(size: 16, weight: .bold, design: .serif))
-                            .foregroundColor(.primary)
-                            .multilineTextAlignment(.leading)
-                        Text("\(v.book) \(v.reference)")
-                            .font(.system(size: 14, design: .serif))
-                            .foregroundColor(.secondary)
-                        Text(v.verse)
-                            .font(.system(size: 15, design: .serif))
-                            .foregroundColor(.primary)
-                            .lineSpacing(4)
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    HStack(spacing: 5) {
-                        Text(cur.pack.name)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                        Spacer()
-                        Text("Practice")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color.accentColor)
-                        Image(systemName: "chevron.right")
+            VStack(alignment: .leading, spacing: 10) {
+                // Header: mode label + position + pin/reset menu. Kept OUTSIDE the
+                // practice button so the Menu's taps don't fight the card tap.
+                HStack(spacing: 6) {
+                    if cur.isPinned {
+                        Image(systemName: "pin.fill")
                             .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(.secondary)
                     }
-                    .padding(.top, 2)
+                    Text(cur.isPinned ? "Pinned" : "Continue Learning")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                    Spacer()
+                    Text("\(cur.indexInPack + 1) of \(cur.pack.verses.count)")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Menu {
+                        if cur.isPinned {
+                            Button { showPinPicker = true } label: {
+                                Label("Change pinned verse…", systemImage: "pin")
+                            }
+                            Button { learning.unpin(); HapticEngine.light() } label: {
+                                Label("Back to current verse", systemImage: "arrow.uturn.backward")
+                            }
+                        } else {
+                            Button { showPinPicker = true } label: {
+                                Label("Pin a verse", systemImage: "pin")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Verse options")
                 }
-                .padding(18)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous)
-                        .fill(flashcardBackground)
-                        .shadow(color: .black.opacity(0.13), radius: 14, x: 0, y: 7)
-                        .shadow(color: .black.opacity(0.05), radius: 2,  x: 0, y: 1)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous)
-                        .strokeBorder(Color(.separator).opacity(0.4), lineWidth: 0.5)
-                )
-                .contentShape(RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous))
+
+                // Body: tap the verse to practice it.
+                Button {
+                    cover = .learning(forceCurrent: false)
+                } label: {
+                    VStack(alignment: .leading, spacing: 10) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(v.title)
+                                .font(.system(size: 16, weight: .bold, design: .serif))
+                                .foregroundColor(.primary)
+                                .multilineTextAlignment(.leading)
+                            Text("\(v.book) \(v.reference)")
+                                .font(.system(size: 14, design: .serif))
+                                .foregroundColor(.secondary)
+                            Text(v.verse)
+                                .font(.system(size: 15, design: .serif))
+                                .foregroundColor(.primary)
+                                .lineSpacing(4)
+                                .multilineTextAlignment(.leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        HStack(spacing: 5) {
+                            Text(cur.pack.name)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                            Spacer()
+                            Text("Practice")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(Color.accentColor)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(Color.accentColor)
+                        }
+                        .padding(.top, 2)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(CardButtonStyle())
+                .accessibilityLabel("Practice \(v.book) \(v.reference)")
             }
-            .buttonStyle(CardButtonStyle())
-            .accessibilityLabel("Continue learning \(v.book) \(v.reference)")
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous)
+                    .fill(flashcardBackground)
+                    .shadow(color: .black.opacity(0.13), radius: 14, x: 0, y: 7)
+                    .shadow(color: .black.opacity(0.05), radius: 2,  x: 0, y: 1)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous)
+                    .strokeBorder(Color(.separator).opacity(0.4), lineWidth: 0.5)
+            )
         } else if !ordered.isEmpty {
             allLearntCard
+        }
+    }
+
+    /// Standalone shortcut back to the live cursor verse, shown as its own card
+    /// below the pinned card when a *different* verse is pinned — so it reads as a
+    /// distinct action, not part of the pinned verse.
+    @ViewBuilder
+    private var goToCurrentVerseCard: some View {
+        if let cur = displayedLearning(), cur.isPinned,
+           !learning.isCurrent(cur.verse), let c = currentLearning() {
+            Button {
+                cover = .learning(forceCurrent: true)
+                HapticEngine.light()
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "arrow.turn.down.right")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Go to current verse")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.primary)
+                        Text("\(c.verse.book) \(c.verse.reference)")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: 8)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, Layout.rowPaddingH)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous)
+                        .fill(Color(.secondarySystemGroupedBackground))
+                )
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Go to current verse, \(c.verse.book) \(c.verse.reference)")
         }
     }
 
@@ -259,22 +338,37 @@ struct SRSDashboardView: View {
     }
 
     @ViewBuilder
-    private var learningSession: some View {
-        if let cur = currentLearning() {
+    private func learningSession(forceCurrent: Bool) -> some View {
+        // `forceCurrent` opens the live cursor even while a different verse is
+        // pinned (the "Go to current verse" shortcut); otherwise open whatever
+        // Home features (the pinned verse, else the cursor).
+        if let cur = forceCurrent ? currentLearning() : displayedLearning() {
             // Wrap in a NavigationStack (chrome hidden) so the keyboard's "Done"
             // toolbar renders — matching how PackListView presents the card.
+            // A pinned verse is a spotlight, not a progression step, so it gets
+            // neither cross-pack stepping nor "Mark as Learnt".
             NavigationStack {
                 CardStudyView(
                     packName: cur.pack.name,
                     verses: cur.pack.verses,
                     initialIndex: cur.indexInPack,
                     initialReviewMode: true,
-                    adjacentPack: { name, forward in adjacentPack(after: name, forward: forward) },
-                    onMarkLearnt: { learning.markLearnt($0) }
+                    adjacentPack: cur.isPinned ? nil : { name, forward in adjacentPack(after: name, forward: forward) },
+                    onMarkLearnt: cur.isPinned ? nil : { learning.markLearnt($0) }
                 )
                 .toolbar(.hidden, for: .navigationBar)
             }
         }
+    }
+
+    /// The live cursor verse (ignoring any pin) resolved to pack + index — backs
+    /// the "Go to current verse" shortcut. `isPinned` is always false here.
+    private func currentLearning() -> (verse: Verse, pack: Pack, indexInPack: Int, isPinned: Bool)? {
+        guard let c = learning.current(in: ordered),
+              let pack = packs.first(where: { $0.name == c.verse.packName }),
+              let idx  = pack.verses.firstIndex(where: { $0.srsKey == c.verse.srsKey })
+        else { return nil }
+        return (c.verse, pack, idx, false)
     }
 
     // MARK: - Hero Card
@@ -288,7 +382,7 @@ struct SRSDashboardView: View {
             } else if agg.queueSize > 0 {
                 heroQueue(agg: agg)
             } else {
-                heroCaughtUp
+                heroCaughtUp(agg: agg)
             }
         }
         .frame(maxWidth: .infinity)
@@ -345,7 +439,7 @@ struct SRSDashboardView: View {
         }
     }
 
-    private var heroCaughtUp: some View {
+    private func heroCaughtUp(agg: Aggregate) -> some View {
         VStack(spacing: 8) {
             Image(systemName: "checkmark.seal.fill")
                 .font(.system(size: 36))
@@ -353,17 +447,42 @@ struct SRSDashboardView: View {
                 .symbolEffect(.bounce, options: .nonRepeating)
             Text("All caught up")
                 .font(.system(size: 17, weight: .semibold))
-            if let next = nextDueAcrossActivePacks() {
-                Text("Next card returns in \(formatRelative(next))")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.secondary)
-            } else {
-                Text("Turn on more packs to add new verses to your queue.")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
+            Text(caughtUpMessage(agg: agg))
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
         }
+    }
+
+    /// The honest "what's next" line for the caught-up state. The old copy only
+    /// read review due-dates, so it announced "next card in 3 days" even though a
+    /// new verse drips in at tomorrow's midnight reset — misleading. This surfaces
+    /// whichever is genuinely soonest.
+    private func caughtUpMessage(agg: Aggregate) -> String {
+        let next         = nextDueAcrossActivePacks()
+        let newVerseDrip = agg.newCandidates > 0 && dailyNewCap > 0
+        let tomorrow     = Calendar.current.startOfDay(for: now).addingTimeInterval(86_400)
+
+        // A card (often a learning step) is still due before midnight.
+        if let next, next < tomorrow {
+            return "Your next review is in \(formatRelative(next))."
+        }
+        // Today's new verses are done, but the daily cap resets at midnight.
+        if newVerseDrip {
+            let n = min(dailyNewCap, agg.newCandidates)   // how many actually drip in tomorrow
+            return n == 1
+                ? "Come back tomorrow for a new verse."
+                : "Come back tomorrow for \(n) new verses."
+        }
+        // Nothing new left to add — just spaced reviews ahead.
+        if let next {
+            return "Your next review is in \(formatRelative(next))."
+        }
+        // New verses remain, but the daily new-verse limit is off.
+        if agg.newCandidates > 0 {
+            return "Raise your daily new verses in Settings to keep going."
+        }
+        return "You've reviewed every verse in your active packs."
     }
 
     private func breakdownChip(label: String, value: Int, color: Color) -> some View {
@@ -425,9 +544,10 @@ struct SRSDashboardView: View {
     // MARK: - Aggregates
 
     private struct Aggregate {
-        var learning:     Int = 0
-        var review:       Int = 0
-        var newProjected: Int = 0
+        var learning:      Int = 0
+        var review:        Int = 0
+        var newProjected:  Int = 0
+        var newCandidates: Int = 0   // full unscheduled pool (future days), not just today's drip
         var queueSize: Int { learning + review + newProjected }
     }
 
@@ -445,7 +565,8 @@ struct SRSDashboardView: View {
             agg.review      += c.review
             totalCandidates += c.newCandidates
         }
-        agg.newProjected = min(globalNewRemaining, totalCandidates)
+        agg.newProjected  = min(globalNewRemaining, totalCandidates)
+        agg.newCandidates = totalCandidates
         return agg
     }
 
@@ -505,6 +626,88 @@ struct PacksReviewView: View {
             }
         }
         .navigationTitle("Packs in Review")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Pin Verse Picker
+
+/// A lightweight pack → verse drill-down for choosing which verse to pin to Home.
+/// Tapping a verse pins it immediately and dismisses — no progress is changed.
+private struct PinVersePicker: View {
+    let packs:     [Pack]
+    var pinnedKey: String?
+    var onPick:    (Verse) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(packs) { pack in
+                        NavigationLink {
+                            verseList(pack)
+                        } label: {
+                            HStack {
+                                Text(pack.name).foregroundStyle(.primary)
+                                Spacer()
+                                if pack.verses.contains(where: { $0.srsKey == pinnedKey }) {
+                                    Image(systemName: "pin.fill")
+                                        .font(.footnote)
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                        }
+                    }
+                } footer: {
+                    Text("Pick a verse to feature on your Home screen and widget. This doesn't change your learning progress.")
+                }
+            }
+            .navigationTitle("Pin a Verse")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func verseList(_ pack: Pack) -> some View {
+        List {
+            ForEach(pack.verses) { verse in
+                Button {
+                    HapticEngine.light()
+                    onPick(verse)
+                    dismiss()
+                } label: {
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("\(verse.book) \(verse.reference)")
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+                            Text(verse.title)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(Color.accentColor)
+                            Text(verse.verse)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                        Spacer(minLength: 8)
+                        if verse.srsKey == pinnedKey {
+                            Image(systemName: "pin.fill")
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .navigationTitle(pack.name)
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/scripture memory/Views/SRSGradingButtons.swift
+++ b/scripture memory/Views/SRSGradingButtons.swift
@@ -1,16 +1,21 @@
 import SwiftUI
 
 /// Four grading buttons (Again / Hard / Good / Easy) shown after the user has
-/// finished a card in an SRS session. The auto-suggested grade is visually
-/// emphasized; the user can override by tapping any other button.
+/// finished a card in an SRS session.
 ///
-/// Each button shows the predicted next interval underneath ("1m", "10m", "1d", "4d", …)
+/// Before the user picks, the auto-suggested grade is shown as an **outline**
+/// (a recommendation) — never pre-filled, so it can't be mistaken for a choice
+/// already made. Once picked (`isConfirmed`), that grade fills in to read as the
+/// selection. Each button shows the predicted next interval ("1m", "1d", "4d", …)
 /// so the consequence of the choice is visible.
 struct SRSGradingButtons: View {
 
     let state:     SRSCardState
     let suggested: SRSGrade
     let now:       Date
+    /// True once the user has actually graded this card. Until then `suggested`
+    /// is only a recommendation and must not look selected.
+    var isConfirmed: Bool = false
     let onPick:    (SRSGrade) -> Void
 
     var body: some View {
@@ -23,6 +28,7 @@ struct SRSGradingButtons: View {
 
     private func gradeButton(_ grade: SRSGrade) -> some View {
         let isSuggested = (grade == suggested)
+        let isPicked    = isSuggested && isConfirmed
         let label = predictedIntervalLabel(state: state, grade: grade, now: now)
         let shape = RoundedRectangle(cornerRadius: 14, style: .continuous)
         return Button {
@@ -32,15 +38,18 @@ struct SRSGradingButtons: View {
             VStack(spacing: 2) {
                 Text(grade.displayName)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(textColor(for: grade, suggested: isSuggested))
+                    .foregroundStyle(textColor(for: grade, suggested: isSuggested, picked: isPicked))
                 Text(label)
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(textColor(for: grade, suggested: isSuggested).opacity(0.85))
+                    .foregroundStyle(textColor(for: grade, suggested: isSuggested, picked: isPicked).opacity(0.85))
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
-            .background(shape.fill(background(for: grade, suggested: isSuggested)))
-            .overlay(shape.stroke(isSuggested ? color(for: grade) : .clear, lineWidth: 2))
+            // Filled only once the grade is the confirmed pick; otherwise plain.
+            .background(shape.fill(isPicked ? color(for: grade) : Color(.secondarySystemGroupedBackground)))
+            // Recommendation marker: an outline on the suggested grade *before*
+            // it's picked — distinct from the filled "selected" look.
+            .overlay(shape.stroke(isSuggested && !isConfirmed ? color(for: grade) : .clear, lineWidth: 2))
         }
         .buttonStyle(.plain)
     }
@@ -54,11 +63,9 @@ struct SRSGradingButtons: View {
         }
     }
 
-    private func textColor(for grade: SRSGrade, suggested: Bool) -> Color {
-        suggested ? .white : .primary
-    }
-
-    private func background(for grade: SRSGrade, suggested: Bool) -> Color {
-        suggested ? color(for: grade) : Color(.secondarySystemGroupedBackground)
+    private func textColor(for grade: SRSGrade, suggested: Bool, picked: Bool) -> Color {
+        if picked    { return .white }            // confirmed selection (filled)
+        if suggested { return color(for: grade) } // recommendation (outlined)
+        return .primary
     }
 }

--- a/scripture memory/Views/SettingsView.swift
+++ b/scripture memory/Views/SettingsView.swift
@@ -15,7 +15,6 @@ struct SettingsView: View {
     @State private var showResetSRSAlert      = false
     @State private var showNotifDeniedAlert   = false
     @State private var showLearningSetup      = false
-    @State private var showResetLearningAlert = false
 
     @ObservedObject private var learning  = LearningStore.shared
     @ObservedObject private var packPrefs = PackPreferencesStore.shared
@@ -51,7 +50,7 @@ struct SettingsView: View {
 
             Section {
                 Toggle(isOn: $hardMode) {
-                    Label("Hard Mode", systemImage: "eye.slash")
+                    rowLabel("Hard Mode", "eye.slash")
                 }
             } footer: {
                 Text("Hides all hints — no word placeholders shown during review.")
@@ -62,7 +61,7 @@ struct SettingsView: View {
                 capRow(icon: "sparkles", title: "New cards / day",
                        binding: $dailyNewCap, range: 0...50)
                 capRow(icon: "arrow.clockwise", title: "Reviews / day",
-                       binding: $dailyReviewCap, range: 0...500, step: 5)
+                       binding: $dailyReviewCap, range: 0...500)
             } header: {
                 Text("Daily Review")
             } footer: {
@@ -71,7 +70,7 @@ struct SettingsView: View {
 
             Section {
                 Toggle(isOn: $reminderEnabled) {
-                    Label("Daily Reminder", systemImage: "bell.badge")
+                    rowLabel("Daily Reminder", "bell.badge")
                 }
                 if reminderEnabled {
                     DatePicker("Remind me at",
@@ -111,7 +110,7 @@ struct SettingsView: View {
                     showLearningSetup = true
                 } label: {
                     HStack(spacing: 8) {
-                        Label("Starting point", systemImage: "flag.checkered")
+                        rowLabel("Current verse", "bookmark.fill")
                         Spacer()
                         Text(currentLearningLabel)
                             .foregroundStyle(.secondary)
@@ -124,26 +123,10 @@ struct SettingsView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                Button(role: .destructive) {
-                    showResetLearningAlert = true
-                } label: {
-                    Text("Reset learning progress")
-                }
             } header: {
                 Text("Learning")
             } footer: {
-                Text("Sets the verse shown on your Home screen. Everything before your starting point counts as already learnt.")
-            }
-            .sheet(isPresented: $showLearningSetup) {
-                LearningSetupView()
-            }
-            .alert("Reset learning progress?", isPresented: $showResetLearningAlert) {
-                Button("Cancel", role: .cancel) { }
-                Button("Reset", role: .destructive) {
-                    LearningStore.shared.resetProgress()
-                }
-            } message: {
-                Text("Your current verse returns to the very first verse. Verses you've marked learnt will be forgotten.")
+                Text("The verse you're currently learning, shown on your Home screen. Everything before it counts as already learnt.")
             }
 
             Section {
@@ -178,21 +161,31 @@ struct SettingsView: View {
             }
         }
         .navigationTitle("Settings")
+        // Hosted on the List (not the Learning Section) so the first presentation
+        // doesn't self-dismiss — a sheet anchored to a lazy List section can tear
+        // down on its initial layout pass.
+        .sheet(isPresented: $showLearningSetup) {
+            LearningSetupView()
+        }
     }
 
-    /// A "icon + title … value [− +]" row. The icon sits in a fixed-width column
-    /// so the two rows' titles align and the icon stays vertically centred with
-    /// the title (the old Stepper-wrapped Label floated the icon above the text).
+    /// A settings-row label with the SF Symbol pinned to a uniform 24pt column,
+    /// so every row's glyph aligns and every title shares one inset. Keeps the
+    /// system `Label` layout, so spacing and the accent tint match iOS defaults.
+    private func rowLabel(_ title: String, _ systemImage: String) -> some View {
+        Label {
+            Text(title)
+        } icon: {
+            Image(systemName: systemImage).frame(width: 24, alignment: .center)
+        }
+    }
+
+    /// A "icon + title … value [− +]" row. The icon column (via `rowLabel`) keeps
+    /// the two titles aligned and the icon vertically centred with the title.
     private func capRow(icon: String, title: String,
                         binding: Binding<Int>, range: ClosedRange<Int>, step: Int = 1) -> some View {
         HStack(spacing: 0) {
-            // Real Label so the icon matches the other rows' tint; fixed-width
-            // icon column so the two titles line up.
-            Label {
-                Text(title)
-            } icon: {
-                Image(systemName: icon).frame(width: 24, alignment: .center)
-            }
+            rowLabel(title, icon)
             Spacer(minLength: 8)
             Text("\(binding.wrappedValue)")
                 .foregroundStyle(.secondary)

--- a/scripture memory/Views/SubmitCardView.swift
+++ b/scripture memory/Views/SubmitCardView.swift
@@ -14,6 +14,7 @@ struct SubmitCardView: View {
     @Binding var verseText: String
     let result:      SubmitResult?
     @FocusState.Binding var focusedField: SubmitField?
+    var isCurrentLearning: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -29,12 +30,29 @@ struct SubmitCardView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-            Text(cardLabel)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(.secondary)
-                .padding(.top, 6)
+            HStack(spacing: 6) {
+                Text(cardLabel)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.secondary)
+                Spacer(minLength: 8)
+                if isCurrentLearning { currentBadge }
+            }
+            .padding(.top, 6)
         }
         .flashcardStyle()
+    }
+
+    /// "Current" chip marking the learning-cursor verse — matches FlashcardView.
+    private var currentBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "bookmark.fill").font(.system(size: 8, weight: .bold))
+            Text("Current").font(.system(size: 9, weight: .bold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color.accentColor))
+        .accessibilityLabel("Current verse")
     }
 
     // MARK: - Input View

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -6,6 +6,7 @@ struct TestSessionView: View {
 
     @StateObject private var vm:     TestSessionViewModel
     @StateObject private var speech: SpeechRecognizer = SpeechRecognizer()
+    @ObservedObject private var learning = LearningStore.shared
 
     @AppStorage("studyMode") private var studyMode: StudyMode = .firstLetter
 
@@ -19,6 +20,9 @@ struct TestSessionView: View {
     @State private var speechTarget: SubmitField = .title
     @State private var isScrubbing           = false
     @State private var isPeeking             = false
+    /// Verses the user revealed via hold-to-peek this session — a failed recall
+    /// that pulls the grade suggestion down to "Again".
+    @State private var peekedVerseIds:       Set<Int> = []
     @State private var showVerseSelector     = false
 
     // SRS session bookkeeping. Lets the user swipe back to an already-graded
@@ -64,30 +68,32 @@ struct TestSessionView: View {
                         .padding(.bottom, 2)
                 }
 
-                Spacer(minLength: 6)
-                ZStack {
-                    cardStack
-                        .frame(width: cardWidth, height: cardHeight)
-                    if isPeeking, let verse = vm.currentVerse {
-                        PeekOverlayCard(
-                            verse: verse,
-                            cardLabel: vm.cardLabel(for: verse),
-                            width: cardWidth,
-                            height: cardHeight,
-                            isPeeking: isPeeking
-                        )
-                        .allowsHitTesting(false)
-                        .transition(.opacity)
-                        .zIndex(100)
+                GeometryReader { area in
+                    let cardH = max(cardHeight, min(cardWidth * 0.82, area.size.height - 12))
+                    ZStack {
+                        cardStack
+                            .frame(width: cardWidth, height: cardH)
+                        if isPeeking, let verse = vm.currentVerse {
+                            PeekOverlayCard(
+                                verse: verse,
+                                cardLabel: vm.cardLabel(for: verse),
+                                width: cardWidth,
+                                height: cardH,
+                                isPeeking: isPeeking
+                            )
+                            .allowsHitTesting(false)
+                            .transition(.opacity)
+                            .zIndex(100)
+                        }
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(width: cardWidth, height: cardHeight)
-                .frame(maxWidth: .infinity)
-                Spacer(minLength: 6)
 
-                scrubberRow
-                    .padding(.horizontal, AppLayout.screenMargin)
-                    .padding(.bottom, 6)
+                if vm.verses.count > 1 {
+                    scrubberRow
+                        .padding(.horizontal, AppLayout.screenMargin)
+                        .padding(.bottom, 6)
+                }
 
                 bottomControls
             }
@@ -111,6 +117,11 @@ struct TestSessionView: View {
             case .title: vm.titleInput = text
             case .verse: vm.verseInput = text
             }
+        }
+        .onChange(of: isPeeking) { _, peeking in
+            // Revealing the answer is a failed recall — remember it so the grade
+            // suggestion reflects that the user needed to look.
+            if peeking, let verse = vm.currentVerse { peekedVerseIds.insert(verse.id) }
         }
         .onChange(of: submitFocus) { _, newFocus in
             guard speech.isListening, let newFocus else { return }
@@ -389,7 +400,8 @@ struct TestSessionView: View {
                 titleText: interactive ? $vm.titleInput : .constant(""),
                 verseText: interactive ? $vm.verseInput : .constant(""),
                 result: interactive ? vm.submitResults[verse.id] : nil,
-                focusedField: $submitFocus
+                focusedField: $submitFocus,
+                isCurrentLearning: learning.isCurrent(verse)
             )
             .allowsHitTesting(interactive)
         } else {
@@ -408,7 +420,8 @@ struct TestSessionView: View {
                 onSectionTap: interactive ? { section in
                     vm.activeSection = section
                     DispatchQueue.main.async { focusInput() }
-                } : nil
+                } : nil,
+                isCurrentLearning: learning.isCurrent(verse)
             )
         }
     }
@@ -448,11 +461,16 @@ struct TestSessionView: View {
                 cardControlBand
             }
 
+            // Completing the current stopped verse here (e.g. it surfaced as a new
+            // card) lets you advance the Home cursor without leaving the session.
+            if !vm.isSessionComplete, vm.isCardComplete,
+               let v = vm.currentVerse, learning.isCurrent(v) {
+                markLearntRow(for: v)
+            }
+
             if !vm.isSessionComplete && vm.completedCount == vm.verses.count {
                 Button {
-                    vm.clearProgress()
-                    onSessionEnded?()
-                    dismiss()
+                    endSession()
                 } label: {
                     Text("End Session").font(.headline).frame(maxWidth: .infinity)
                 }
@@ -475,8 +493,9 @@ struct TestSessionView: View {
     private var cardControlBand: some View {
         HStack(alignment: .center, spacing: StudyControlMetrics.rowSpacing) {
             // Peeking only makes sense while the verse is still hidden — once the
-            // card is complete the full text is already shown, so drop the button.
-            if !vm.isCardComplete {
+            // card is answered (revealed, or submitted right or wrong) the text is
+            // already on the card, so drop the button.
+            if !vm.isCardAnswered {
                 PeekHoldButton(isPeeking: $isPeeking)
                     .transition(.opacity)
             }
@@ -484,10 +503,11 @@ struct TestSessionView: View {
                 if vm.isCardComplete {
                     if sessionKind == .srs, let verse = vm.currentVerse {
                         SRSGradingButtons(
-                            state:     displayState(for: verse),
-                            suggested: gradeButtonHighlight(for: verse),
-                            now:       Date(),
-                            onPick:    { gradeAndAdvance($0) }
+                            state:       displayState(for: verse),
+                            suggested:   gradeButtonHighlight(for: verse),
+                            now:         Date(),
+                            isConfirmed: sessionGrades[verse.id] != nil,
+                            onPick:      { gradeAndAdvance($0) }
                         )
                     } else {
                         nextButton
@@ -527,6 +547,26 @@ struct TestSessionView: View {
         }
         .disabled(vm.currentIndex >= vm.verses.count - 1)
         .opacity(vm.currentIndex >= vm.verses.count - 1 ? 0.5 : 1)
+    }
+
+    /// When the card under review is the current stopped verse, let the user mark
+    /// it learnt right here — advancing the Home cursor. The SRS grade still
+    /// schedules the card and moves on, so this never replaces grading; once
+    /// tapped, the cursor moves and the row hides itself.
+    private func markLearntRow(for verse: Verse) -> some View {
+        Button {
+            learning.markLearnt(verse)
+            HapticEngine.success()
+        } label: {
+            Label("Mark as Complete", systemImage: "checkmark.circle.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity).padding(.vertical, 12)
+                .background(Color.green)
+                .roundedRect(12)
+        }
+        .accessibilityLabel("Mark current verse as complete")
+        .transition(.scale.combined(with: .opacity))
     }
 
     // MARK: - Session Complete Panel
@@ -595,10 +635,11 @@ struct TestSessionView: View {
             if hasResult {
                 if sessionKind == .srs, let verse = vm.currentVerse {
                     SRSGradingButtons(
-                        state:     displayState(for: verse),
-                        suggested: gradeButtonHighlight(for: verse),
-                        now:       Date(),
-                        onPick:    { gradeAndAdvance($0) }
+                        state:       displayState(for: verse),
+                        suggested:   gradeButtonHighlight(for: verse),
+                        now:         Date(),
+                        isConfirmed: sessionGrades[verse.id] != nil,
+                        onPick:      { gradeAndAdvance($0) }
                     )
                 } else {
                     HStack(spacing: 10) {
@@ -680,11 +721,21 @@ struct TestSessionView: View {
                         case .firstLetter:
                             let correct = vm.processFirstLetterInput(newValue)
                             DispatchQueue.main.async { vm.inputText = "" }
-                            if correct { HapticEngine.light() } else { HapticEngine.error(); triggerShake($shakeOffset) }
+                            if correct {
+                                HapticEngine.light()
+                            } else {
+                                // A wrong first letter is a genuine recall miss. Count it
+                                // so the SRS grade suggestion reflects the struggle — these
+                                // modes have no diff to score, unlike submit mode, so without
+                                // this every card looks perfect and is always suggested "Good".
+                                vm.recordMistake()
+                                HapticEngine.error(); triggerShake($shakeOffset)
+                            }
                         case .fullWord:
                             if vm.processFullWordInput(newValue) {
                                 HapticEngine.light()
                             } else if newValue.hasSuffix(" ") {
+                                vm.recordMistake()
                                 HapticEngine.error(); triggerShake($shakeOffset)
                             }
                         case .submit:
@@ -837,10 +888,49 @@ struct TestSessionView: View {
 
     private func suggestedGradeForCurrentCard() -> SRSGrade {
         guard let verse = vm.currentVerse else { return .good }
-        let isAllCorrect: Bool = (studyMode == .submit)
-            ? (vm.submitResults[verse.id]?.isAllCorrect == true)
-            : true   // Other modes only complete via correct typing.
-        return suggestedGrade(isAllCorrect: isAllCorrect, mistakes: vm.mistakes(for: verse.id))
+        return suggestedGradeFor(verse)
+    }
+
+    /// Slips tolerated in the typo-prone first-letter / full-word modes before the
+    /// suggestion drops from "Good" to "Hard" — they fumble keystrokes far more than
+    /// entire-verse typing, so a couple of misses shouldn't be read as poor recall.
+    private static let typingMistakeTolerance = 2
+
+    private func suggestedGradeFor(_ verse: Verse) -> SRSGrade {
+        // Peeking at the answer is a failed recall — never suggest better than Again.
+        if peekedVerseIds.contains(verse.id) { return .again }
+
+        let mistakes = vm.mistakes(for: verse.id)
+        switch studyMode {
+        case .submit:
+            let allCorrect = vm.submitResults[verse.id]?.isAllCorrect == true
+            return suggestedGrade(isAllCorrect: allCorrect, mistakes: mistakes)
+        case .firstLetter, .fullWord:
+            // Completion already means every word was eventually correct; only the
+            // number of slips matters, with leeway before counting it as a struggle.
+            return mistakes <= Self.typingMistakeTolerance ? .good : .hard
+        }
+    }
+
+    /// Ends the session. In SRS, any card that's finished but still ungraded — e.g.
+    /// the user typed the last card and tapped "End Session" instead of a grade —
+    /// gets its suggested grade applied first, so the review actually counts
+    /// (schedules the card) instead of silently dropping.
+    private func endSession() {
+        if sessionKind == .srs {
+            var gradedAny = false
+            for verse in vm.verses where sessionGrades[verse.id] == nil && vm.isVerseComplete(verse) {
+                let grade = suggestedGradeFor(verse)
+                if let prior = SRSStore.shared.state(for: verse) { preGradeStates[verse.id] = prior }
+                SRSStore.shared.grade(verse: verse, grade: grade)
+                sessionGrades[verse.id] = grade
+                gradedAny = true
+            }
+            if gradedAny { StreakStore.shared.recordToday() }
+        }
+        vm.clearProgress()
+        onSessionEnded?()
+        dismiss()
     }
 
     private func gradeAndAdvance(_ grade: SRSGrade) {

--- a/scripture memory/Views/TestSessionViewModel.swift
+++ b/scripture memory/Views/TestSessionViewModel.swift
@@ -65,6 +65,16 @@ final class TestSessionViewModel: ObservableObject {
         }
     }
 
+    /// True once the current card has been answered — submitted in entire-verse
+    /// mode (right *or* wrong) or fully revealed in first-letter / full-word mode.
+    /// Unlike `isCardComplete` (perfect-only in submit mode), a submitted-but-
+    /// imperfect card counts as answered, so peek can hide once the answer is shown.
+    var isCardAnswered: Bool {
+        guard let verse = currentVerse else { return false }
+        if studyMode == .submit { return submitResults[verse.id] != nil }
+        return isCardComplete
+    }
+
     var isSessionComplete: Bool {
         guard !verses.isEmpty else { return false }
         return verses.allSatisfy { verse in
@@ -328,7 +338,14 @@ final class TestSessionViewModel: ObservableObject {
     }
 
     private func advance(verse: Verse, sectionWords: [String], revealed: Int) {
-        let newCount = revealed + 1
+        var newCount = revealed + 1
+        // Auto-skip pure-punctuation tokens (e.g. a standalone "-" with spaces around
+        // it) — they have no first letter to type, so they must not swallow the
+        // keystroke meant for the next real word.
+        while newCount < sectionWords.count,
+              !sectionWords[newCount].contains(where: { $0.isLetter || $0.isNumber }) {
+            newCount += 1
+        }
         withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
             setRevealed(newCount, for: verse.id, section: activeSection)
         }

--- a/scripture memory/Views/VerseScrubberRow.swift
+++ b/scripture memory/Views/VerseScrubberRow.swift
@@ -24,6 +24,17 @@ struct VerseScrubberRow: View {
     let onStepForward: () -> Void
 
     var body: some View {
+        // A one-verse session has nothing to scrub to — a lone centred knob (plus
+        // a stray fill stub) just reads as broken — so collapse the control unless
+        // cross-pack stepping keeps the chevrons meaningful.
+        if verseCount <= 1 && !canStepBeyondStart && !canStepBeyondEnd {
+            EmptyView()
+        } else {
+            scrubberContent
+        }
+    }
+
+    private var scrubberContent: some View {
         VStack(spacing: showPositionLabel ? 6 : 0) {
             HStack(spacing: 10) {
                 let canPrev = currentIndex > 0
@@ -64,7 +75,9 @@ struct VerseScrubberRow: View {
                 ? CGFloat(currentIndex) / CGFloat(verseCount - 1) * (w - knobW)
                 : (w - knobW) / 2
             let progress = verseCount > 1 ? CGFloat(currentIndex) / CGFloat(verseCount - 1) : 0
-            let fillW = knobW / 2 + progress * (w - knobW)
+            // Single verse: run the fill to the centred knob instead of leaving a
+            // stray stub pinned to the left edge.
+            let fillW = verseCount > 1 ? (knobW / 2 + progress * (w - knobW)) : (knobX + knobW / 2)
 
             ZStack(alignment: .leading) {
                 Capsule()


### PR DESCRIPTION
## Summary
Surfaces the "current learning verse" (the learning cursor) across every study surface, and refines SRS grading, the streak, and first-letter input.

### Current-verse cursor
- "Current" badge on study/test flashcards and the pack grid
- Mark-as-Complete on the card in read mode; completing the current verse from any surface advances the Home cursor
- Floating "Jump to current verse" shortcut (expands, then collapses to an icon); list-view visibility tracks scroll position
- Standalone "Go to current verse" card on Home when a different verse is pinned

### SRS / Daily Review
- Suggested grade rendered as an outline, not a pre-filled selection
- "End Session" applies the suggested grade to finished-but-ungraded cards so the review still counts
- First-letter / full-word modes record mistakes (leeway before "Hard"); peeking suggests "Again"
- First-letter input auto-skips standalone punctuation tokens (e.g. " - ")

### Home / streak / settings
- Streak counts on app launch and foreground (viewing the verse keeps it alive)
- Read-mode card restored to 5:3 (review keeps the larger size for masked text)
- "All caught up" copy made accurate and count-aware
- Settings "Starting point" -> "Current verse"; pinned card decluttered

## Testing
- `swift test` — 74 tests pass
- Xcode build (iphonesimulator) green
- Verified key flows live in the iOS simulator (iPhone 16 Pro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
