### PR TITLE
Add NIV copyright notice and Navigators attribution in Settings

### DIFF
--- a/scripture memory/Views/SettingsView.swift
+++ b/scripture memory/Views/SettingsView.swift
@@ -153,11 +153,20 @@ struct SettingsView: View {
             } header: {
                 Text("About")
             } footer: {
-                Text("Made with God's ❤️ for The Navigators")
-                    .font(.system(.subheadline, design: .serif))
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.top, 4)
-                    .padding(.bottom, 28)
+                VStack(spacing: 18) {
+                    Text("Made with God's ❤️ for The Navigators")
+                        .font(.system(.subheadline, design: .serif))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.top, 4)
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Scripture quotations taken from The Holy Bible, New International Version® NIV®. Copyright © 1973, 1978, 1984, 2011 by Biblica, Inc.® Used by permission. All rights reserved worldwide.")
+                        Text("Verse selections are based on The Navigators' Topical Memory System®. This app is independent and is not affiliated with, endorsed by, or sponsored by The Navigators.")
+                    }
+                    .font(.footnote)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(.bottom, 28)
             }
         }
         .navigationTitle("Settings")


### PR DESCRIPTION
## What

Adds the publisher's prescribed NIV gratis-use copyright notice plus a Topical Memory System attribution and non-affiliation disclaimer to the **About** footer in Settings.

## Why

- Satisfies the NIV permission terms (the gratis-use policy requires the copyright notice be displayed in-app).
- Closes the most visible reviewer-facing gap for the Apple App Store Guideline 2.1 / protected third-party material request.

## Change

`scripture memory/Views/SettingsView.swift` — wraps the About footer in a `VStack`, keeping the existing "Made with God's ❤️" line and adding two small-print lines (NIV © Biblica notice + Navigators TMS attribution/non-affiliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)