### PR TITLE
Refine SRS review: clearer suggested grade, auto-advance cursor, Anki-style undo

### DIFF
--- a/scripture memory/Model/LearningStore.swift
+++ b/scripture memory/Model/LearningStore.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Combine
 
+extension Notification.Name {
+    /// Posted when the pinned/featured verse changes, so the app re-syncs the widget
+    /// snapshot right away — SwiftUI `onChange` on the pinned key can miss the update
+    /// while the pin-picker sheet is presented.
+    static let featuredVerseDidChange = Notification.Name("scripture.featuredVerseDidChange")
+}
+
 /// Tracks which verses the user has **learnt**, and derives the linear "current
 /// learning verse" from that — the first verse, in pack order, that hasn't been
 /// marked learnt yet. Crossing pack boundaries falls out naturally.
@@ -108,6 +115,7 @@ final class LearningStore: ObservableObject {
         guard !verse.srsKey.isEmpty else { return }
         pinnedKey = verse.srsKey
         defaults.set(verse.srsKey, forKey: Self.pinStorageKey)
+        NotificationCenter.default.post(name: .featuredVerseDidChange, object: nil)
     }
 
     /// Clear the pin — Home/widget return to the current learning verse.
@@ -115,6 +123,7 @@ final class LearningStore: ObservableObject {
         guard pinnedKey != nil else { return }
         pinnedKey = nil
         defaults.removeObject(forKey: Self.pinStorageKey)
+        NotificationCenter.default.post(name: .featuredVerseDidChange, object: nil)
     }
 
     /// How many of `ordered` are learnt (for progress display).
@@ -126,6 +135,13 @@ final class LearningStore: ObservableObject {
     func markLearnt(_ verse: Verse) {
         guard !verse.srsKey.isEmpty, !learntKeys.contains(verse.srsKey) else { return }
         learntKeys.insert(verse.srsKey)
+        persist()
+    }
+
+    /// Undo `markLearnt` — used when a review grade that auto-advanced the cursor is
+    /// undone, so the cursor returns to this verse.
+    func unmarkLearnt(_ verse: Verse) {
+        guard learntKeys.remove(verse.srsKey) != nil else { return }
         persist()
     }
 

--- a/scripture memory/Model/SRSStore.swift
+++ b/scripture memory/Model/SRSStore.swift
@@ -132,6 +132,23 @@ final class SRSStore: ObservableObject {
         return next
     }
 
+    /// Revert a single card to a known prior state — the review **Undo**. A `nil`
+    /// prior state means the card was brand-new, so its state is removed entirely;
+    /// when `wasNewlyIntroduced`, today's consumed new-card slot is also given back
+    /// so the undo doesn't leave the daily counter inflated.
+    func revert(verse: Verse, to priorState: SRSCardState?, wasNewlyIntroduced: Bool, now: Date = Date()) {
+        let key = verse.srsKey
+        if let priorState {
+            states[key] = priorState
+        } else {
+            states.removeValue(forKey: key)
+        }
+        if wasNewlyIntroduced, !verse.packName.isEmpty {
+            unbumpDailyNew(packName: verse.packName, now: now)
+        }
+        persist()
+    }
+
     /// Wipe all SRS state. `ReviewProgress.completedIds` is intentionally untouched.
     /// Active-pack opt-ins are preserved — they're a UI preference, not progress.
     func resetAll() {
@@ -155,6 +172,15 @@ final class SRSStore: ObservableObject {
         let day = Self.dayKey(now)
         var perPack = dailyNewByDate[day] ?? [:]
         perPack[packName, default: 0] += 1
+        dailyNewByDate[day] = perPack
+    }
+
+    /// Undo a `bumpDailyNew` — returns a consumed slot when a brand-new card's
+    /// first grade is reverted via `revert`. Floors at zero.
+    private func unbumpDailyNew(packName: String, now: Date) {
+        let day = Self.dayKey(now)
+        guard var perPack = dailyNewByDate[day], let count = perPack[packName], count > 0 else { return }
+        perPack[packName] = count - 1
         dailyNewByDate[day] = perPack
     }
 

--- a/scripture memory/Views/ContentView.swift
+++ b/scripture memory/Views/ContentView.swift
@@ -87,6 +87,9 @@ struct ContentView: View {
         }
         .onChange(of: learning.learntKeys) { _, _ in syncWidget() }
         .onChange(of: learning.pinnedKey)  { _, _ in syncWidget() }
+        // Belt-and-braces: a direct signal so pinning/unpinning always re-syncs the
+        // widget, even if the onChange above is missed while the picker sheet is up.
+        .onReceive(NotificationCenter.default.publisher(for: .featuredVerseDidChange)) { _ in syncWidget() }
         .onChange(of: bibleVersion)        { _, _ in syncWidget() }
         .onChange(of: hasOnboarded)        { _, _ in syncWidget() }
         // Refresh the widget snapshot when leaving/returning — catches streak and

--- a/scripture memory/Views/SRSGradingButtons.swift
+++ b/scripture memory/Views/SRSGradingButtons.swift
@@ -1,21 +1,22 @@
 import SwiftUI
 
-/// Four grading buttons (Again / Hard / Good / Easy) shown after the user has
-/// finished a card in an SRS session.
+/// Four grading buttons (Again / Hard / Good / Easy) shown after a card is
+/// finished in an SRS session.
 ///
-/// Before the user picks, the auto-suggested grade is shown as an **outline**
-/// (a recommendation) — never pre-filled, so it can't be mistaken for a choice
-/// already made. Once picked (`isConfirmed`), that grade fills in to read as the
-/// selection. Each button shows the predicted next interval ("1m", "1d", "4d", …)
-/// so the consequence of the choice is visible.
+/// - The **selected** grade (the one Confirm will commit) is filled with its
+///   colour. Upstream it usually defaults to the suggestion, but the user can
+///   tap any button to choose their own difficulty.
+/// - The **suggested** grade carries a clear "Suggested" tag above it, so the
+///   recommended choice is obvious — "this is your suggested one, you can pick
+///   another". `suggested` may be `nil` (e.g. first-letter mode, where frequent
+///   typos make a performance-based suggestion unreliable); then no tag shows
+///   and the user simply chooses for themselves.
 struct SRSGradingButtons: View {
 
     let state:     SRSCardState
-    let suggested: SRSGrade
+    let suggested: SRSGrade?
+    let selected:  SRSGrade?
     let now:       Date
-    /// True once the user has actually graded this card. Until then `suggested`
-    /// is only a recommendation and must not look selected.
-    var isConfirmed: Bool = false
     let onPick:    (SRSGrade) -> Void
 
     var body: some View {
@@ -24,11 +25,13 @@ struct SRSGradingButtons: View {
                 gradeButton(grade)
             }
         }
+        // Headroom so the "Suggested" tag can sit above its button without clipping.
+        .padding(.top, 14)
     }
 
     private func gradeButton(_ grade: SRSGrade) -> some View {
         let isSuggested = (grade == suggested)
-        let isPicked    = isSuggested && isConfirmed
+        let isSelected  = (grade == selected)
         let label = predictedIntervalLabel(state: state, grade: grade, now: now)
         let shape = RoundedRectangle(cornerRadius: 14, style: .continuous)
         return Button {
@@ -38,20 +41,37 @@ struct SRSGradingButtons: View {
             VStack(spacing: 2) {
                 Text(grade.displayName)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(textColor(for: grade, suggested: isSuggested, picked: isPicked))
+                    .foregroundStyle(textColor(grade: grade, selected: isSelected, suggested: isSuggested))
                 Text(label)
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(textColor(for: grade, suggested: isSuggested, picked: isPicked).opacity(0.85))
+                    .foregroundStyle(textColor(grade: grade, selected: isSelected, suggested: isSuggested).opacity(0.85))
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
-            // Filled only once the grade is the confirmed pick; otherwise plain.
-            .background(shape.fill(isPicked ? color(for: grade) : Color(.secondarySystemGroupedBackground)))
-            // Recommendation marker: an outline on the suggested grade *before*
-            // it's picked — distinct from the filled "selected" look.
-            .overlay(shape.stroke(isSuggested && !isConfirmed ? color(for: grade) : .clear, lineWidth: 2))
+            // Filled only when this grade is the current selection.
+            .background(shape.fill(isSelected ? color(for: grade) : Color(.secondarySystemGroupedBackground)))
+            // Outline marks the suggestion when it isn't (also) the filled selection.
+            .overlay(shape.stroke(isSuggested && !isSelected ? color(for: grade) : .clear, lineWidth: 2))
+            // "Suggested" tag straddling the top edge of the recommended button.
+            .overlay(alignment: .top) {
+                if isSuggested { suggestedTag(color: color(for: grade)) }
+            }
         }
         .buttonStyle(.plain)
+    }
+
+    /// A small pill anchored to the top edge of the suggested button. The
+    /// background-coloured ring makes it read as a tag sitting on the button.
+    private func suggestedTag(color: Color) -> some View {
+        Text("Suggested")
+            .font(.system(size: 9, weight: .heavy))
+            .foregroundStyle(.white)
+            .fixedSize()
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(color))
+            .overlay(Capsule().stroke(Color(.systemBackground), lineWidth: 1.5))
+            .offset(y: -10)
     }
 
     private func color(for grade: SRSGrade) -> Color {
@@ -63,9 +83,9 @@ struct SRSGradingButtons: View {
         }
     }
 
-    private func textColor(for grade: SRSGrade, suggested: Bool, picked: Bool) -> Color {
-        if picked    { return .white }            // confirmed selection (filled)
-        if suggested { return color(for: grade) } // recommendation (outlined)
+    private func textColor(grade: SRSGrade, selected: Bool, suggested: Bool) -> Color {
+        if selected  { return .white }            // filled selection
+        if suggested { return color(for: grade) } // outlined recommendation
         return .primary
     }
 }

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -29,7 +29,16 @@ struct TestSessionView: View {
     // card and change the grade without compounding (regrade computes from
     // the captured pre-grade state, not the already-advanced one).
     @State private var sessionGrades:    [Int: SRSGrade]      = [:]
+    /// Difficulty the user has selected (filled) for the current card but not yet
+    /// confirmed — lets them change it before committing. Reset on each new card.
+    @State private var pendingGrade:     SRSGrade?            = nil
     @State private var preGradeStates:   [Int: SRSCardState]  = [:]
+    /// Verse ids in the order they were graded — the Anki-style Undo stack. SRS
+    /// review runs forward-only; Undo pops the last grade and returns to that card.
+    @State private var gradedOrder:      [Int]                = []
+    /// Verses whose Good/Easy grade auto-advanced the learning cursor, so Undo can
+    /// put the cursor back.
+    @State private var autoLearntIds:    Set<Int>             = []
 
     @Environment(\.dismiss) private var dismiss
 
@@ -89,7 +98,10 @@ struct TestSessionView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
 
-                if vm.verses.count > 1 {
+                // Anki-style review is forward-only — you advance by grading, and
+                // Undo (top bar) reverts the last grade — so it has no scrubber.
+                // Quiz keeps free navigation.
+                if vm.verses.count > 1, sessionKind != .srs {
                     scrubberRow
                         .padding(.horizontal, AppLayout.screenMargin)
                         .padding(.bottom, 6)
@@ -101,6 +113,7 @@ struct TestSessionView: View {
         .background(Color(.systemGroupedBackground))
         .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
+            pendingGrade = nil   // each card starts from its own suggested difficulty
             if speech.isListening { speech.stopListening() }
             if isScrubbing {
                 // Don't dismiss the keyboard — just point focus at the title field
@@ -160,6 +173,18 @@ struct TestSessionView: View {
                 }
                 .accessibilityLabel("Close session")
 
+                // Undo the last grade — the forward-only review's back affordance.
+                // Kept on the leading edge so it stays reachable even while the
+                // keyboard is up on the next card.
+                if sessionKind == .srs {
+                    Button { undoLastGrade() } label: {
+                        Image(systemName: "arrow.uturn.backward").studyChromeCircleButton()
+                    }
+                    .disabled(gradedOrder.isEmpty)
+                    .opacity(gradedOrder.isEmpty ? 0.3 : 1)
+                    .accessibilityLabel("Undo last rating")
+                }
+
                 Spacer()
 
                 // While typing, a guaranteed-visible "Done" replaces the trailing
@@ -176,11 +201,14 @@ struct TestSessionView: View {
                     .accessibilityLabel("Close keyboard")
                 } else {
                     HStack(spacing: 8) {
-                        // Verse selector dropdown
-                        Button { showVerseSelector = true } label: {
-                            Image(systemName: "list.bullet").studyChromeCircleButton()
+                        // Verse selector (jump anywhere) — Quiz only; SRS review is
+                        // forward-only, so free jumping doesn't belong there.
+                        if sessionKind != .srs {
+                            Button { showVerseSelector = true } label: {
+                                Image(systemName: "list.bullet").studyChromeCircleButton()
+                            }
+                            .accessibilityLabel("Jump to verse")
                         }
-                        .accessibilityLabel("Jump to verse")
                         // Score display — only in Entire Verse mode
                         if studyMode == .submit { scoreDisplay }
                     }
@@ -453,22 +481,60 @@ struct TestSessionView: View {
 
     // MARK: - Bottom Controls
 
+    /// In an SRS review the session isn't "done" until every card has been
+    /// **graded** — not merely revealed. `vm.isSessionComplete` flips true as soon
+    /// as the last card is *revealed* (first-letter / full-word) or entered
+    /// *perfectly* (submit); showing the summary then would skip the final card's
+    /// grading buttons and the card would never get scheduled. Quiz sessions have
+    /// no grading, so they keep the plain reveal-based completion.
+    private var showSessionSummary: Bool {
+        if sessionKind == .srs {
+            return vm.verses.allSatisfy { sessionGrades[$0.id] != nil }
+        }
+        return vm.isSessionComplete
+    }
+
     private var bottomControls: some View {
         VStack(spacing: 12) {
-            if vm.isSessionComplete {
+            if showSessionSummary {
                 sessionCompletePanel
             } else {
                 cardControlBand
             }
 
-            // Completing the current stopped verse here (e.g. it surfaced as a new
-            // card) lets you advance the Home cursor without leaving the session.
-            if !vm.isSessionComplete, vm.isCardComplete,
+            // Quiz (non-SRS) has no grade to key off, so completing the current
+            // stopped verse here still offers a manual "Mark as Complete". In SRS a
+            // Good/Easy grade advances the cursor automatically (see gradeAndAdvance).
+            if !showSessionSummary, sessionKind != .srs, vm.isCardComplete,
                let v = vm.currentVerse, learning.isCurrent(v) {
                 markLearntRow(for: v)
             }
 
-            if !vm.isSessionComplete && vm.completedCount == vm.verses.count {
+            // SRS: pick a difficulty above (changeable), then confirm to schedule the
+            // card and move on. Confirming the last card ends the session. Gated on
+            // `isCardAnswered` (not `isCardComplete`) so it tracks the grading selector
+            // exactly — in submit mode a *wrong* answer is answered-but-not-complete,
+            // and still needs a Confirm to commit the grade.
+            if !showSessionSummary, sessionKind == .srs, vm.isCardAnswered,
+               let verse = vm.currentVerse {
+                // `currentSelection` is nil only in first-letter mode before the user
+                // picks (no auto-suggestion) — keep Confirm disabled until they do.
+                let pick = currentSelection(for: verse)
+                Button {
+                    guard let grade = pick else { return }
+                    pendingGrade = nil
+                    gradeAndAdvance(grade)
+                } label: {
+                    Text(pick == nil ? "Pick a difficulty to continue" : "Confirm")
+                        .font(.headline).frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .tint(.accentColor)
+                .disabled(pick == nil)
+            } else if !showSessionSummary, sessionKind != .srs,
+                      vm.completedCount == vm.verses.count {
+                // Quiz (non-SRS) has no grading, so it keeps an explicit end button.
                 Button {
                     endSession()
                 } label: {
@@ -483,6 +549,7 @@ struct TestSessionView: View {
         .padding(.bottom, 24)
         .padding(.top, 6)
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: vm.isCardComplete)
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: vm.isCardAnswered)
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: vm.isSessionComplete)
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: vm.completedCount)
     }
@@ -503,11 +570,11 @@ struct TestSessionView: View {
                 if vm.isCardComplete {
                     if sessionKind == .srs, let verse = vm.currentVerse {
                         SRSGradingButtons(
-                            state:       displayState(for: verse),
-                            suggested:   gradeButtonHighlight(for: verse),
-                            now:         Date(),
-                            isConfirmed: sessionGrades[verse.id] != nil,
-                            onPick:      { gradeAndAdvance($0) }
+                            state:     displayState(for: verse),
+                            suggested: suggestedGradeFor(verse),
+                            selected:  currentSelection(for: verse),
+                            now:       Date(),
+                            onPick:    { pendingGrade = $0 }
                         )
                     } else {
                         nextButton
@@ -635,11 +702,11 @@ struct TestSessionView: View {
             if hasResult {
                 if sessionKind == .srs, let verse = vm.currentVerse {
                     SRSGradingButtons(
-                        state:       displayState(for: verse),
-                        suggested:   gradeButtonHighlight(for: verse),
-                        now:         Date(),
-                        isConfirmed: sessionGrades[verse.id] != nil,
-                        onPick:      { gradeAndAdvance($0) }
+                        state:     displayState(for: verse),
+                        suggested: suggestedGradeFor(verse),
+                        selected:  currentSelection(for: verse),
+                        now:       Date(),
+                        onPick:    { pendingGrade = $0 }
                     )
                 } else {
                     HStack(spacing: 10) {
@@ -769,8 +836,11 @@ struct TestSessionView: View {
                 // Skip predominantly-vertical drags so TextEditor scroll/selection in submit mode survives.
                 guard abs(value.translation.width) > abs(value.translation.height) else { return }
                 if isCardFlying { commitSwipe() }
-                let canNext = vm.currentIndex < vm.verses.count - 1
-                let canPrev = vm.currentIndex > 0
+                // Forward-only SRS review: no swipe navigation (advance by grading,
+                // step back via Undo). Quiz keeps free swiping.
+                let swipeNav = sessionKind != .srs
+                let canNext = swipeNav && vm.currentIndex < vm.verses.count - 1
+                let canPrev = swipeNav && vm.currentIndex > 0
                 dragOffset = CardSwipeConfig.clampedDragTranslation(
                     value.translation,
                     canGoNext: canNext,
@@ -781,11 +851,12 @@ struct TestSessionView: View {
                 if isCardFlying { commitSwipe() }
                 let isHorizontal = abs(value.translation.width) > abs(value.translation.height)
                 let vx = value.predictedEndTranslation.width
-                if isHorizontal,
+                let swipeNav = sessionKind != .srs
+                if isHorizontal, swipeNav,
                    (dragOffset.width < -CardSwipeConfig.threshold || vx < -CardSwipeConfig.velocityThreshold),
                    vm.currentIndex < vm.verses.count - 1 {
                     swipeForward()
-                } else if isHorizontal,
+                } else if isHorizontal, swipeNav,
                           (dragOffset.width > CardSwipeConfig.threshold || vx > CardSwipeConfig.velocityThreshold),
                           vm.currentIndex > 0 {
                     swipeBackward()
@@ -880,23 +951,25 @@ struct TestSessionView: View {
         return currentSRSState(for: verse)
     }
 
-    /// Auto-suggested grade unless the user has already picked one this session,
-    /// in which case the previously-picked grade stays highlighted.
-    private func gradeButtonHighlight(for verse: Verse) -> SRSGrade {
-        sessionGrades[verse.id] ?? suggestedGradeForCurrentCard()
+    /// The grade currently shown as **selected** (filled) and that Confirm will
+    /// commit: the user's explicit pick, else a grade already applied this session
+    /// (regrade when scrubbing back), else the suggestion. `nil` only when nothing
+    /// is picked and there's no suggestion — first-letter mode before the user
+    /// chooses — which keeps Confirm disabled until they pick.
+    private func currentSelection(for verse: Verse) -> SRSGrade? {
+        pendingGrade ?? sessionGrades[verse.id] ?? suggestedGradeFor(verse)
     }
 
-    private func suggestedGradeForCurrentCard() -> SRSGrade {
-        guard let verse = vm.currentVerse else { return .good }
-        return suggestedGradeFor(verse)
-    }
-
-    /// Slips tolerated in the typo-prone first-letter / full-word modes before the
-    /// suggestion drops from "Good" to "Hard" — they fumble keystrokes far more than
-    /// entire-verse typing, so a couple of misses shouldn't be read as poor recall.
+    /// Slips tolerated in the typo-prone full-word mode before the suggestion drops
+    /// from "Good" to "Hard" — keystroke fumbles shouldn't be read as poor recall.
     private static let typingMistakeTolerance = 2
 
-    private func suggestedGradeFor(_ verse: Verse) -> SRSGrade {
+    /// The algorithm's recommended grade — shown with the "Suggested" tag. Returns
+    /// `nil` when there's no reliable recommendation: first-letter mode is so
+    /// keystroke-heavy that a wrong letter is common, so the mistake count is a poor
+    /// signal — we don't suggest a grade and leave the choice to the user.
+    private func suggestedGradeFor(_ verse: Verse) -> SRSGrade? {
+        guard studyMode != .firstLetter else { return nil }
         // Peeking at the answer is a failed recall — never suggest better than Again.
         if peekedVerseIds.contains(verse.id) { return .again }
 
@@ -905,10 +978,12 @@ struct TestSessionView: View {
         case .submit:
             let allCorrect = vm.submitResults[verse.id]?.isAllCorrect == true
             return suggestedGrade(isAllCorrect: allCorrect, mistakes: mistakes)
-        case .firstLetter, .fullWord:
+        case .fullWord:
             // Completion already means every word was eventually correct; only the
             // number of slips matters, with leeway before counting it as a struggle.
             return mistakes <= Self.typingMistakeTolerance ? .good : .hard
+        case .firstLetter:
+            return nil   // handled by the guard above; keeps the switch exhaustive
         }
     }
 
@@ -920,7 +995,9 @@ struct TestSessionView: View {
         if sessionKind == .srs {
             var gradedAny = false
             for verse in vm.verses where sessionGrades[verse.id] == nil && vm.isVerseComplete(verse) {
-                let grade = suggestedGradeFor(verse)
+                // First-letter mode has no auto-suggestion; default an ungraded-but-
+                // finished card to Good so ending the session still schedules it.
+                let grade = suggestedGradeFor(verse) ?? .good
                 if let prior = SRSStore.shared.state(for: verse) { preGradeStates[verse.id] = prior }
                 SRSStore.shared.grade(verse: verse, grade: grade)
                 sessionGrades[verse.id] = grade
@@ -953,7 +1030,17 @@ struct TestSessionView: View {
                 ?? SRSCardState.newCard(key: verse.srsKey, now: Date())
             SRSStore.shared.regrade(verse: verse, grade: grade, from: prior)
         }
+        if firstGradeInSession { gradedOrder.append(verse.id) }
         sessionGrades[verse.id] = grade
+
+        // Auto-advance the Home learning cursor: a solid recall (Good/Easy) of the
+        // verse you're currently learning marks it learnt and moves the cursor on —
+        // no manual "Mark as Complete" step. Again/Hard keep you on the verse.
+        // Recorded in `autoLearntIds` so Undo can put the cursor back.
+        if grade == .good || grade == .easy, learning.isCurrent(verse) {
+            learning.markLearnt(verse)
+            autoLearntIds.insert(verse.id)
+        }
 
         if vm.currentIndex < vm.verses.count - 1 {
             isScrubbing = true
@@ -968,6 +1055,37 @@ struct TestSessionView: View {
             onSessionEnded?()
             dismiss()
         }
+    }
+
+    /// Anki-style Undo: revert the most recent grade (last-in-first-out) and return
+    /// to that card so it can be re-rated. Rolls back the card's SRS schedule to its
+    /// captured pre-grade state and, if that grade had auto-advanced the learning
+    /// cursor, restores the cursor too. The card keeps its revealed/submitted state,
+    /// so the grading buttons are right there for a fresh rating.
+    private func undoLastGrade() {
+        guard let lastId = gradedOrder.last,
+              let idx = vm.verses.firstIndex(where: { $0.id == lastId }) else { return }
+        let verse = vm.verses[idx]
+
+        // A nil captured state means the card was brand-new, so revert removes its
+        // state and hands back the consumed daily-new slot.
+        let prior = preGradeStates[lastId]
+        SRSStore.shared.revert(verse: verse, to: prior, wasNewlyIntroduced: prior == nil)
+
+        if autoLearntIds.remove(lastId) != nil {
+            learning.unmarkLearnt(verse)
+        }
+
+        sessionGrades.removeValue(forKey: lastId)
+        preGradeStates.removeValue(forKey: lastId)
+        gradedOrder.removeLast()
+        pendingGrade = nil
+
+        // Return to the just-ungraded card to re-rate it.
+        isScrubbing = true
+        vm.currentIndex = idx
+        HapticEngine.light()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
     }
 }
 


### PR DESCRIPTION
## Summary
Improves the daily-review (SRS) experience, all verified live in the iOS simulator.

- **Clearer suggested grade** — the recommended difficulty now carries a "Suggested" tag, visually distinct from the user's selection; any grade is freely pickable.
- **First-letter mode** leaves the difficulty to the user (frequent typos make an auto-suggestion unreliable).
- **Fix: final card now gets graded** — the session completes only once every card is *graded*, not when the last card is merely revealed (first-letter/full-word) or entered perfectly (submit). Previously it skipped straight to the summary and never scheduled that card.
- **Auto-advance the learning cursor** on a Good/Easy grade; removed the manual "Mark as Complete" button from review (kept for Quiz).
- **Anki-style flow** — forward-only navigation (no scrubber/swipe/jump back) plus an **Undo** button that reverts the last grade (rolling back the card's schedule and the learning cursor) and returns to the card to re-rate.
- **Widget** re-syncs immediately when the featured verse changes (pin/unpin), even while the picker sheet is up.

## Testing
Verified on an iPhone 16 Pro simulator across all three input modes (First Letter, Full Word, Entire Verse): suggested-tag display, first-letter no-suggestion + Confirm gating, last-card grading, cursor auto-advance, and the forward-only + Undo flow (revert grade → return to card → re-rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)