### PR TITLE
Fix review-mode bugs; add Home search, undo toast, dictation in all modes

### DIFF
--- a/scripture memory/Model/SpeechRecognizer.swift
+++ b/scripture memory/Model/SpeechRecognizer.swift
@@ -1,12 +1,18 @@
 import Foundation
 import Speech
 import AVFoundation
+import SwiftUI
 
 @MainActor
 class SpeechRecognizer: ObservableObject {
     @Published var transcript = ""
     @Published var isListening = false
     @Published var permissionDenied = false
+
+    /// Why dictation couldn't start, for the UI to show. Every failure path below
+    /// used to just return, leaving the mic button un-lit and the user with no idea
+    /// whether they'd mis-tapped, been denied, or hit something broken.
+    @Published var errorMessage: String?
 
     private var recognizer: SFSpeechRecognizer?
     private var recognitionTask: SFSpeechRecognitionTask?
@@ -27,6 +33,7 @@ class SpeechRecognizer: ObservableObject {
 
     func startListening() {
         guard !isListening else { return }
+        errorMessage = nil
 
         SFSpeechRecognizer.requestAuthorization { [weak self] status in
             Task { @MainActor in
@@ -36,6 +43,7 @@ class SpeechRecognizer: ObservableObject {
                     self.requestMicAndBegin()
                 default:
                     self.permissionDenied = true
+                    self.errorMessage = "Speech recognition permission was denied. Enable it in Settings › Privacy › Speech Recognition."
                 }
             }
         }
@@ -59,13 +67,19 @@ class SpeechRecognizer: ObservableObject {
                     self.beginRecognition()
                 } else {
                     self.permissionDenied = true
+                    self.errorMessage = "Microphone access was denied. Enable it in Settings › Privacy › Microphone."
                 }
             }
         }
     }
 
     private func beginRecognition() {
-        guard let recognizer, recognizer.isAvailable else { return }
+        // Commonly false in the Simulator, and on device when the speech assets
+        // aren't downloaded or the network is down for a locale that needs it.
+        guard let recognizer, recognizer.isAvailable else {
+            errorMessage = "Speech recognition isn't available right now. Check your connection and try again."
+            return
+        }
 
         recognitionTask?.cancel()
         recognitionTask = nil
@@ -92,6 +106,7 @@ class SpeechRecognizer: ObservableObject {
             try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
+            errorMessage = "Couldn't start the microphone. Another app may be using it."
             return
         }
 
@@ -108,6 +123,14 @@ class SpeechRecognizer: ObservableObject {
                     self.transcript = result.bestTranscription.formattedString
                 }
                 if error != nil || (result?.isFinal ?? false) {
+                    // An error before a single word came through means dictation
+                    // never actually got going. Say so, instead of just switching
+                    // the mic back off and leaving the user to wonder. Errors after
+                    // some speech was transcribed are ordinary end-of-session
+                    // teardown and stay silent.
+                    if error != nil, self.transcript.isEmpty {
+                        self.errorMessage = "Dictation didn't pick up any audio. Check your microphone and try again."
+                    }
                     self.stopListening()
                 }
             }
@@ -118,7 +141,28 @@ class SpeechRecognizer: ObservableObject {
             transcript = ""
             isListening = true
         } catch {
+            errorMessage = "Couldn't start the microphone. Another app may be using it."
             stopListening()
+        }
+    }
+}
+
+// MARK: - Error Presentation
+
+extension View {
+    /// Reports a failed dictation start. Without it the mic button simply doesn't
+    /// light up and the user is left guessing.
+    func speechErrorAlert(_ speech: SpeechRecognizer) -> some View {
+        alert(
+            "Dictation Unavailable",
+            isPresented: Binding(
+                get: { speech.errorMessage != nil },
+                set: { if !$0 { speech.errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(speech.errorMessage ?? "")
         }
     }
 }

--- a/scripture memory/Utilities/SharedUtilities.swift
+++ b/scripture memory/Utilities/SharedUtilities.swift
@@ -158,8 +158,7 @@ enum StudyControlMetrics {
 /// visually subordinate to the centered primary action. Compact (matches the
 /// mic / keyboard-dismiss buttons). Wrapped in a `Button` (with a no-op action)
 /// so pressing it never resigns the focused text field — otherwise the keyboard
-/// would dismiss mid-review. The `DragGesture(minimumDistance: 0)` rides
-/// alongside for press-and-hold: press down reveals, release hides.
+/// would dismiss mid-review.
 struct PeekHoldButton: View {
     @Binding var isPeeking: Bool
 
@@ -180,7 +179,13 @@ struct PeekHoldButton: View {
                 )
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressReportingButtonStyle { pressed in
+            withAnimation(.easeInOut(duration: 0.1)) { isPeeking = pressed }
+            if pressed {
+                HapticEngine.light()
+                dismissHint()
+            }
+        })
         .accessibilityLabel("Peek at answer")
         .accessibilityHint("Press and hold to reveal the verse")
         .accessibilityAddTraits(.isButton)
@@ -198,19 +203,6 @@ struct PeekHoldButton: View {
                     .allowsHitTesting(false)
             }
         }
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in
-                    if !isPeeking {
-                        withAnimation(.easeInOut(duration: 0.1)) { isPeeking = true }
-                        HapticEngine.light()
-                        dismissHint()
-                    }
-                }
-                .onEnded { _ in
-                    withAnimation(.easeInOut(duration: 0.1)) { isPeeking = false }
-                }
-        )
         .task {
             guard !hintSeen else { return }
             try? await Task.sleep(for: .milliseconds(700))   // let the screen settle
@@ -224,6 +216,24 @@ struct PeekHoldButton: View {
     private func dismissHint() {
         if showHint { withAnimation(.easeOut(duration: 0.25)) { showHint = false } }
         hintSeen = true
+    }
+}
+
+/// Reports a button's press state the moment the touch lands, and again on release.
+///
+/// `PeekHoldButton` used to get press-and-hold from a `DragGesture(minimumDistance: 0)`
+/// riding alongside the button. That gesture sits behind UIKit's decision about
+/// whether the touch is really a drag, and inside the review screen's gesture stack
+/// (card swipe + tap-to-focus + the button itself) that arbitration took a long
+/// beat — so peek felt like it demanded a multi-second press before anything
+/// happened. A `ButtonStyle`'s `isPressed` flips on touch-down with no arbitration
+/// to wait for, so the reveal is immediate.
+struct PressReportingButtonStyle: ButtonStyle {
+    let onPressChange: (Bool) -> Void
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .onChange(of: configuration.isPressed) { _, pressed in onPressChange(pressed) }
     }
 }
 

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -30,6 +30,17 @@ struct CardStudyView: View {
     /// browse mode, measured from the content's offset. Drives the fast-scroll
     /// thumb so it tracks smoothly and reaches both ends exactly.
     @State private var scrollFraction: Double = 0
+    /// Index of the card sitting in the middle of the viewport in list mode,
+    /// derived from the scroll offset. `currentIndex` can't answer "where am I?"
+    /// there — it only moves when you tap a card — so the position counter needs
+    /// its own scroll-derived value.
+    @State private var visibleListIndex: Int = 0
+    /// The jump shortcut's label is a one-time teach, not a recurring banner —
+    /// see `JumpToCurrentButton`. Lives here so both the card and list placements
+    /// share one budget for the whole time this screen is open.
+    @State private var jumpLabelShown = false
+    /// Pending "marked complete" undo prompt.
+    @State private var undoToastState: UndoToastState?
     /// Scroll target for the vertical read list. Driven by `scrollPosition(id:)`
     /// rather than `ScrollViewReader.scrollTo` because scrollPosition's
     /// programmatic scrolls are natively interruptible — the user can grab
@@ -97,9 +108,16 @@ struct CardStudyView: View {
         return v.srsKey == key
     }
 
-    /// Offer "Mark as Learnt" in the Continue-Learning flow (explicit hook) or
-    /// whenever the card on screen is the current stopped verse.
-    private var offersMarkLearnt: Bool { onMarkLearnt != nil || isCurrentLearningVerse }
+    /// Offer "Mark as Complete" only on the verse the cursor is actually parked on.
+    ///
+    /// This used to also fire whenever `onMarkLearnt` was supplied — but that hook is
+    /// set for the entire Continue-Learning session, so every card in it offered to
+    /// mark a verse complete, including ones already learnt and ones nowhere near
+    /// the cursor. On those the button was at best a no-op (`markLearnt` ignores an
+    /// already-learnt verse) and at worst misleading, and it displaced the Next
+    /// button you actually wanted. The hook decides *what marking does*, not
+    /// *whether there's anything to mark*.
+    private var offersMarkLearnt: Bool { isCurrentLearningVerse }
 
     /// Float the "Current verse" shortcut when this pack holds the current stopped
     /// verse and we're parked on a different card.
@@ -138,6 +156,21 @@ struct CardStudyView: View {
     private func markVerseComplete(_ verse: Verse) {
         if let cb = onMarkLearnt { cb(verse) } else { LearningStore.shared.markLearnt(verse) }
         HapticEngine.success()
+        raiseMarkedCompleteToast(for: verse)
+    }
+
+    /// Offer a short window to take back a "Mark as Complete". It's a one-tap
+    /// action sitting right next to the card, and it advances the learning cursor —
+    /// cheap to hit by accident, tedious to reverse without this.
+    ///
+    /// Undo only restores the learnt flag (and with it the cursor). It deliberately
+    /// doesn't rewind navigation: the review-mode button also steps to the next
+    /// card, and that step can cross into another pack, so unwinding it would be a
+    /// far bigger and less predictable jump than the user asked to undo.
+    private func raiseMarkedCompleteToast(for verse: Verse) {
+        undoToastState = UndoToastState(message: "Marked as complete") {
+            LearningStore.shared.unmarkLearnt(verse)
+        }
     }
 
     // MARK: - Body
@@ -189,7 +222,9 @@ struct CardStudyView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .overlay(alignment: .bottomTrailing) {
                             if showGoToCurrent {
-                                JumpToCurrentButton(action: jumpToCurrentVerse)
+                                JumpToCurrentButton(startExpanded: !jumpLabelShown,
+                                                    onExpandedShown: { jumpLabelShown = true },
+                                                    action: jumpToCurrentVerse)
                                     // Align the trailing edge with the card (and the
                                     // app's layout margin) instead of the screen edge.
                                     .padding(.trailing, AppLayout.screenMargin)
@@ -212,6 +247,7 @@ struct CardStudyView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
+        .undoToast($undoToastState)
         .onChange(of: vm.isReviewMode) { _, reviewing in handleReviewModeChange(reviewing) }
         .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
@@ -247,12 +283,11 @@ struct CardStudyView: View {
                 Text(vm.packName)
                     .font(.system(size: 15, weight: .semibold))
                     .lineLimit(1)
-                // Hide position counter in vertical-scroll read mode (it's meaningless there)
-                if !isVerticalScroll || vm.isReviewMode {
-                    Text("\(vm.currentIndex + 1) of \(vm.verses.count)")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.secondary)
-                }
+                Text(positionLabel)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .contentTransition(.numericText())
+                    .animation(.easeOut(duration: 0.15), value: positionLabel)
             }
             .frame(maxWidth: max(120, width - 220))
 
@@ -311,6 +346,16 @@ struct CardStudyView: View {
 
     /// True whenever either text input has keyboard focus.
     private var isEditing: Bool { isInputFocused || submitFocus != nil }
+
+    /// "3 of 37" for the top bar. Single-card modes track `currentIndex`; list mode
+    /// tracks what's actually on screen, since scrolling there doesn't move
+    /// `currentIndex` (it only changes when you tap a card). The counter used to be
+    /// hidden entirely in list mode for that reason — but "where am I in this pack?"
+    /// is exactly the question a long scrolling list raises.
+    private var positionLabel: String {
+        let i = (isVerticalScroll && !vm.isReviewMode) ? visibleListIndex : vm.currentIndex
+        return "\(i + 1) of \(vm.verses.count)"
+    }
 
     // MARK: - Card Stack (horizontal swipe mode)
 
@@ -416,6 +461,15 @@ struct CardStudyView: View {
                         let f = Double(min(max(m.offset / maxScroll, 0), 1))
                         if abs(f - scrollFraction) > 0.0001 { scrollFraction = f }
                         if abs(listScrollOffset - m.offset) > 0.5 { listScrollOffset = m.offset }
+
+                        // Which card is under the middle of the viewport. Cards are a
+                        // fixed height here, so inverting the same layout the jump
+                        // button uses (12pt top pad, card + 20pt spacing) gives the
+                        // index directly.
+                        let viewportCentre = m.offset + outerGeo.size.height / 2
+                        let raw = (viewportCentre - 12 - cardHeight / 2) / (cardHeight + 20)
+                        let idx = min(max(Int(raw.rounded()), 0), max(0, vm.verses.count - 1))
+                        if visibleListIndex != idx { visibleListIndex = idx }
                     }
                     .scrollPosition(id: $verticalScrollTarget, anchor: .center)
 
@@ -461,7 +515,9 @@ struct CardStudyView: View {
                 // button returns after you scroll away from a jump.
                 .overlay(alignment: .bottomTrailing) {
                     if showJumpInList(cardHeight: cardHeight, viewportHeight: outerGeo.size.height) {
-                        JumpToCurrentButton(action: {
+                        JumpToCurrentButton(startExpanded: !jumpLabelShown,
+                                            onExpandedShown: { jumpLabelShown = true },
+                                            action: {
                             // Set the scroll target directly (not just currentIndex)
                             // so a re-jump still works when currentIndex is already the
                             // cursor from a previous jump.
@@ -619,7 +675,12 @@ struct CardStudyView: View {
                             markLearntButton
                         }
                     } else {
-                        completeLabel
+                        // Takes the slot the old "Complete!" label held. That label
+                        // only announced a state the card already shows with its
+                        // green section checks, while the one thing you actually
+                        // want next — moving on — was stranded on the scrubber
+                        // chevron. The check icon keeps the completion signal.
+                        nextButton
                     }
                 } else if studyMode == .submit {
                     submitControls
@@ -631,16 +692,36 @@ struct CardStudyView: View {
         }
     }
 
-    private var completeLabel: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundColor(.green).font(.system(size: 22))
-                .symbolEffect(.bounce, options: .nonRepeating)
-            Text("Complete!")
-                .font(.system(size: 17, weight: .semibold)).foregroundColor(.green)
+    /// Advance to the next card once this one is done. Steps into the adjacent pack
+    /// at a boundary, same as the scrubber's chevron, so it's only disabled at the
+    /// true end of the sequence.
+    private var nextButton: some View {
+        let canAdvance = vm.currentIndex < vm.verses.count - 1 || canCrossForward
+        return Button {
+            isScrubbing = true
+            stepForward()
+            HapticEngine.light()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                isScrubbing = false
+                refocusIfNeeded()
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                    .font(.system(size: 18))
+                    .symbolEffect(.bounce, options: .nonRepeating)
+                Text("Next")
+                    .font(.system(size: 16, weight: .semibold))
+            }
+            .foregroundColor(.primary)
+            .frame(maxWidth: .infinity).padding(.vertical, 12)
+            .background(Color(.secondarySystemGroupedBackground))
+            .roundedRect(12)
         }
-        .frame(maxWidth: .infinity)
-        .transition(.scale.combined(with: .opacity))
+        .disabled(!canAdvance)
+        .opacity(canAdvance ? 1 : 0.5)
+        .accessibilityLabel("Verse complete, go to next")
     }
 
     /// "Continue Learning" only: the single action that marks a verse done. Marks
@@ -650,6 +731,7 @@ struct CardStudyView: View {
         Button {
             if let v = vm.currentVerse {
                 if let cb = onMarkLearnt { cb(v) } else { LearningStore.shared.markLearnt(v) }
+                raiseMarkedCompleteToast(for: v)
             }
             HapticEngine.success()
             isScrubbing = true
@@ -930,7 +1012,24 @@ struct CardStudyView: View {
 /// it fades (never scales) in, so the expanded pill is tappable immediately.
 private struct JumpToCurrentButton: View {
     let action: () -> Void
-    @State private var expanded = true
+    /// Whether this appearance gets the labelled pill. The label teaches what the
+    /// button is; once that's landed, re-teaching it every time the button comes
+    /// back (which is every time you navigate away from the cursor verse) is just
+    /// noise — and it briefly covers the card underneath.
+    var startExpanded: Bool = true
+    /// Fired as soon as the pill is shown, so the owner can suppress it from here on.
+    var onExpandedShown: () -> Void = {}
+
+    @State private var expanded: Bool
+
+    init(startExpanded: Bool = true,
+         onExpandedShown: @escaping () -> Void = {},
+         action: @escaping () -> Void) {
+        self.startExpanded    = startExpanded
+        self.onExpandedShown  = onExpandedShown
+        self.action           = action
+        _expanded             = State(initialValue: startExpanded)
+    }
 
     var body: some View {
         Button(action: action) {
@@ -957,7 +1056,13 @@ private struct JumpToCurrentButton: View {
         // springing in, so the expanded pill would miss taps for its whole life.
         .transition(.opacity)
         .task {
+            guard expanded else { return }
+            // Claim the one expanded showing up front, not after the collapse —
+            // navigating away inside that first second cancels this task, and the
+            // label would otherwise be owed all over again.
+            onExpandedShown()
             try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
             withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { expanded = false }
         }
     }

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -102,10 +102,17 @@ struct CardStudyView: View {
     private var offersMarkLearnt: Bool { onMarkLearnt != nil || isCurrentLearningVerse }
 
     /// Float the "Current verse" shortcut when this pack holds the current stopped
-    /// verse, we're parked on a different card, and the keyboard isn't up.
+    /// verse and we're parked on a different card.
+    ///
+    /// This used to also require the keyboard to be down. Review mode holds focus on
+    /// the answer field the whole time it's open, so that condition was never
+    /// satisfied there and the shortcut simply didn't exist in review — the mode
+    /// where hopping back to the verse you're actually learning matters most. Read
+    /// mode has no text input at all, so the condition never did anything there
+    /// either; it only ever suppressed the button.
     private var showGoToCurrent: Bool {
         guard let i = currentVerseIndexInPack else { return false }
-        return i != vm.currentIndex && !isEditing
+        return i != vm.currentIndex
     }
 
     private func jumpToCurrentVerse() {
@@ -323,15 +330,35 @@ struct CardStudyView: View {
                 let goingBack = dragOffset.width > 0
                 // Peek is rendered as an overlay in `body` (consistent across
                 // all modes); the underlying card never swaps for peek.
-                makeCard(verse: verse, verseIndex: vm.currentIndex, interactive: true, isPeeking: false)
+                let frontCard = makeCard(verse: verse, verseIndex: vm.currentIndex, interactive: true, isPeeking: false)
                     .offset(x: goingBack ? 0 : dragOffset.width,
                             y: goingBack ? backwardDragProgress * 12 : dragOffset.height * 0.1)
                     .scaleEffect(goingBack ? 1.0 - backwardDragProgress * 0.05 : 1.0)
                     .rotationEffect(goingBack ? .zero : .degrees(Double(dragOffset.width) * 0.03))
                     .zIndex(2)
-                    // `simultaneousGesture` lets TextField taps and TextEditor cursor/selection still fire;
-                    // the gesture itself filters out predominantly-vertical drags so editor scroll keeps working.
-                    .simultaneousGesture(swipeGesture)
+                // `simultaneousGesture` lets TextField taps and TextEditor cursor/selection still fire;
+                // the gesture itself filters out predominantly-vertical drags so editor scroll keeps working.
+                let swipingCard = frontCard.simultaneousGesture(swipeGesture)
+
+                // Tap anywhere on the card to bring the keyboard back. Previously the
+                // only way in was the section text itself — a couple of thin lines —
+                // so most of the card was dead space. Restricted to the masked-recall
+                // modes: in submit mode the card *is* two text inputs, and forcing
+                // focus to the title would steal taps meant for the verse editor.
+                if vm.isReviewMode && studyMode != .submit {
+                    swipingCard
+                        // Simultaneous so a tap on the title/verse underscores still
+                        // reaches FlashcardView's section handler (which picks the
+                        // section) while taps elsewhere just open the keyboard.
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                guard !vm.isCardComplete else { return }
+                                focusInput()
+                            }
+                        )
+                } else {
+                    swipingCard
+                }
             }
             if vm.currentIndex > 0 && dragOffset.width > 0 {
                 makeCard(verse: vm.verses[vm.currentIndex - 1], verseIndex: vm.currentIndex - 1, interactive: false)
@@ -527,17 +554,25 @@ struct CardStudyView: View {
             onScrubIndexChange: nil,
             canStepBeyondStart: canCrossBackward,
             canStepBeyondEnd: canCrossForward,
+            // Stepping lands on a new card to answer, so the keyboard comes back with
+            // it — `refocusIfNeeded` no-ops outside review mode and on finished cards.
             onStepBack: {
                 isScrubbing = true
                 stepBackward()
                 HapticEngine.light()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    isScrubbing = false
+                    refocusIfNeeded()
+                }
             },
             onStepForward: {
                 isScrubbing = true
                 stepForward()
                 HapticEngine.light()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    isScrubbing = false
+                    refocusIfNeeded()
+                }
             }
         )
     }
@@ -619,7 +654,10 @@ struct CardStudyView: View {
             HapticEngine.success()
             isScrubbing = true
             stepForward()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                isScrubbing = false
+                refocusIfNeeded()
+            }
         } label: {
             Label("Mark as Complete", systemImage: "checkmark.circle.fill")
                 .font(.system(size: 16, weight: .semibold))
@@ -854,8 +892,23 @@ struct CardStudyView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { focusInput() }
     }
 
-    private func focusInput() {
+    /// Puts the keyboard back on the answer input, re-arming until it actually takes.
+    ///
+    /// Completing a card unmounts the input field (the Try Again / Mark as Complete
+    /// row takes its place), so on the *next* card the field is a freshly inserted
+    /// view. A lone `isInputFocused = true` fired while that insertion is still
+    /// animating in gets dropped on the floor — which is why the keyboard stayed shut
+    /// once you'd finished a verse. Retrying costs nothing when focus lands on the
+    /// first attempt (the guard below stops immediately).
+    private func focusInput(retriesLeft: Int = 4) {
         studyMode == .submit ? (submitFocus = .title) : (isInputFocused = true)
+        guard retriesLeft > 0 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+            // Left review mode or finished the card while we waited — leave it alone.
+            guard vm.isReviewMode, !vm.isCardComplete else { return }
+            let landed = studyMode == .submit ? (submitFocus != nil) : isInputFocused
+            if !landed { focusInput(retriesLeft: retriesLeft - 1) }
+        }
     }
 
     private func toggleSpeech() {

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -248,9 +248,11 @@ struct CardStudyView: View {
         }
         .background(Color(.systemGroupedBackground))
         .undoToast($undoToastState)
+        .speechErrorAlert(speech)
         .onChange(of: vm.isReviewMode) { _, reviewing in handleReviewModeChange(reviewing) }
         .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
+            vm.resetDictation()
             if speech.isListening { speech.stopListening() }
             if isScrubbing {
                 if submitFocus != nil { submitFocus = .title }
@@ -260,9 +262,15 @@ struct CardStudyView: View {
         }
         .onChange(of: speech.transcript) { _, text in
             guard speech.isListening else { return }
-            switch speechTarget {
-            case .title: vm.titleInput = text
-            case .verse: vm.verseInput = text
+            // Entire Verse collects the transcript as free text to submit; the two
+            // typing modes match it word by word against the hidden verse instead.
+            if studyMode == .submit {
+                switch speechTarget {
+                case .title: vm.titleInput = text
+                case .verse: vm.verseInput = text
+                }
+            } else {
+                vm.processDictation(text)
             }
         }
         .onChange(of: submitFocus) { _, newFocus in
@@ -741,7 +749,9 @@ struct CardStudyView: View {
                 refocusIfNeeded()
             }
         } label: {
-            Label("Mark as Complete", systemImage: "checkmark.circle.fill")
+            // Short label: it shares the row with "Try Again", and the checkmark
+            // plus its position on the cursor verse already carry the meaning.
+            Label("Complete", systemImage: "checkmark.circle.fill")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity).padding(.vertical, 12)
@@ -815,8 +825,7 @@ struct CardStudyView: View {
     private var inputField: some View {
         HStack(spacing: 10) {
             HStack(spacing: 10) {
-                Image(systemName: "character.cursor.ibeam")
-                    .foregroundColor(.secondary).font(.system(size: 16))
+                dictationButton
 
                 TextField(studyMode.inputPlaceholder, text: $vm.inputText)
                     .font(.system(size: 17))
@@ -851,6 +860,27 @@ struct CardStudyView: View {
 
             hintButton
         }
+    }
+
+    /// Speak the verse instead of typing it. Takes the slot the decorative
+    /// "character.cursor.ibeam" glyph used to occupy inside the text field: the
+    /// control row (peek, field, hint) has no width left for a fourth button, and
+    /// that glyph was ornament. Entire Verse mode keeps its own larger mic in
+    /// `submitControls` — this field only exists in the two typing modes.
+    ///
+    /// A `Button`, so pressing it doesn't resign the field's first responder and
+    /// dismiss the keyboard mid-verse.
+    private var dictationButton: some View {
+        Button { toggleSpeech() } label: {
+            Image(systemName: speech.isListening ? "mic.fill" : "mic")
+                .font(.system(size: 16))
+                .foregroundColor(speech.isListening ? .red : .secondary)
+                .contentTransition(.symbolEffect(.replace))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(speech.isListening ? "Stop dictation" : "Dictate verse")
     }
 
     /// Reveals the next hidden word (verse first, then title). Wrapped in a
@@ -998,6 +1028,9 @@ struct CardStudyView: View {
             speech.stopListening()
         } else {
             speechTarget = submitFocus ?? .title
+            // The recognizer restarts its transcript from empty, so the
+            // already-matched count has to start over with it.
+            vm.resetDictation()
             speech.startListening()
         }
     }

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -254,6 +254,41 @@ final class CardStudyViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Dictation
+
+    /// How many words of the running transcript have already been matched. The
+    /// recognizer re-emits the *whole* transcript on every partial result, so
+    /// without this each update would replay the verse from the beginning.
+    private var spokenWordsConsumed = 0
+
+    /// Drops dictation bookkeeping — call when a listening session starts or the
+    /// card changes, both of which restart the transcript.
+    func resetDictation() { spokenWordsConsumed = 0 }
+
+    /// Feeds a dictation transcript through the same reveal path typing uses: each
+    /// newly spoken word that matches the next hidden word reveals it, crossing from
+    /// title to verse exactly as typing does.
+    ///
+    /// Only words past the ones already handled are considered, and the count never
+    /// rewinds. Speech arrives as a growing and occasionally *revised* transcript,
+    /// and revealing is one-way — re-matching a revised prefix would double-advance
+    /// the verse. A spoken word that doesn't match is consumed rather than retried,
+    /// so one misheard word can't wedge the card.
+    func processDictation(_ transcript: String) {
+        let spoken = transcript.split(whereSeparator: { $0 == " " || $0.isNewline }).map(String.init)
+        guard spoken.count > spokenWordsConsumed else { return }
+        for word in spoken[spokenWordsConsumed...] {
+            guard let verse = currentVerse else { break }
+            let words    = sectionWords(activeSection, in: verse)
+            let revealed = revealedCount(for: verse.id, section: activeSection)
+            guard revealed < words.count else { break }
+            if DiffEngine.normalizedMatch(word, words[revealed]) {
+                advance(verse: verse, sectionWords: words, revealed: revealed)
+            }
+        }
+        spokenWordsConsumed = spoken.count
+    }
+
     // MARK: - Hint
 
     /// Reveals the next hidden word as a hint — in the section the user is

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -116,20 +116,28 @@ final class CardStudyViewModel: ObservableObject {
         }
     }
 
+    /// Flips between the pack's own order and a random one.
+    ///
+    /// Reordering is purely presentational: every bit of progress (revealed word
+    /// counts, submitted answers) is keyed by verse **id**, not by position, so
+    /// shuffling can't invalidate any of it. Wiping those dictionaries here meant
+    /// toggling shuffle off — the natural "put it back how it was" gesture — threw
+    /// away the whole session. Keep the progress, and stay parked on the verse the
+    /// user is looking at rather than snapping back to the top.
     func toggleShuffle() {
+        let anchorId = currentVerse?.id
         var t = Transaction(); t.disablesAnimations = true
         withTransaction(t) {
-            isShuffled            = !isShuffled
-            verses                = isShuffled ? originalVerses.shuffled() : originalVerses
-            currentIndex          = 0
-            titleRevealedCounts   = [:]
-            verseRevealedCounts   = [:]
-            submitResults         = [:]
+            isShuffled = !isShuffled
+            verses     = isShuffled ? originalVerses.shuffled() : originalVerses
+            currentIndex = anchorId.flatMap { id in verses.firstIndex { $0.id == id } } ?? 0
             inputText  = ""
             titleInput = ""
             verseInput = ""
-            activeSection = .title
         }
+        // `currentIndex`'s didSet only re-points the highlight when the index
+        // actually changed — the anchor verse may well land on the same index.
+        syncActiveSection()
     }
 
     /// Clears all text inputs. Call when the user navigates to a new card.

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -167,7 +167,8 @@ struct FlashcardView: View {
                          words: verse.verseWords,
                          revealed: verseRevealedCount,
                          cardWidth: cardWidth,
-                         font: .system(size: verseSize, design: .serif))
+                         font: .system(size: verseSize, design: .serif),
+                         fillsRemainingSpace: true)
 
             if !hardMode && activeRevealed < activeWords.count {
                 Spacer().frame(height: 10)
@@ -178,8 +179,13 @@ struct FlashcardView: View {
 
     // MARK: - Section View
 
+    /// - Parameter fillsRemainingSpace: give this section the card's leftover
+    ///   vertical space as tap target. Set on the verse (the last section), so the
+    ///   empty area beneath it — which visually reads as part of the verse — selects
+    ///   the verse instead of doing nothing.
     @ViewBuilder
-    private func sectionView(_ section: CardSection, words: [String], revealed: Int, cardWidth: CGFloat, font: Font) -> some View {
+    private func sectionView(_ section: CardSection, words: [String], revealed: Int, cardWidth: CGFloat, font: Font,
+                             fillsRemainingSpace: Bool = false) -> some View {
         let isActive   = (activeSection == section)
         let isComplete = revealed >= words.count && !words.isEmpty
         let verseGap = verseLineSpacing(cardWidth: cardWidth)
@@ -211,6 +217,15 @@ struct FlashcardView: View {
                     .offset(x: -6)
             }
         }
+        // Stretch the tap target past the glyphs: full card width, and for the verse
+        // all the way down through the blank space below it. Aiming at the text
+        // itself was a needle-thread — in hard mode a whole section is the single
+        // word "Verse", leaving most of the card dead to taps. Applied *after* the
+        // active-section overlay so the accent bar still hugs the text rather than
+        // running the height of the card.
+        .frame(maxWidth: .infinity,
+               maxHeight: fillsRemainingSpace ? .infinity : nil,
+               alignment: .topLeading)
         .contentShape(Rectangle())
         // A finished section (all words revealed) can't be re-focused — tapping it
         // shouldn't pull the keyboard off the section you're still working on.

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -74,7 +74,7 @@ struct FlashcardView: View {
             HStack(spacing: 4) {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 11, weight: .bold))
-                Text("Mark as Complete")
+                Text("Complete")
                     .font(.system(size: 11, weight: .bold))
             }
             .foregroundStyle(.white)

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -19,35 +19,6 @@ struct PackListView: View {
 
     private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
 
-    // MARK: - Search Result Model
-
-    struct VerseSearchResult: Identifiable {
-        var id: String { "\(pack.name)-\(verse.id)" }
-        let verse:      Verse
-        let pack:       Pack
-        let verseIndex: Int
-    }
-
-    // MARK: - Search Logic
-
-    private var searchResults: [VerseSearchResult] {
-        guard !searchText.isEmpty else { return [] }
-        let query = searchText.lowercased()
-        var results: [VerseSearchResult] = []
-        for pack in visiblePacks {
-            for (index, verse) in pack.verses.enumerated() {
-                let ref = "\(verse.book) \(verse.reference)".lowercased()
-                if ref.contains(query)
-                    || verse.title.lowercased().contains(query)
-                    || verse.verse.lowercased().contains(query) {
-                    results.append(VerseSearchResult(verse: verse, pack: pack, verseIndex: index))
-                    if results.count == 25 { return results }
-                }
-            }
-        }
-        return results
-    }
-
     // MARK: - Body
 
     var body: some View {
@@ -72,7 +43,11 @@ struct PackListView: View {
                     .padding(.vertical, 12)
                 }
             } else {
-                searchResultsView
+                VerseSearchResultsList(
+                    query:   searchText,
+                    results: VerseSearch.results(for: searchText, in: visiblePacks),
+                    onSelect: { searchSelected = $0 }
+                )
             }
         }
         .animation(nil, value: searchText.isEmpty)
@@ -114,66 +89,6 @@ struct PackListView: View {
         }
     }
 
-    // MARK: - Search Results View
-
-    private var searchResultsView: some View {
-        GeometryReader { geo in
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    if searchResults.isEmpty {
-                        ContentUnavailableView {
-                            Label("No Results", systemImage: "magnifyingglass")
-                        } description: {
-                            Text("No verses match \u{201C}\(searchText)\u{201D}.")
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.top, 48)
-                    } else {
-                        ForEach(Array(searchResults.enumerated()), id: \.element.id) { _, result in
-                            VStack(spacing: 0) {
-                                Button {
-                                    searchSelected = result
-                                } label: {
-                                    HStack(spacing: 14) {
-                                        VStack(alignment: .leading, spacing: 3) {
-                                            Text("\(result.verse.book) \(result.verse.reference)")
-                                                .font(.system(size: 15, weight: .semibold))
-                                                .foregroundStyle(.primary)
-                                            Text(result.verse.title)
-                                                .font(.system(size: 13, weight: .medium))
-                                                .foregroundStyle(.primary)
-                                            Text(result.verse.verse)
-                                                .font(.system(size: 12))
-                                                .foregroundStyle(.secondary)
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                                .multilineTextAlignment(.leading)
-                                            Text(result.pack.name)
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundStyle(.tertiary)
-                                        }
-                                        Spacer()
-                                        Image(systemName: "chevron.right")
-                                            .font(.system(size: 12, weight: .semibold))
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    .padding(.horizontal, AppLayout.screenMargin)
-                                    .padding(.vertical, 11)
-                                    .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.plain)
-                                Divider().padding(.leading, 16)
-                            }
-                        }
-                    }
-                }
-                .background(Color(.systemBackground))
-                .clipShape(RoundedRectangle(cornerRadius: AppLayout.cardRadius, style: .continuous))
-                .padding(.horizontal, AppLayout.screenMargin)
-                .padding(.top, 8)
-            }
-        }
-    }
 }
 
 // MARK: - Pack Cover

--- a/scripture memory/Views/SRSDashboardView.swift
+++ b/scripture memory/Views/SRSDashboardView.swift
@@ -19,17 +19,20 @@ struct SRSDashboardView: View {
 
     @State private var cover: ActiveCover?
     @State private var showPinPicker = false
+    @State private var searchText    = ""
 
-    /// One full-screen presentation at a time — review session OR the linear
-    /// learning session. (Two separate `.fullScreenCover` modifiers on one view
-    /// conflict in SwiftUI, so they're unified here.)
+    /// One full-screen presentation at a time — review session, the linear learning
+    /// session, or a verse opened from search. (Two separate `.fullScreenCover`
+    /// modifiers on one view conflict in SwiftUI, so they're unified here.)
     private enum ActiveCover: Identifiable {
         case review(TestSession)
         case learning(forceCurrent: Bool)
+        case verse(VerseSearchResult)
         var id: String {
             switch self {
             case .review(let s):       return "review-\(s.id)"
             case .learning(let force): return force ? "learning-current" : "learning"
+            case .verse(let r):        return "verse-\(r.id)"
             }
         }
     }
@@ -95,6 +98,44 @@ struct SRSDashboardView: View {
     }
 
     var body: some View {
+        Group {
+            if searchText.isEmpty {
+                dashboard
+            } else {
+                VerseSearchResultsList(
+                    query:   searchText,
+                    results: VerseSearch.results(for: searchText, in: packs),
+                    onSelect: { cover = .verse($0) }
+                )
+            }
+        }
+        // Swapping the whole screen shouldn't animate — matches Packs.
+        .animation(nil, value: searchText.isEmpty)
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Home")
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Search verses"
+        )
+        .fullScreenCover(item: $cover) { c in
+            switch c {
+            case .review(let s): TestSessionView(session: s, onSessionEnded: { cover = nil })
+            case .learning(let force): learningSession(forceCurrent: force)
+            case .verse(let r):
+                // Read mode in its own pack, like tapping the verse from Packs.
+                NavigationStack {
+                    CardStudyView(packName: r.pack.name, verses: r.pack.verses, initialIndex: r.verseIndex)
+                        .toolbar(.hidden, for: .navigationBar)
+                }
+            }
+        }
+        .sheet(isPresented: $showPinPicker) {
+            PinVersePicker(packs: packs, pinnedKey: learning.pinnedKey) { learning.pin($0) }
+        }
+    }
+
+    private var dashboard: some View {
         ScrollView {
             VStack(spacing: Layout.sectionSpacing) {
                 streakCard
@@ -113,17 +154,6 @@ struct SRSDashboardView: View {
             .padding(.horizontal, Layout.edgeMargin)
             .padding(.top, 8)
             .padding(.bottom, 24)
-        }
-        .background(Color(.systemGroupedBackground))
-        .navigationTitle("Home")
-        .fullScreenCover(item: $cover) { c in
-            switch c {
-            case .review(let s): TestSessionView(session: s, onSessionEnded: { cover = nil })
-            case .learning(let force): learningSession(forceCurrent: force)
-            }
-        }
-        .sheet(isPresented: $showPinPicker) {
-            PinVersePicker(packs: packs, pinnedKey: learning.pinnedKey) { learning.pin($0) }
         }
     }
 

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -24,6 +24,8 @@ struct TestSessionView: View {
     /// that pulls the grade suggestion down to "Again".
     @State private var peekedVerseIds:       Set<Int> = []
     @State private var showVerseSelector     = false
+    /// Pending "marked complete" undo prompt.
+    @State private var undoToastState:       UndoToastState?
 
     // SRS session bookkeeping. Lets the user swipe back to an already-graded
     // card and change the grade without compounding (regrade computes from
@@ -111,6 +113,7 @@ struct TestSessionView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
+        .undoToast($undoToastState)
         .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
             pendingGrade = nil   // each card starts from its own suggested difficulty
@@ -624,6 +627,11 @@ struct TestSessionView: View {
         Button {
             learning.markLearnt(verse)
             HapticEngine.success()
+            // One tap, right under the card, and it advances the learning cursor —
+            // give it a moment's grace before it's final.
+            undoToastState = UndoToastState(message: "Marked as complete") {
+                learning.unmarkLearnt(verse)
+            }
         } label: {
             Label("Mark as Complete", systemImage: "checkmark.circle.fill")
                 .font(.system(size: 16, weight: .semibold))

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -114,8 +114,10 @@ struct TestSessionView: View {
         }
         .background(Color(.systemGroupedBackground))
         .undoToast($undoToastState)
+        .speechErrorAlert(speech)
         .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
+            vm.resetDictation()
             pendingGrade = nil   // each card starts from its own suggested difficulty
             if speech.isListening { speech.stopListening() }
             if isScrubbing {
@@ -129,9 +131,15 @@ struct TestSessionView: View {
         }
         .onChange(of: speech.transcript) { _, text in
             guard speech.isListening else { return }
-            switch speechTarget {
-            case .title: vm.titleInput = text
-            case .verse: vm.verseInput = text
+            // Entire Verse collects the transcript as free text to submit; the two
+            // typing modes match it word by word against the hidden verse instead.
+            if studyMode == .submit {
+                switch speechTarget {
+                case .title: vm.titleInput = text
+                case .verse: vm.verseInput = text
+                }
+            } else {
+                vm.processDictation(text)
             }
         }
         .onChange(of: isPeeking) { _, peeking in
@@ -633,7 +641,7 @@ struct TestSessionView: View {
                 learning.unmarkLearnt(verse)
             }
         } label: {
-            Label("Mark as Complete", systemImage: "checkmark.circle.fill")
+            Label("Complete", systemImage: "checkmark.circle.fill")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity).padding(.vertical, 12)
@@ -790,8 +798,7 @@ struct TestSessionView: View {
     private var inputField: some View {
         HStack(spacing: 10) {
             HStack(spacing: 10) {
-                Image(systemName: "character.cursor.ibeam")
-                    .foregroundColor(.secondary).font(.system(size: 16))
+                dictationButton
 
                 TextField(studyMode.inputPlaceholder, text: $vm.inputText)
                     .font(.system(size: 17))
@@ -833,6 +840,27 @@ struct TestSessionView: View {
 
             hintButton
         }
+    }
+
+    /// Speak the verse instead of typing it. Takes the slot the decorative
+    /// "character.cursor.ibeam" glyph used to occupy inside the text field: the
+    /// control row (peek, field, hint) has no width left for a fourth button, and
+    /// that glyph was ornament. Entire Verse mode keeps its own larger mic in
+    /// `submitControls` — this field only exists in the two typing modes.
+    ///
+    /// A `Button`, so pressing it doesn't resign the field's first responder and
+    /// dismiss the keyboard mid-verse.
+    private var dictationButton: some View {
+        Button { toggleSpeech() } label: {
+            Image(systemName: speech.isListening ? "mic.fill" : "mic")
+                .font(.system(size: 16))
+                .foregroundColor(speech.isListening ? .red : .secondary)
+                .contentTransition(.symbolEffect(.replace))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(speech.isListening ? "Stop dictation" : "Dictate verse")
     }
 
     /// Reveals the next hidden word (verse first, then title). Wrapped in a
@@ -973,6 +1001,9 @@ struct TestSessionView: View {
             speech.stopListening()
         } else {
             speechTarget = submitFocus ?? .title
+            // The recognizer restarts its transcript from empty, so the
+            // already-matched count has to start over with it.
+            vm.resetDictation()
             speech.startListening()
         }
     }

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -799,18 +799,15 @@ struct TestSessionView: View {
                             if correct {
                                 HapticEngine.light()
                             } else {
-                                // A wrong first letter is a genuine recall miss. Count it
-                                // so the SRS grade suggestion reflects the struggle — these
-                                // modes have no diff to score, unlike submit mode, so without
-                                // this every card looks perfect and is always suggested "Good".
-                                vm.recordMistake()
+                                // Deliberately unscored — a mistyped letter is as likely a
+                                // fat finger as a memory lapse. Same for full word below.
+                                // See `TestSessionViewModel.recordMistake`.
                                 HapticEngine.error(); triggerShake($shakeOffset)
                             }
                         case .fullWord:
                             if vm.processFullWordInput(newValue) {
                                 HapticEngine.light()
                             } else if newValue.hasSuffix(" ") {
-                                vm.recordMistake()
                                 HapticEngine.error(); triggerShake($shakeOffset)
                             }
                         case .submit:
@@ -944,8 +941,23 @@ struct TestSessionView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { focusInput() }
     }
 
-    private func focusInput() {
+    /// Puts the keyboard back on the answer input, re-arming until it actually takes.
+    ///
+    /// Completing a card unmounts the input field (grading buttons take its place),
+    /// so on the *next* card the field is a freshly inserted view. A lone
+    /// `isInputFocused = true` fired while that insertion is still animating in gets
+    /// dropped on the floor — which is why the keyboard stayed shut for the rest of
+    /// the session once you finished your first verse. Retrying costs nothing when
+    /// focus lands on the first attempt (the guard below stops immediately).
+    private func focusInput(retriesLeft: Int = 4) {
         studyMode == .submit ? (submitFocus = .title) : (isInputFocused = true)
+        guard retriesLeft > 0 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+            // Card finished or session over while we waited — leave the keyboard alone.
+            guard !vm.isCardComplete, !vm.isSessionComplete else { return }
+            let landed = studyMode == .submit ? (submitFocus != nil) : isInputFocused
+            if !landed { focusInput(retriesLeft: retriesLeft - 1) }
+        }
     }
 
     private func toggleSpeech() {
@@ -988,31 +1000,21 @@ struct TestSessionView: View {
         pendingGrade ?? sessionGrades[verse.id] ?? suggestedGradeFor(verse)
     }
 
-    /// Slips tolerated in the typo-prone full-word mode before the suggestion drops
-    /// from "Good" to "Hard" — keystroke fumbles shouldn't be read as poor recall.
-    private static let typingMistakeTolerance = 2
-
-    /// The algorithm's recommended grade — shown with the "Suggested" tag. Returns
-    /// `nil` when there's no reliable recommendation: first-letter mode is so
-    /// keystroke-heavy that a wrong letter is common, so the mistake count is a poor
-    /// signal — we don't suggest a grade and leave the choice to the user.
+    /// The algorithm's recommended grade — shown with the "Suggested" tag.
+    ///
+    /// Only Entire Verse mode produces one, because it's the only mode that scores an
+    /// answer: it diffs what you actually wrote against the verse. The two typing
+    /// modes reveal the text a word at a time and no longer count slips at all (a
+    /// mistyped letter says more about the keyboard than about recall — see
+    /// `TestSessionViewModel.recordMistake`), so there's nothing left to base a
+    /// recommendation on and the choice is the user's.
     private func suggestedGradeFor(_ verse: Verse) -> SRSGrade? {
-        guard studyMode != .firstLetter else { return nil }
+        guard studyMode == .submit else { return nil }
         // Peeking at the answer is a failed recall — never suggest better than Again.
         if peekedVerseIds.contains(verse.id) { return .again }
 
-        let mistakes = vm.mistakes(for: verse.id)
-        switch studyMode {
-        case .submit:
-            let allCorrect = vm.submitResults[verse.id]?.isAllCorrect == true
-            return suggestedGrade(isAllCorrect: allCorrect, mistakes: mistakes)
-        case .fullWord:
-            // Completion already means every word was eventually correct; only the
-            // number of slips matters, with leeway before counting it as a struggle.
-            return mistakes <= Self.typingMistakeTolerance ? .good : .hard
-        case .firstLetter:
-            return nil   // handled by the guard above; keeps the switch exhaustive
-        }
+        let allCorrect = vm.submitResults[verse.id]?.isAllCorrect == true
+        return suggestedGrade(isAllCorrect: allCorrect, mistakes: vm.mistakes(for: verse.id))
     }
 
     /// Ends the session. In SRS, any card that's finished but still ungraded — e.g.

--- a/scripture memory/Views/TestSessionViewModel.swift
+++ b/scripture memory/Views/TestSessionViewModel.swift
@@ -237,6 +237,41 @@ final class TestSessionViewModel: ObservableObject {
         verseInput = ""
     }
 
+    // MARK: - Dictation
+
+    /// How many words of the running transcript have already been matched. The
+    /// recognizer re-emits the *whole* transcript on every partial result, so
+    /// without this each update would replay the verse from the beginning.
+    private var spokenWordsConsumed = 0
+
+    /// Drops dictation bookkeeping — call when a listening session starts or the
+    /// card changes, both of which restart the transcript.
+    func resetDictation() { spokenWordsConsumed = 0 }
+
+    /// Feeds a dictation transcript through the same reveal path typing uses: each
+    /// newly spoken word that matches the next hidden word reveals it, crossing from
+    /// title to verse exactly as typing does.
+    ///
+    /// Only words past the ones already handled are considered, and the count never
+    /// rewinds. Speech arrives as a growing and occasionally *revised* transcript,
+    /// and revealing is one-way — re-matching a revised prefix would double-advance
+    /// the verse. A spoken word that doesn't match is consumed rather than retried,
+    /// so one misheard word can't wedge the card.
+    func processDictation(_ transcript: String) {
+        let spoken = transcript.split(whereSeparator: { $0 == " " || $0.isNewline }).map(String.init)
+        guard spoken.count > spokenWordsConsumed else { return }
+        for word in spoken[spokenWordsConsumed...] {
+            guard let verse = currentVerse else { break }
+            let words    = sectionWords(activeSection, in: verse)
+            let revealed = revealedCount(for: verse.id, section: activeSection)
+            guard revealed < words.count else { break }
+            if DiffEngine.normalizedMatch(word, words[revealed]) {
+                advance(verse: verse, sectionWords: words, revealed: revealed)
+            }
+        }
+        spokenWordsConsumed = spoken.count
+    }
+
     // MARK: - Hint
 
     /// Reveals the next hidden word as a hint — in the section the user is

--- a/scripture memory/Views/TestSessionViewModel.swift
+++ b/scripture memory/Views/TestSessionViewModel.swift
@@ -135,9 +135,16 @@ final class TestSessionViewModel: ObservableObject {
             : verseRevealedCounts[verseId, default: 0]
     }
 
-    // MARK: - Mistake Tracking (submit mode only)
+    // MARK: - Mistake Tracking
 
+    /// Only Entire Verse mode scores. The two typing modes reveal the text a word at
+    /// a time against a phone keyboard, so a fat-fingered neighbouring key reads as a
+    /// recall miss — the count measures typing accuracy far more than memory, and it
+    /// handed people a negative for slips they never made. Nothing is tracked in
+    /// those modes: no score, and no input to the SRS grade suggestion (which
+    /// declines to suggest anything there — see `suggestedGradeFor`).
     func recordMistake() {
+        guard studyMode == .submit else { return }
         guard let verse = currentVerse else { return }
         let current = mistakeCounts[verse.id, default: 0]
         guard current < 5 else { return }

--- a/scripture memory/Views/TestSetupView.swift
+++ b/scripture memory/Views/TestSetupView.swift
@@ -28,6 +28,12 @@ struct TestSetupView: View {
     @State private var savedSession:      TestSession? = nil
     @State private var showOverwriteAlert = false
 
+    /// Typed-entry state for the card count. Stepping one at a time is fine for a
+    /// nudge but painful for "make it 40", so the number itself is tappable and
+    /// swaps to a number-pad field.
+    @State private var countDraft = ""
+    @FocusState private var countFieldFocused: Bool
+
     private static let savedSessionKey = "lastTestSessionVerseIds"
     private static let quizCountKey    = "reviewSetupQuizCount"
 
@@ -293,10 +299,7 @@ struct TestSetupView: View {
                     .opacity(clampedCount <= 1 ? 0.35 : 1)
                     .accessibilityLabel("Fewer cards to quiz")
 
-                    Text("\(clampedCount)")
-                        .font(.system(size: 22, weight: .bold, design: .monospaced))
-                        .frame(minWidth: 36)
-                        .accessibilityLabel("\(clampedCount) cards to quiz")
+                    countField
 
                     Button {
                         if quizCount < selectedCount { quizCount += 1 }
@@ -336,7 +339,77 @@ struct TestSetupView: View {
         .overlay(Rectangle().fill(Color(.separator).opacity(0.4)).frame(height: 0.5), alignment: .top)
     }
 
+    /// The card count, tappable to type a value directly instead of stepping there
+    /// one press at a time. Always a `TextField` (rather than a label that swaps for
+    /// one on tap) so tapping it focuses an already-mounted responder and the keypad
+    /// opens on the first tap. While unfocused it renders the clamped count, so it
+    /// still tracks the +/- buttons and the selection.
+    private var countField: some View {
+        TextField("", text: $countDraft)
+            .keyboardType(.numberPad)
+            .multilineTextAlignment(.center)
+            .font(.system(size: 22, weight: .bold, design: .monospaced))
+            .focused($countFieldFocused)
+            .frame(minWidth: 44)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            // Sanitise and commit on every keystroke, so what the field shows is
+            // always exactly what Start will use.
+            //
+            // Two things this guards against. `.numberPad` only limits what the
+            // on-screen keyboard *offers* — a hardware keyboard, dictation or paste
+            // can still put letters in, so non-digits are stripped as they arrive.
+            // And committing only when editing ended wasn't enough: tapping a pack
+            // row doesn't resign focus, so the field could sit there reading "999"
+            // while the session quietly still used the old number.
+            .onChange(of: countDraft) { _, newValue in
+                var digits = String(newValue.filter(\.isNumber).prefix(4))
+                if let typed = Int(digits) {
+                    let clamped = max(1, min(typed, max(1, selectedCount)))
+                    // Rewrite the field too, so it can never display a count that's
+                    // out of range for the current selection.
+                    if clamped != typed { digits = "\(clamped)" }
+                    quizCount = clamped
+                }
+                // An empty field mid-edit is fine — `commitCountEdit` restores a
+                // valid number when focus leaves.
+                if digits != newValue { countDraft = digits }
+            }
+            .onChange(of: countFieldFocused) { _, focused in
+                if focused {
+                    countDraft = ""          // start clean — typing replaces, not appends
+                } else {
+                    commitCountEdit()
+                }
+            }
+            .onChange(of: clampedCount) { _, newValue in
+                // +/- taps and selection changes while not editing.
+                if !countFieldFocused { countDraft = "\(newValue)" }
+            }
+            .onAppear { countDraft = "\(clampedCount)" }
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") { countFieldFocused = false }
+                }
+            }
+            .accessibilityLabel("Cards to quiz")
+            .accessibilityValue("\(clampedCount)")
+            .accessibilityHint("Tap to type a number")
+    }
+
     // MARK: - Actions
+
+    /// Applies a typed card count, clamped to 1...selected. An empty or unparseable
+    /// draft (tapped in, then out) falls back to the count already in effect.
+    private func commitCountEdit() {
+        let digits = countDraft.filter(\.isNumber)
+        if let typed = Int(digits), typed >= 1 {
+            quizCount = max(1, min(typed, max(1, selectedCount)))
+        }
+        countDraft = "\(clampedCount)"
+    }
 
     private func launchNewSession() {
         // Wipe any stale progress so the new session starts clean

--- a/scripture memory/Views/UndoToast.swift
+++ b/scripture memory/Views/UndoToast.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+// MARK: - State
+
+/// A pending undo prompt. `id` gives each toast its own view identity, so raising
+/// a second one while the first is still on screen re-arms the dismiss timer
+/// instead of inheriting the old one's remaining time.
+struct UndoToastState: Identifiable {
+    let id = UUID()
+    let message: String
+    let undo: () -> Void
+}
+
+// MARK: - Toast
+
+/// Transient confirmation for an action that is easy to fire by accident and
+/// fiddly to reverse by hand — marking a verse complete, which also advances the
+/// learning cursor. Confirms what happened, offers one-tap Undo, and leaves on
+/// its own.
+struct UndoToast: View {
+    let message: String
+    let onUndo: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Color.green)
+
+            Text(message)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+
+            Spacer(minLength: 6)
+
+            Button(action: onUndo) {
+                Text("Undo")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                    // Padded to a comfortable target — the toast is short-lived, so
+                    // a miss costs the user the whole affordance.
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 2)
+        .padding(.vertical, 6)
+        .background(
+            Capsule(style: .continuous)
+                .fill(.regularMaterial)
+                .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 4)
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .strokeBorder(Color(.separator).opacity(0.35), lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .contain)
+    }
+}
+
+// MARK: - Presentation
+
+extension View {
+
+    /// How long an undo stays available. Long enough to notice and react to,
+    /// short enough not to sit on top of the controls underneath it.
+    private static var undoToastSeconds: Double { 5 }
+
+    /// Floats `toast` over the bottom edge until it's undone or times out.
+    ///
+    /// Attach to the screen's root so the toast clears the bottom controls it sits
+    /// above. Tapping Undo runs the action and dismisses immediately.
+    func undoToast(_ toast: Binding<UndoToastState?>) -> some View {
+        overlay(alignment: .bottom) {
+            if let state = toast.wrappedValue {
+                UndoToast(message: state.message) {
+                    state.undo()
+                    HapticEngine.light()
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.9)) {
+                        toast.wrappedValue = nil
+                    }
+                }
+                .padding(.horizontal, AppLayout.screenMargin)
+                .padding(.bottom, 10)
+                .id(state.id)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                // Keyed on `id` so replacing a visible toast restarts the countdown.
+                // Cancellation (view removed, or a newer toast) must not dismiss the
+                // replacement, hence the explicit cancellation check.
+                .task(id: state.id) {
+                    try? await Task.sleep(for: .seconds(Self.undoToastSeconds))
+                    guard !Task.isCancelled else { return }
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.9)) {
+                        toast.wrappedValue = nil
+                    }
+                }
+            }
+        }
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: toast.wrappedValue?.id)
+    }
+}

--- a/scripture memory/Views/VerseSearch.swift
+++ b/scripture memory/Views/VerseSearch.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+// MARK: - Result
+
+/// A verse matched by a search, carrying enough context to open it in place:
+/// which pack it lives in and its index there.
+struct VerseSearchResult: Identifiable {
+    var id: String { "\(pack.name)-\(verse.id)" }
+    let verse:      Verse
+    let pack:       Pack
+    let verseIndex: Int
+}
+
+// MARK: - Matching
+
+enum VerseSearch {
+
+    /// Cap on rows returned. A short query like "the" matches most of the library,
+    /// and this runs on every keystroke — without a ceiling the whole collection is
+    /// walked and rendered for a result nobody scrolls to.
+    static let resultLimit = 25
+
+    /// Case-insensitive substring match over reference, title and verse body,
+    /// scanned in pack order so results stay in the same sequence the user browses.
+    static func results(for query: String, in packs: [Pack]) -> [VerseSearchResult] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return [] }
+
+        var results: [VerseSearchResult] = []
+        for pack in packs {
+            for (index, verse) in pack.verses.enumerated() {
+                let ref = "\(verse.book) \(verse.reference)".lowercased()
+                if ref.contains(q)
+                    || verse.title.lowercased().contains(q)
+                    || verse.verse.lowercased().contains(q) {
+                    results.append(VerseSearchResult(verse: verse, pack: pack, verseIndex: index))
+                    if results.count == resultLimit { return results }
+                }
+            }
+        }
+        return results
+    }
+}
+
+// MARK: - Results List
+
+/// The verse-search results list, shared by Home and Packs so both searches look
+/// and behave identically.
+struct VerseSearchResultsList: View {
+    let query:    String
+    let results:  [VerseSearchResult]
+    let onSelect: (VerseSearchResult) -> Void
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if results.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Results", systemImage: "magnifyingglass")
+                    } description: {
+                        Text("No verses match \u{201C}\(query)\u{201D}.")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 48)
+                } else {
+                    ForEach(results) { result in
+                        VStack(spacing: 0) {
+                            Button { onSelect(result) } label: { row(result) }
+                                .buttonStyle(.plain)
+                            Divider().padding(.leading, 16)
+                        }
+                    }
+                }
+            }
+            .background(Color(.systemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: AppLayout.cardRadius, style: .continuous))
+            .padding(.horizontal, AppLayout.screenMargin)
+            .padding(.top, 8)
+        }
+    }
+
+    private func row(_ result: VerseSearchResult) -> some View {
+        HStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("\(result.verse.book) \(result.verse.reference)")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text(result.verse.title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
+                Text(result.verse.verse)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .multilineTextAlignment(.leading)
+                Text(result.pack.name)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, AppLayout.screenMargin)
+        .padding(.vertical, 11)
+        .contentShape(Rectangle())
+    }
+}


### PR DESCRIPTION
Three commits' worth of review-mode fixes, plus the follow-on requests.

## Review mode

- **Keyboard returns on the next verse.** Completing a card unmounts the input field, so the single `isInputFocused = true` fired afterwards landed mid-insertion and was dropped — leaving the keyboard shut for the rest of the session. `focusInput` re-arms until focus takes.
- **The whole card is a tap target.** Section hit areas span the full card width, and the verse claims the blank space beneath it — in hard mode a section collapses to the single word "Verse", leaving most of the card dead.
- **Only Entire Verse scores.** Both typing modes reveal a word at a time against a phone keyboard, so a fat-fingered key read as a recall miss and handed people a negative for slips they never made. With no signal left, those modes no longer offer an SRS grade suggestion either.
- **Shuffle no longer discards progress.** Reveal counts and submitted answers are keyed by verse id, so reordering can't invalidate them; toggling shuffle off used to wipe the session.
- **Peek reveals instantly.** The press came from a `DragGesture` sitting behind UIKit's is-this-a-scroll arbitration, which inside the card's gesture stack felt like a required long-press. A `ButtonStyle`'s `isPressed` has no such wait.
- **"Mark as Complete" only on the cursor verse.** It also fired whenever the `onMarkLearnt` hook was supplied, and that hook is set for a whole Continue-Learning session — so every card offered it, including already-learnt verses, where it was a no-op that displaced the Next button.
- **Next replaces the "Complete!" label**, and jump-to-current works in review mode (it was gated on the keyboard being down, which review never satisfies).

## Elsewhere

- **Verse search on Home**, matching Packs. Search logic and result list moved to a shared `VerseSearch.swift` rather than duplicated.
- **Quiz card count is typeable.** Non-digits stripped; value clamped and committed per keystroke, since tapping a pack row doesn't resign focus and a commit-on-blur field could read "999" while the session used the old number.
- **Undo toast** after marking a verse complete (5s).
- **List mode shows "N of M"** again, derived from scroll offset.
- **Dictation in all study modes** — spoken words matched one at a time against the next hidden word.

## Verification

All 78 unit tests pass. Everything above was exercised on the iOS 26.5 simulator.

**One exception:** speech-to-reveal itself is unverified. The simulator has no audio input, so the recognizer errors out immediately. The UI, both permission prompts and the new failure alert were verified; the actual transcription-to-reveal path needs a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)