### PR TITLE
Let users choose Read or Review mode for the Home current-verse card

### DIFF
--- a/scripture memory/Model/AppSettings.swift
+++ b/scripture memory/Model/AppSettings.swift
@@ -50,3 +50,31 @@ enum BibleVersion: String, CaseIterable {
         self == .niv11 ? packsNIV11 : packsNIV84
     }
 }
+
+// MARK: - Home Verse Start Mode
+
+/// Which mode the Home "current verse" card opens in when tapped: `.read` shows
+/// the full verse for study; `.review` starts active-recall practice. The
+/// in-session Read/Review toggle still lets the user switch at any time.
+enum HomeVerseStartMode: String, CaseIterable {
+    case read
+    case review
+
+    var displayName: String {
+        switch self {
+        case .read:   return "Read"
+        case .review: return "Review"
+        }
+    }
+
+    /// CTA verb shown on the Home current-verse card.
+    var ctaLabel: String {
+        switch self {
+        case .read:   return "Read"
+        case .review: return "Practice"
+        }
+    }
+
+    /// Whether the learning session should open in active-recall review mode.
+    var opensInReview: Bool { self == .review }
+}

--- a/scripture memory/Views/SRSDashboardView.swift
+++ b/scripture memory/Views/SRSDashboardView.swift
@@ -10,6 +10,7 @@ struct SRSDashboardView: View {
     @AppStorage("bibleVersion")       private var bibleVersion:   BibleVersion = .niv84
     @AppStorage("srs.dailyNewCap")    private var dailyNewCap:    Int          = 1
     @AppStorage("srs.dailyReviewCap") private var dailyReviewCap: Int          = 5
+    @AppStorage("homeVerseStartMode.v1") private var homeVerseStartMode: HomeVerseStartMode = .read
 
     @ObservedObject private var store     = SRSStore.shared
     @ObservedObject private var packPrefs = PackPreferencesStore.shared
@@ -241,7 +242,7 @@ struct SRSDashboardView: View {
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                             Spacer()
-                            Text("Practice")
+                            Text(homeVerseStartMode.ctaLabel)
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(Color.accentColor)
                             Image(systemName: "chevron.right")
@@ -254,7 +255,7 @@ struct SRSDashboardView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(CardButtonStyle())
-                .accessibilityLabel("Practice \(v.book) \(v.reference)")
+                .accessibilityLabel("\(homeVerseStartMode.ctaLabel) \(v.book) \(v.reference)")
             }
             .padding(18)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -352,7 +353,7 @@ struct SRSDashboardView: View {
                     packName: cur.pack.name,
                     verses: cur.pack.verses,
                     initialIndex: cur.indexInPack,
-                    initialReviewMode: true,
+                    initialReviewMode: homeVerseStartMode.opensInReview,
                     adjacentPack: cur.isPinned ? nil : { name, forward in adjacentPack(after: name, forward: forward) },
                     onMarkLearnt: cur.isPinned ? nil : { learning.markLearnt($0) }
                 )

--- a/scripture memory/Views/SettingsView.swift
+++ b/scripture memory/Views/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @AppStorage("hardMode")           private var hardMode:     Bool         = false
     @AppStorage("srs.dailyNewCap")    private var dailyNewCap:    Int        = 1
     @AppStorage("srs.dailyReviewCap") private var dailyReviewCap: Int        = 5
+    @AppStorage("homeVerseStartMode.v1") private var homeVerseStartMode: HomeVerseStartMode = .read
 
     @AppStorage(NotificationManager.Keys.enabled) private var reminderEnabled = false
     @AppStorage(NotificationManager.Keys.hour)    private var reminderHour    = NotificationManager.defaultHour
@@ -123,10 +124,19 @@ struct SettingsView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+
+                Picker(selection: $homeVerseStartMode) {
+                    ForEach(HomeVerseStartMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                } label: {
+                    rowLabel("Opens in", "book")
+                }
+                .pickerStyle(.menu)
             } header: {
                 Text("Learning")
             } footer: {
-                Text("The verse you're currently learning, shown on your Home screen. Everything before it counts as already learnt.")
+                Text("The verse you're currently learning, shown on your Home screen. Everything before it counts as already learnt. Choose whether tapping it opens for reading or active review.")
             }
 
             Section {


### PR DESCRIPTION
## What

Adds a user setting controlling which mode the Home **current-verse card** opens in when tapped — **Read** (study the full verse) or **Review** (active-recall practice).

- New `HomeVerseStartMode` enum (`Read` / `Review`) in `AppSettings.swift`.
- Settings → **Learning** → new **"Opens in"** picker row.
- The card's CTA label follows the choice (**Read** vs **Practice**).
- Wired into the single hardcoded call site (`SRSDashboardView.learningSession`), which previously always forced Review.

## Default: Read

The current verse is by definition *not yet memorized*, so reading before active recall is the gentler first step (no staring at blanks you can't fill), and it matches every other entry point into a verse (pack study, verse list), which already open in Read. Power users can switch the setting to Review, and the existing **in-session Read/Review toggle** still lets anyone flip modes mid-session.

## Test

- `xcodebuild` app target builds clean for the simulator.
- `swift test` — all 74 `SRSCore` unit tests pass.
- Wiring is deterministic (`initialReviewMode: homeVerseStartMode.opensInReview`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)