### PR TITLE
Remote verse catalog, stable card ids, and printed-pack covers

### DIFF
--- a/AppInfo.plist
+++ b/AppInfo.plist
@@ -15,5 +15,17 @@
             </array>
         </dict>
     </array>
+
+    <!-- Remote verse catalog (Supabase). Leave both empty to run entirely off the
+         bundled JSON — the app works exactly as before and never touches the
+         network. The key below is the *publishable* one (`sb_publishable_…`,
+         formerly `anon`): it is designed to ship in clients, and row-level
+         security (see supabase/schema.sql) is what keeps the catalog read-only.
+         Never put the secret key (`sb_secret_…`, formerly `service_role`) here —
+         it bypasses RLS. -->
+    <key>SupabaseURL</key>
+    <string>https://jpyktgyajlvzjtpomvyz.supabase.co</string>
+    <key>SupabaseAnonKey</key>
+    <string>sb_publishable_cZKhdNOAhfy9TZfqszZnig_ayAcWCF1</string>
 </dict>
 </plist>

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
                 "DiffEngine.swift",
                 "DiffResult.swift",
                 "TextTokens.swift",
+                "SpellingVariants.swift",
                 "ReminderPlan.swift",
                 "ScrubberMath.swift",
                 "PackArranger.swift",

--- a/Scripts/seed_supabase.py
+++ b/Scripts/seed_supabase.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Push the bundled verse JSON into Supabase.
+
+Run once to populate an empty project, and again whenever you've changed the
+bundled JSON and want the hosted catalog to match. After seeding, edits are
+normally made in the Supabase Table Editor rather than here.
+
+    SUPABASE_URL=https://<project>.supabase.co \
+    SUPABASE_SERVICE_KEY=<secret key> \
+    python3 Scripts/seed_supabase.py
+
+The secret key (`sb_secret_…`, formerly `service_role`) bypasses row-level
+security, so it must never be committed or shipped in the app — pass it through
+the environment. The app ships the publishable key (`sb_publishable_…`, formerly
+`anon`) instead, which the policies make read-only.
+
+`--check` verifies what's hosted matches what's bundled and writes nothing;
+useful as a CI guard against the two drifting apart.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RESOURCES = REPO / "scripture memory" / "Resources"
+
+EDITIONS = {
+    "NIV84": RESOURCES / "verseData.json",
+    "NIV11": RESOURCES / "verseDataNIV11.json",
+}
+
+
+class Supabase:
+    def __init__(self, url: str, key: str):
+        self.url = url.rstrip("/")
+        self.key = key
+
+    def _request(self, method: str, path: str, body=None, prefer: str | None = None):
+        headers = {
+            "apikey": self.key,
+            "Authorization": f"Bearer {self.key}",
+            "Content-Type": "application/json",
+        }
+        if prefer:
+            headers["Prefer"] = prefer
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(f"{self.url}/rest/v1/{path}", data=data,
+                                     headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=60) as response:
+                raw = response.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace")
+            # PGRST205 is "no such table". Every first run hits it, because the
+            # tables are DDL and this script only moves rows — so say the actual
+            # next step instead of forwarding a schema-cache error.
+            if "PGRST205" in detail:
+                raise SystemExit(
+                    "The catalog tables don't exist yet.\n"
+                    "Create them first: Supabase dashboard -> SQL Editor -> New query,\n"
+                    "paste supabase/schema.sql, Run. Then re-run this script."
+                ) from None
+            if error.code in (401, 403):
+                raise SystemExit(
+                    f"{method} {path} was rejected ({error.code}).\n"
+                    "SUPABASE_SERVICE_KEY must be the *secret* key (sb_secret_...), "
+                    "not the publishable one — writing needs to bypass RLS."
+                ) from None
+            raise SystemExit(f"{method} {path} failed ({error.code}): {detail}") from None
+
+    def select(self, path: str):
+        return self._request("GET", path)
+
+    def insert(self, table: str, rows: list[dict]):
+        # Chunked: a single request carrying every verse in the catalogue is
+        # large enough to hit request-size limits on some plans.
+        out = []
+        for start in range(0, len(rows), 500):
+            got = self._request("POST", table, rows[start:start + 500],
+                                prefer="return=representation")
+            out += got or []
+        return out
+
+    def delete_all(self, table: str):
+        # PostgREST refuses an unfiltered DELETE; `id=gte.0` is the "yes, all of
+        # it" spelling.
+        self._request("DELETE", f"{table}?id=gte.0")
+
+    def rpc(self, function: str, args: dict | None = None):
+        return self._request("POST", f"rpc/{function}", args or {})
+
+
+def bundled_catalog() -> list[tuple[str, dict, int]]:
+    """(edition, pack, sort_index) for every bundled pack."""
+    out = []
+    for edition, path in EDITIONS.items():
+        packs = json.loads(path.read_text())
+        for index, pack in enumerate(packs):
+            out.append((edition, pack, index))
+    return out
+
+
+def cmd_check(client: Supabase) -> int:
+    hosted = client.select("packs?select=edition,name,verses(verse_id)")
+    hosted_counts = {(row["edition"], row["name"]): len(row["verses"]) for row in hosted}
+    bundled_counts = {(edition, pack["name"]): len(pack["verses"])
+                      for edition, pack, _ in bundled_catalog()}
+
+    if hosted_counts == bundled_counts:
+        print(f"in sync: {len(bundled_counts)} packs, "
+              f"{sum(bundled_counts.values())} verses")
+        return 0
+
+    for key in sorted(set(hosted_counts) | set(bundled_counts)):
+        hosted_n = hosted_counts.get(key)
+        bundled_n = bundled_counts.get(key)
+        if hosted_n != bundled_n:
+            print(f"  {key[0]} {key[1]}: hosted={hosted_n} bundled={bundled_n}")
+    return 1
+
+
+def cmd_seed(client: Supabase) -> int:
+    # Replace rather than merge: the bundled JSON is the whole truth here, and a
+    # verse deleted from it has to disappear from the catalog too. `verses`
+    # cascades from `packs`, so one delete clears both.
+    print("clearing existing catalog…")
+    client.delete_all("packs")
+
+    verse_rows: list[dict] = []
+    pack_rows = []
+    for edition, pack, index in bundled_catalog():
+        pack_rows.append({
+            "edition": edition,
+            "name": pack["name"],
+            "color": pack["color"],
+            "accent_text": pack.get("accentText", ""),
+            "sort_index": index,
+        })
+
+    print(f"inserting {len(pack_rows)} packs…")
+    inserted = client.insert("packs", pack_rows)
+    pack_ids = {(row["edition"], row["name"]): row["id"] for row in inserted}
+
+    for edition, pack, _ in bundled_catalog():
+        pack_id = pack_ids[(edition, pack["name"])]
+        for index, verse in enumerate(pack["verses"]):
+            if not verse.get("cardUid"):
+                raise SystemExit(
+                    f"{edition} / {pack['name']} / {verse['book']} {verse['reference']} "
+                    "has no cardUid.\nRun `python3 Scripts/sync_verses.py patch` first — "
+                    "it assigns them."
+                )
+            verse_rows.append({
+                "pack_id":    pack_id,
+                "verse_id":   verse["id"],
+                "card_uid":   verse["cardUid"],
+                "sort_index": index,
+                "title":      verse["title"],
+                "verse":      verse["verse"],
+                "book":       verse["book"],
+                "reference":  verse["reference"],
+                "subpack":    verse.get("subpack", ""),
+                "version":    verse.get("version"),
+            })
+
+    print(f"inserting {len(verse_rows)} verses…")
+    client.insert("verses", verse_rows)
+
+    # Belt and braces. The auto-publish triggers have already bumped the version
+    # several times during this run — once per write statement, so a seed moves
+    # it by about six — but this guarantees a final publish even against a
+    # database where the triggers aren't installed.
+    version = client.rpc("bump_catalog_version")
+    print(f"done — catalog version is now {version}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--check", action="store_true",
+                        help="compare hosted against bundled, write nothing")
+    args = parser.parse_args()
+
+    url = os.environ.get("SUPABASE_URL", "").strip()
+    key = os.environ.get("SUPABASE_SERVICE_KEY", "").strip()
+    if not url or not key:
+        print("set SUPABASE_URL and SUPABASE_SERVICE_KEY", file=sys.stderr)
+        return 2
+
+    client = Supabase(url, key)
+    return cmd_check(client) if args.check else cmd_seed(client)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/sync_verses.py
+++ b/Scripts/sync_verses.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Reconcile the bundled verse JSON against tms.navigators.tech.
+
+The Navigators' own web app (a Next.js site) ships each pack's full contents in
+the `__NEXT_DATA__` payload of `/pack/<id>/view`, and `?bibleVersion=<VER>`
+re-renders the same pack in another translation. That makes it the authoritative
+source for both the pack ordering and the verse text we bundle.
+
+Commands
+--------
+    audit    Compare every bundled pack against the source and print a diff of
+             the reference lists. Read-only.
+    patch    Apply the reconciliation to Resources/verseData*.json: insert
+             verses the source has and we don't, fix the known title typo, and
+             pin the two verses whose printed card is KJV.
+    dump     Emit a single canonical catalog JSON (all packs, all versions) on
+             stdout — the seed input for the Supabase catalog.
+
+Verse `id`s are load-bearing: quiz selections, submitted answers and
+review-complete flags are all persisted by id. Inserted verses therefore get
+fresh ids from a reserved high block rather than renumbering the pack, so a
+user's existing progress keeps pointing at the verse it was recorded for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RESOURCES = REPO / "scripture memory" / "Resources"
+CACHE = Path(os.environ.get("TMS_CACHE", REPO / ".build" / "tms-cache"))
+
+BUNDLES = {
+    "NIV84": RESOURCES / "verseData.json",
+    "NIV11": RESOURCES / "verseDataNIV11.json",
+}
+
+# The widget extension has its own bundle and can't read the app's resources, so
+# it ships a byte-copy of the NIV84 file. Nothing keeps the two in step, so
+# `patch` re-mirrors it — a drifted widget quietly shows the wrong verse text.
+MIRRORS = {RESOURCES / "verseData.json": REPO / "ScriptureWidget" / "verseData.json"}
+
+# Bundled pack name -> the source pack ids that concatenate into it. TMS 60 is
+# published as five lettered booklets; we ship it as one 60-card pack.
+PACK_MAP = {
+    "5 Assurances": [1],
+    "TMS 60": [2, 3, 4, 5, 6],
+    "DEP 1: Assurance of Salvation": [51],
+    "DEP 2: Quiet Time": [52],
+    "DEP 3: The Word": [69],
+    "DEP 4: Prayer": [84],
+    "DEP 5: Fellowship": [103],
+    "DEP 6: Witnessing": [104],
+    "DEP 7: The Lordship of Christ": [105],
+    "DEP 8: World Vision": [106],
+    "TMS 180 · Getting to Know God": [56],
+    "TMS 180 · Growing in Love": [59],
+    "TMS 180 · Growing in Faith": [60],
+    "TMS 180 · Walking in Victory": [61],
+    "TMS 180 · Sharing Christ with Others": [62],
+}
+
+# First id handed out to a verse inserted by `patch`. Well clear of the existing
+# ranges (max bundled id is 10176) so insertion never collides or renumbers.
+INSERT_ID_BASE = 20001
+
+# Verses whose printed card in the physical pack is KJV regardless of which NIV
+# edition the rest of the pack uses. Keyed (pack, book, reference).
+KJV_PINNED = [
+    ("DEP 4: Prayer", "1 Thessalonians", "5:17"),
+    ("DEP 2: Quiet Time", "Psalm", "27:8"),
+]
+
+# Cover colours, read off photographs of the printed packs.
+#
+# What shipped before came from tms.navigators.tech, where pack colour is picked
+# by whoever uploaded it — pure `#00ff07`, `#14f7ff` and so on. Those bear no
+# relation to the physical packs the covers are imitating.
+#
+# The photos were taken under warm shop lighting at an angle, so these are the
+# sampled hues cleaned up to flat print colours rather than literal pixel values.
+PACK_COLORS = {
+    # DEP 242. Pack 1 is printed on white stock with red type; everything else is
+    # a solid field with white type. The app picks the type colour from the
+    # field's luminance, so the cream value is all it needs.
+    # Sampled off the shop display card holding all eight, with only a light
+    # exposure lift (~6%).
+    #
+    # I first white-balanced these hard against the board behind them, on the
+    # reasoning that the board is painted white and reads #DFE0DF, so everything
+    # was ~12% underexposed. Arithmetically fine, visibly wrong: it assumes the
+    # board is pure white and pushes every pack to a brightness the printed cards
+    # don't have. Trusting the measurement over the result is how you end up with
+    # a set of neons that each individually "matches".
+    #
+    # The set runs as a spectrum: white, red, orange, yellow, green, sky, royal,
+    # violet.
+    "DEP 1: Assurance of Salvation": "#F4F2ED",
+    "DEP 2: Quiet Time":             "#E14C30",
+    "DEP 3: The Word":               "#EA8A2E",
+    "DEP 4: Prayer":                 "#E7AF21",
+    "DEP 5: Fellowship":             "#019A4E",
+    "DEP 6: Witnessing":             "#0090D0",
+    "DEP 7: The Lordship of Christ": "#01409E",
+    "DEP 8: World Vision":           "#362B8A",
+
+    # The olive green of "Lessons on Assurance", the book these five come from.
+    "5 Assurances": "#7FA23C",
+
+    "TMS 180 · Getting to Know God":        "#5E3A87",
+    "TMS 180 · Growing in Love":            "#8E3339",
+    "TMS 180 · Growing in Faith":           "#2E86B8",
+    "TMS 180 · Walking in Victory":         "#8E9A3C",
+    "TMS 180 · Sharing Christ with Others": "#D9925C",
+}
+
+# Straight text corrections in bundled titles/verses, applied to both editions.
+TEXT_FIXES = [
+    ("Moses - personal fellowship wtih the Lord",
+     "Moses - personal fellowship with the Lord"),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Source fetching
+# --------------------------------------------------------------------------- #
+
+NEXT_DATA = re.compile(
+    r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', re.S
+)
+
+
+def fetch_pack(pack_id: int, version: str) -> dict:
+    """The source pack payload, memoised on disk (the site is slow and static)."""
+    CACHE.mkdir(parents=True, exist_ok=True)
+    cached = CACHE / f"{pack_id}_{version}.json"
+    if cached.exists():
+        return json.loads(cached.read_text())
+
+    url = f"https://tms.navigators.tech/pack/{pack_id}/view?bibleVersion={version}"
+    req = urllib.request.Request(url, headers={"User-Agent": "scripture-memory-sync"})
+    html = urllib.request.urlopen(req, timeout=30).read().decode()
+    match = NEXT_DATA.search(html)
+    if not match:
+        raise RuntimeError(f"no __NEXT_DATA__ in {url}")
+    pack = json.loads(match.group(1))["props"]["pageProps"]["initialPack"]
+    cached.write_text(json.dumps(pack, ensure_ascii=False))
+    return pack
+
+
+def strip_control_chars(text: str) -> str:
+    """Drop C0/C1 control characters.
+
+    Jonah 4:10-11 ended with a literal U+001A (SUBSTITUTE) — invisible on the
+    card, but `wordTokens` split it off as its own word, so the scorer counted a
+    word nobody could type.
+    """
+    return "".join(c for c in text if c.isprintable() or c in " \n\t")
+
+
+def normalize_text(text: str) -> str:
+    """Bring source text in line with what the bundle already uses.
+
+    The site renders poetic line breaks as runs of spaces, and its NIV84 edition
+    types nested quotes as backticks. Neither convention appears anywhere in the
+    bundled JSON, so an inserted verse that kept them would render visibly unlike
+    the card above it — and the backtick would be a word token the user has to
+    type. Applied only to text we're pulling in; bundled verses are left alone.
+    """
+    return re.sub(r"\s+", " ", text.replace("`", "'")).strip()
+
+
+def flatten(pack: dict) -> list[dict]:
+    """Source `contents` (interleaved TITLE / VERSE) -> flat verse records.
+
+    A TITLE applies to every VERSE after it until the next TITLE — that heading
+    is what our cards show as the verse title.
+    """
+    out: list[dict] = []
+    title = ""
+    for item in pack["contents"]:
+        if item["type"] == "TITLE":
+            title = item["name"].strip()
+        else:
+            out.append({
+                "title": normalize_text(title),
+                "book": item["book"].strip(),
+                "reference": f"{item['chapter']}:{item['verses']}".strip(),
+                "verse": normalize_text(item["text"]),
+            })
+    return out
+
+
+def source_pack(name: str, version: str) -> list[dict]:
+    verses: list[dict] = []
+    for pack_id in PACK_MAP[name]:
+        verses += flatten(fetch_pack(pack_id, version))
+    return verses
+
+
+# --------------------------------------------------------------------------- #
+# Card identity
+# --------------------------------------------------------------------------- #
+
+def legacy_key(pack_name: str, verse: dict) -> str:
+    """The identity the app used before `cardUid` — pack + book + reference.
+
+    Mirrors `SRSKey.make` exactly (lowercased book, whitespace stripped from the
+    reference). Reproduced here only so uids can be seeded from it, which is what
+    makes the on-device migration a pure lookup.
+    """
+    book = verse["book"].lower().strip()
+    reference = re.sub(r"\s", "", verse["reference"]).lower()
+    return f"{pack_name}#{book}|{reference}"
+
+
+def mint_uid(pack_name: str, verse: dict, occurrence: int = 1) -> str:
+    """A card's permanent id.
+
+    Derived from the legacy identity *once*, then stored and never recomputed —
+    that seeding is what lets existing installs map their saved progress across
+    without a server round trip. After assignment the value is authoritative on
+    its own, so renaming a pack or restyling a reference no longer touches it.
+    Both editions of a card derive the same uid because both agree on pack, book
+    and reference.
+
+    `occurrence` disambiguates packs that print the same passage on two cards
+    under different titles (see `assign_uids`). It's part of the derivation only;
+    once minted the uid stands alone and doesn't care about position.
+    """
+    seed = legacy_key(pack_name, verse)
+    if occurrence > 1:
+        seed += f"#{occurrence}"
+    return hashlib.sha256(seed.encode()).hexdigest()[:16]
+
+
+def assign_uids(bundle: list[dict]) -> int:
+    """Fill in any missing `cardUid`. Idempotent — existing ones are never
+    touched, which is the whole point: a uid that could be recomputed from
+    content would inherit exactly the fragility it exists to remove.
+
+    Three packs print the same passage on two different cards (Acts 17:11 twice
+    in DEP 3, 1 Timothy 2:1-2 twice in DEP 4, Romans 10:9-10 twice in DEP 6).
+    The old pack+book+reference key couldn't tell those apart, so the app treated
+    each pair as one card — starring one starred both, and learning one skipped
+    the other. Counting occurrences gives the second card its own id and its own
+    progress.
+    """
+    added = 0
+    for pack in bundle:
+        counts: dict[str, int] = {}
+        for verse in pack["verses"]:
+            key = legacy_key(pack["name"], verse)
+            counts[key] = counts.get(key, 0) + 1
+            if not verse.get("cardUid"):
+                verse["cardUid"] = mint_uid(pack["name"], verse, counts[key])
+                added += 1
+    return added
+
+
+# --------------------------------------------------------------------------- #
+# Comparison
+# --------------------------------------------------------------------------- #
+
+def ref_key(verse: dict) -> str:
+    """Book + reference, normalised so `9:11` and `9, 11` compare equal.
+
+    The source and the bundle disagree on whitespace inside multi-verse
+    references, which is cosmetic — matching on it would report every one of
+    them as a mismatch and bury the real gaps.
+    """
+    book = verse["book"].strip().rstrip(".")
+    ref = re.sub(r"\s+", "", verse["reference"])
+    return f"{book} {ref}"
+
+
+def missing_from_bundle(local: list[dict], remote: list[dict]) -> list[tuple[int, dict]]:
+    """Source verses absent from the bundle, as (insert index, verse).
+
+    Walks both lists in order, so a verse is reported at the position it holds
+    in the published pack rather than appended at the end.
+    """
+    local_keys = [ref_key(v) for v in local]
+    gaps: list[tuple[int, dict]] = []
+    i = 0
+    for verse in remote:
+        key = ref_key(verse)
+        if i < len(local_keys) and local_keys[i] == key:
+            i += 1
+        elif key not in local_keys:
+            gaps.append((i + len(gaps), verse))
+    return gaps
+
+
+def reorder_to_source(local: list[dict], remote: list[dict]) -> list[dict] | None:
+    """`local` resequenced into the source's order, or None if it can't be.
+
+    Card numbers come from position in the pack (`CardFooter`), so an edition
+    that lists two verses in the wrong order gives them the wrong printed
+    numbers — and disagrees with the other edition of the same card. Records
+    move whole, ids included, so nothing keyed by id is disturbed.
+
+    Only safe when the two lists hold exactly the same references; anything else
+    is a gap for `missing_from_bundle` (or a human) to deal with first.
+    """
+    by_key: dict[str, list[dict]] = {}
+    for verse in local:
+        by_key.setdefault(ref_key(verse), []).append(verse)
+    if sorted(by_key) != sorted({ref_key(v) for v in remote}):
+        return None
+    if any(len(group) > 1 for group in by_key.values()):
+        return None       # duplicate reference — ambiguous, leave it alone
+    ordered = [by_key[ref_key(v)][0] for v in remote]
+    return ordered if ordered != local else None
+
+
+def cmd_audit(_args) -> int:
+    import difflib
+
+    problems = 0
+    for version, path in BUNDLES.items():
+        bundle = json.loads(path.read_text())
+        by_name = {p["name"]: p for p in bundle}
+        print(f"\n===== {path.name} ({version}) =====")
+        for name in PACK_MAP:
+            if name not in by_name:
+                print(f"  !! bundle is missing pack {name!r}")
+                problems += 1
+                continue
+            local = by_name[name]["verses"]
+            remote = source_pack(name, version)
+            lk = [ref_key(v) for v in local]
+            rk = [ref_key(v) for v in remote]
+            if lk == rk:
+                print(f"  ok  {name}  ({len(lk)} verses)")
+                continue
+            problems += 1
+            print(f"  !!  {name}  bundle={len(lk)} source={len(rk)}")
+            for line in difflib.unified_diff(lk, rk, "bundle", "source",
+                                             lineterm="", n=1):
+                print(f"        {line}")
+    return 1 if problems else 0
+
+
+# --------------------------------------------------------------------------- #
+# Patching
+# --------------------------------------------------------------------------- #
+
+def cmd_patch(args) -> int:
+    next_id = INSERT_ID_BASE
+    # Both editions must give the same verse the same id — they are two
+    # translations of one card, and ids are how a saved quiz finds it back.
+    assigned: dict[tuple[str, str], int] = {}
+
+    for version, path in BUNDLES.items():
+        bundle = json.loads(path.read_text())
+        changes: list[str] = []
+
+        for pack in bundle:
+            if pack["name"] not in PACK_MAP:
+                continue
+            remote = source_pack(pack["name"], version)
+            by_key = {ref_key(v): v for v in remote}
+
+            for index, verse in missing_from_bundle(pack["verses"], remote):
+                slot = (pack["name"], ref_key(verse))
+                if slot not in assigned:
+                    assigned[slot] = next_id
+                    next_id += 1
+                record = {
+                    "id": assigned[slot],
+                    "title": verse["title"],
+                    "verse": verse["verse"],
+                    "book": verse["book"],
+                    "reference": re.sub(r"\s+$", "", verse["reference"]),
+                    "subpack": pack["verses"][min(index, len(pack["verses"]) - 1)]["subpack"],
+                }
+                pack["verses"].insert(index, record)
+                changes.append(f"+ {pack['name']}: {ref_key(verse)} at #{index + 1}")
+
+            resequenced = reorder_to_source(pack["verses"], remote)
+            if resequenced is not None:
+                moved = [ref_key(v) for a, v in zip(pack["verses"], resequenced)
+                         if ref_key(a) != ref_key(v)]
+                pack["verses"] = resequenced
+                changes.append(f"> {pack['name']}: resequenced {', '.join(moved)}")
+
+            # Pin the KJV-only cards to their KJV text.
+            for pin_pack, book, reference in KJV_PINNED:
+                if pack["name"] != pin_pack:
+                    continue
+                key = ref_key({"book": book, "reference": reference})
+                kjv = {ref_key(v): v for v in source_pack(pack["name"], "KJV")}.get(key)
+                if kjv is None:
+                    print(f"  !! no KJV text for {key} in {pin_pack}", file=sys.stderr)
+                    continue
+                for verse in pack["verses"]:
+                    if ref_key(verse) != key:
+                        continue
+                    if verse.get("verse") != kjv["verse"] or verse.get("version") != "KJV":
+                        verse["verse"] = kjv["verse"]
+                        verse["version"] = "KJV"
+                        changes.append(f"~ {pack['name']}: {key} pinned to KJV")
+
+            # Invisible characters that the tokenizer nonetheless sees.
+            for verse in pack["verses"]:
+                for field in ("title", "verse"):
+                    cleaned = re.sub(r"\s+", " ", strip_control_chars(verse[field])).strip()
+                    if cleaned != verse[field]:
+                        verse[field] = cleaned
+                        changes.append(f"~ {pack['name']}: stripped control chars from "
+                                       f"{verse['book']} {verse['reference']}")
+
+            # Straight text corrections.
+            for verse in pack["verses"]:
+                for wrong, right in TEXT_FIXES:
+                    for field in ("title", "verse"):
+                        if wrong in verse[field]:
+                            verse[field] = verse[field].replace(wrong, right)
+                            changes.append(f"~ {pack['name']}: fixed {wrong!r}")
+
+        for pack in bundle:
+            wanted = PACK_COLORS.get(pack["name"])
+            if wanted and pack.get("color") != wanted:
+                changes.append(f"~ {pack['name']}: colour {pack.get('color')} -> {wanted}")
+                pack["color"] = wanted
+
+        # Last, so verses inserted above are minted in the same pass.
+        minted = assign_uids(bundle)
+        if minted:
+            changes.append(f"~ assigned {minted} card uid(s)")
+
+        print(f"{path.name}: {len(changes)} change(s)")
+        for line in changes:
+            print(f"  {line}")
+        if changes and not args.dry_run:
+            path.write_text(json.dumps(bundle, ensure_ascii=False, indent=2) + "\n")
+
+    if not args.dry_run:
+        for source, mirror in MIRRORS.items():
+            if not mirror.exists() or mirror.read_bytes() != source.read_bytes():
+                mirror.write_bytes(source.read_bytes())
+                print(f"mirrored {source.name} -> {mirror.relative_to(REPO)}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Catalog dump (Supabase seed input)
+# --------------------------------------------------------------------------- #
+
+def cmd_dump(args) -> int:
+    """One document holding every pack in every bundled edition.
+
+    Shape matches what the app's remote catalog expects, so the same file seeds
+    Supabase and can be served verbatim as a static fallback.
+    """
+    editions = {}
+    for version, path in BUNDLES.items():
+        editions[version] = json.loads(path.read_text())
+    catalog = {"catalogVersion": args.catalog_version, "editions": editions}
+    json.dump(catalog, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("audit", help="compare bundled packs against the source")
+
+    patch = sub.add_parser("patch", help="apply reconciliation to the bundled JSON")
+    patch.add_argument("--dry-run", action="store_true",
+                       help="report changes without writing")
+
+    dump = sub.add_parser("dump", help="emit the canonical catalog JSON")
+    dump.add_argument("--catalog-version", type=int, default=1)
+
+    args = parser.parse_args()
+    return {"audit": cmd_audit, "patch": cmd_patch, "dump": cmd_dump}[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripture Memory.xcodeproj/project.pbxproj
+++ b/Scripture Memory.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 53709C032DBE80FE000BA559 /* Build configuration list for PBXProject "Scripture Memory" */;
+			buildConfigurationList = 53709C032DBE80FE000BA559 /* Build configuration list for PBXProject "scripture memory" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -380,7 +380,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "joel.scripture-memory";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -429,7 +429,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "joel.scripture-memory";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -506,7 +506,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		53709C032DBE80FE000BA559 /* Build configuration list for PBXProject "Scripture Memory" */ = {
+		53709C032DBE80FE000BA559 /* Build configuration list for PBXProject "scripture memory" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				53709C122DBE80FF000BA559 /* Debug */,

--- a/Scripture Memory.xcodeproj/xcshareddata/xcschemes/ScriptureWidgetExtension.xcscheme
+++ b/Scripture Memory.xcodeproj/xcshareddata/xcschemes/ScriptureWidgetExtension.xcscheme
@@ -19,7 +19,7 @@
                BlueprintIdentifier = "A1B2C3D4E5F600000000A003"
                BuildableName = "ScriptureWidgetExtension.appex"
                BlueprintName = "ScriptureWidgetExtension"
-               ReferencedContainer = "container:Scripture Memory.xcodeproj">
+               ReferencedContainer = "container:scripture memory.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
@@ -33,7 +33,7 @@
                BlueprintIdentifier = "53709C072DBE80FE000BA559"
                BuildableName = "Scripture Memory.app"
                BlueprintName = "Scripture Memory"
-               ReferencedContainer = "container:Scripture Memory.xcodeproj">
+               ReferencedContainer = "container:scripture memory.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -64,7 +64,7 @@
             BlueprintIdentifier = "53709C072DBE80FE000BA559"
             BuildableName = "Scripture Memory.app"
             BlueprintName = "Scripture Memory"
-            ReferencedContainer = "container:Scripture Memory.xcodeproj">
+            ReferencedContainer = "container:scripture memory.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -100,7 +100,7 @@
             BlueprintIdentifier = "53709C072DBE80FE000BA559"
             BuildableName = "Scripture Memory.app"
             BlueprintName = "Scripture Memory"
-            ReferencedContainer = "container:Scripture Memory.xcodeproj">
+            ReferencedContainer = "container:scripture memory.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/ScriptureWidget/DailyVerseWidget.swift
+++ b/ScriptureWidget/DailyVerseWidget.swift
@@ -95,23 +95,19 @@ struct VerseEntryView: View {
                             titleSize: CGFloat, refSize: CGFloat, verseSize: CGFloat, packSize: CGFloat,
                             gap1: CGFloat, gap2: CGFloat, verseSpacing: CGFloat, titleLines: Int) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(v.title)
-                .font(.system(size: titleSize, weight: .bold, design: .serif))
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: false, vertical: true)
-                .lineLimit(titleLines)
-                .minimumScaleFactor(0.8)
-            Spacer().frame(height: gap1)
-            Text(v.fullReference)
-                .font(.system(size: refSize))
-                .foregroundStyle(.primary)
-                .lineLimit(1).minimumScaleFactor(0.8)
-            Spacer().frame(height: gap2)
-            Text(v.verse)
-                .font(.system(size: verseSize, design: .serif))
-                .foregroundStyle(.primary)
-                .lineSpacing(verseSpacing)
-                .minimumScaleFactor(0.5)
+            // Title, reference and verse scale together — the sizes below are
+            // proportions, not final values.
+            FittedVerseBlock(title: v.title,
+                             reference: v.fullReference,
+                             verse: v.verse,
+                             baseTitle: titleSize,
+                             baseRef: refSize,
+                             baseVerse: verseSize,
+                             gap1: gap1,
+                             gap2: gap2,
+                             lineSpacing: verseSpacing,
+                             titleLines: titleLines)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             Spacer(minLength: 4)
             HStack(spacing: 3) {
                 if entry.isPinned {
@@ -134,22 +130,21 @@ struct VerseEntryView: View {
         VStack(spacing: 0) {
             // ── Top half: the verse ───────────────────────────────────
             VStack(alignment: .leading, spacing: 0) {
-                Text(v.title)
-                    .font(.system(size: 18, weight: .bold, design: .serif))
-                    .foregroundStyle(.primary)
-                    .lineLimit(2).minimumScaleFactor(0.75)
-                Spacer().frame(height: 5)
-                Text(v.fullReference)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                Spacer().frame(height: 7)
-                Text(v.verse)
-                    .font(.system(size: 15, design: .serif))
-                    .foregroundStyle(.primary.opacity(0.92))
-                    .lineSpacing(4)
-                    .lineLimit(5)
-                    .minimumScaleFactor(0.7)
+                // Same block fit as the smaller families, but with a tighter
+                // ceiling: the bottom half of this widget is the streak block, so
+                // the verse gets the room the layout gives it, not all of it.
+                FittedVerseBlock(title: v.title,
+                                 reference: v.fullReference,
+                                 verse: v.verse,
+                                 baseTitle: 18,
+                                 baseRef: 14,
+                                 baseVerse: 15,
+                                 gap1: 5,
+                                 gap2: 7,
+                                 lineSpacing: 4,
+                                 titleLines: 2,
+                                 maxScale: 1.3)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 Spacer(minLength: 4)
                 HStack(spacing: 3) {
                     if entry.isPinned {

--- a/ScriptureWidget/WidgetVerse.swift
+++ b/ScriptureWidget/WidgetVerse.swift
@@ -38,18 +38,61 @@ private struct WidgetPack: Decodable {
     let verses: [WidgetVerse]
 }
 
-/// The bundled verse catalogue (pack names injected) — used by the configuration
-/// picker and as a fallback when no current learning verse is available yet.
+/// The verse catalogue — used by the configuration picker and as a fallback
+/// when no current learning verse is available yet.
+///
+/// Prefers the catalog the app downloaded into the shared App Group, and only
+/// falls back to the copy bundled with the widget. Before this, the picker was
+/// permanently on whatever shipped with the build, so a pack added or a verse
+/// corrected in Supabase never appeared here even though the featured verse
+/// (which comes through the App Group snapshot) updated fine.
 enum VerseLibrary {
-    static let allVerses: [WidgetVerse] = {
+
+    /// Mirrors `VerseCatalog.Document` on the app side. Only the fields the
+    /// widget needs are decoded; `schema` is required so a file written by an
+    /// older app build is rejected rather than half-read.
+    private struct SharedCatalog: Decodable {
+        let schema: Int
+        let editions: [String: [WidgetPack]]
+    }
+
+    private static let currentSchema = 2
+
+    static let allVerses: [WidgetVerse] = shared() ?? bundled()
+
+    private static func shared() -> [WidgetVerse]? {
+        guard let url = FileManager.default
+                .containerURL(forSecurityApplicationGroupIdentifier: SharedStore.appGroup)?
+                .appendingPathComponent("verseCatalog.json"),
+              let data = try? Data(contentsOf: url),
+              let doc  = try? JSONDecoder().decode(SharedCatalog.self, from: data),
+              doc.schema == currentSchema
+        else { return nil }
+
+        // The edition the app is showing; fall back to NIV84, then to whatever
+        // the file happens to contain.
+        let preferred = UserDefaults(suiteName: SharedStore.appGroup)?
+            .string(forKey: "widget.edition.v1")
+        let packs = preferred.flatMap { doc.editions[$0] }
+            ?? doc.editions["NIV84"]
+            ?? doc.editions.values.first
+        guard let packs, !packs.isEmpty else { return nil }
+        return flatten(packs)
+    }
+
+    private static func bundled() -> [WidgetVerse] {
         guard let url   = Bundle.main.url(forResource: "verseData", withExtension: "json"),
               let data  = try? Data(contentsOf: url),
               let packs = try? JSONDecoder().decode([WidgetPack].self, from: data)
         else { return [] }
-        return packs.flatMap { pack in
+        return flatten(packs)
+    }
+
+    private static func flatten(_ packs: [WidgetPack]) -> [WidgetVerse] {
+        packs.flatMap { pack in
             pack.verses.map { var v = $0; v.packName = pack.name; return v }
         }
-    }()
+    }
 
     static func verse(id: String) -> WidgetVerse? {
         allVerses.first { $0.id == id }

--- a/ScriptureWidget/WidgetVerseFit.swift
+++ b/ScriptureWidget/WidgetVerseFit.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import UIKit
+
+/// Measure-to-fit sizing for widget verse text.
+///
+/// The widget set every verse at a fixed point size with a `minimumScaleFactor`,
+/// which only ever shrinks — so a long verse squeezed down to fit while a short
+/// one stayed small with half the widget empty around it. This finds the largest
+/// size that still fits the space the layout actually leaves, so short verses
+/// grow into it. Same approach as `VerseFit` in the app, which is what the
+/// flashcards use.
+///
+/// Duplicated rather than shared because the widget is a separate target with
+/// its own bundle and can't see the app's sources — the same reason
+/// `WidgetVerse` restates `Verse`.
+enum WidgetVerseFit {
+
+    /// Rendered height of `text` at `size` (serif) with `lineSpacing`, wrapped to `width`.
+    static func height(_ text: String, width: CGFloat, size: CGFloat, lineSpacing: CGFloat) -> CGFloat {
+        guard width > 1 else { return .greatestFiniteMagnitude }
+        var font = UIFont.systemFont(ofSize: size)
+        if let d = font.fontDescriptor.withDesign(.serif) { font = UIFont(descriptor: d, size: size) }
+        let para = NSMutableParagraphStyle()
+        para.lineSpacing = lineSpacing
+        let rect = (text as NSString).boundingRect(
+            with: CGSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font, .paragraphStyle: para], context: nil)
+        return ceil(rect.height)
+    }
+
+    /// Largest size in `min...max` whose text fits `width × height`.
+    static func fontSize(_ text: String, width: CGFloat, height: CGFloat,
+                         lineSpacing: CGFloat, minSize: CGFloat, maxSize: CGFloat) -> CGFloat {
+        guard width > 1, height > 1, !text.isEmpty else { return maxSize }
+        if Self.height(text, width: width, size: maxSize, lineSpacing: lineSpacing) <= height { return maxSize }
+        var lo = minSize, hi = maxSize
+        for _ in 0..<12 {
+            let mid = (lo + hi) / 2
+            if Self.height(text, width: width, size: mid, lineSpacing: lineSpacing) <= height {
+                lo = mid
+            } else {
+                hi = mid
+            }
+        }
+        return (lo * 2).rounded(.down) / 2
+    }
+}
+
+/// Height of a bold serif line (the title), wrapped and capped to `maxLines`.
+private func measuredTitleHeight(_ text: String, width: CGFloat, size: CGFloat, maxLines: Int) -> CGFloat {
+    var font = UIFont.systemFont(ofSize: size, weight: .bold)
+    if let d = font.fontDescriptor.withDesign(.serif) { font = UIFont(descriptor: d, size: size) }
+    let rect = (text as NSString).boundingRect(
+        with: CGSize(width: width, height: .greatestFiniteMagnitude),
+        options: [.usesLineFragmentOrigin, .usesFontLeading],
+        attributes: [.font: font], context: nil)
+    return ceil(min(rect.height, font.lineHeight * CGFloat(maxLines)))
+}
+
+/// Height of a plain line (the reference).
+private func measuredLineHeight(_ size: CGFloat) -> CGFloat {
+    ceil(UIFont.systemFont(ofSize: size).lineHeight)
+}
+
+/// The whole verse block — title, reference and body — scaled as one.
+///
+/// Sizing only the verse was half a fix: a three-word verse grew to fill the
+/// widget while its own title and reference stayed put, so the block came out
+/// bottom-heavy and the heading looked like a caption on its own text. Every
+/// size and gap here moves by a single factor, chosen so the composed block
+/// fills the height it's given — which is what keeps the proportions the same
+/// as the flashcard whether the verse is three words or sixty.
+struct FittedVerseBlock: View {
+    let title:       String
+    let reference:   String
+    let verse:       String
+    let baseTitle:   CGFloat
+    let baseRef:     CGFloat
+    let baseVerse:   CGFloat
+    let gap1:        CGFloat
+    let gap2:        CGFloat
+    let lineSpacing: CGFloat
+    let titleLines:  Int
+    /// Ceiling on the scale factor. Without one a very short verse pushes the
+    /// type to a size that reads as a poster rather than a widget.
+    var maxScale:    CGFloat = 1.55
+
+    // Broken into statements rather than one expression: as a single chained sum
+    // of five calls the type checker gives up on it.
+    private func totalHeight(scale k: CGFloat, width: CGFloat) -> CGFloat {
+        let t: CGFloat = measuredTitleHeight(title, width: width, size: baseTitle * k, maxLines: titleLines)
+        let r: CGFloat = measuredLineHeight(baseRef * k)
+        let v: CGFloat = WidgetVerseFit.height(verse, width: width,
+                                               size: baseVerse * k,
+                                               lineSpacing: lineSpacing * k)
+        let gaps: CGFloat = (gap1 * k) + (gap2 * k)
+        return t + r + v + gaps
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let k = scale(width: geo.size.width, height: geo.size.height)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(title)
+                    .font(.system(size: baseTitle * k, weight: .bold, design: .serif))
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(titleLines)
+                    .minimumScaleFactor(0.8)
+                Spacer().frame(height: gap1 * k)
+                Text(reference)
+                    .font(.system(size: baseRef * k))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1).minimumScaleFactor(0.8)
+                Spacer().frame(height: gap2 * k)
+                Text(verse)
+                    .font(.system(size: baseVerse * k, design: .serif))
+                    .foregroundStyle(.primary)
+                    .lineSpacing(lineSpacing * k)
+                    .minimumScaleFactor(0.6)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private func scale(width: CGFloat, height: CGFloat) -> CGFloat {
+        guard width > 1, height > 1 else { return 1 }
+        if totalHeight(scale: maxScale, width: width) <= height { return maxScale }
+        var lo: CGFloat = 0.6, hi = maxScale
+        for _ in 0..<12 {
+            let mid = (lo + hi) / 2
+            if totalHeight(scale: mid, width: width) <= height { lo = mid } else { hi = mid }
+        }
+        return lo
+    }
+}

--- a/ScriptureWidget/verseData.json
+++ b/ScriptureWidget/verseData.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "5 Assurances",
-    "color": "#3A7CA5",
+    "color": "#7FA23C",
     "accentText": "5",
     "verses": [
       {
@@ -10,7 +10,8 @@
         "verse": "And this is the testimony: God has given us eternal life, and this life is in his Son. He who has the Son has life; he who does not have the Son of God does not have life.",
         "book": "1 John",
         "reference": "5:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fb7aabf3e66b755f"
       },
       {
         "id": 2,
@@ -18,7 +19,8 @@
         "verse": "\"Until now you have not asked for anything in my name. Ask and you will receive, and your joy will be complete.\"",
         "book": "John",
         "reference": "16:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "01fc8d676ac96c6c"
       },
       {
         "id": 3,
@@ -26,7 +28,8 @@
         "verse": "No temptation has seized you except what is common to man. And God is faithful; he will not let you be tempted beyond what you can bear. But when you are tempted, he will also provide a way out so that you can stand up under it.",
         "book": "1 Corinthians",
         "reference": "10:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c91123b93df2df7e"
       },
       {
         "id": 4,
@@ -34,7 +37,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b8e7f6a946673b5c"
       },
       {
         "id": 5,
@@ -42,7 +46,8 @@
         "verse": "Trust in the Lord with all your heart and lean not on your own understanding; in all your ways acknowledge him, and he will make your paths straight.",
         "book": "Proverbs",
         "reference": "3:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c32b24cdb10f31d"
       }
     ]
   },
@@ -57,7 +62,8 @@
         "verse": "Therefore, if anyone is in Christ, he is a new creation; the old has gone, the new has come!",
         "book": "2 Corinthians",
         "reference": "5:17",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "53b7f282e8db4d0d"
       },
       {
         "id": 7,
@@ -65,7 +71,8 @@
         "verse": "I have been crucified with Christ and I no longer live, but Christ lives in me. The life I live in the body, I live by faith in the Son of God, who loved me and gave Himself for me.",
         "book": "Galatians",
         "reference": "2:20",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "abc5fccfb66e8c14"
       },
       {
         "id": 8,
@@ -73,7 +80,8 @@
         "verse": "Therefore, I urge you, brothers, in view of God's mercy to offer your bodies as living sacrifices, holy and pleasing to God - this is your spiritual act of worship.",
         "book": "Romans",
         "reference": "12:1",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "5887cf7e17ef94b3"
       },
       {
         "id": 9,
@@ -81,7 +89,8 @@
         "verse": "Whoever has My commands and obeys them, he is the one who loves Me. He who loves Me will be loved by My Father, and I too will love him and show Myself to him.",
         "book": "John",
         "reference": "14:21",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "838b46c6d3fe8b41"
       },
       {
         "id": 10,
@@ -89,7 +98,8 @@
         "verse": "All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness.",
         "book": "2 Timothy",
         "reference": "3:16",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "47991ecef8531919"
       },
       {
         "id": 11,
@@ -97,15 +107,8 @@
         "verse": "Do not let this Book of the Law depart from your mouth; meditate on it day and night, so that you may be careful to do everything written in it. Then you will be prosperous and successful.",
         "book": "Joshua",
         "reference": "1:8",
-        "subpack": "A"
-      },
-      {
-        "id": 12,
-        "title": "Prayer",
-        "verse": "Do not be anxious about anything, but in everything, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
-        "book": "Philippians",
-        "reference": "4:6-7",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "d30f59c977460049"
       },
       {
         "id": 13,
@@ -113,7 +116,17 @@
         "verse": "If you remain in Me and My words remain in you, ask whatever you wish, and it will be given you.",
         "book": "John",
         "reference": "15:7",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "85dea192cd6d36f4"
+      },
+      {
+        "id": 12,
+        "title": "Prayer",
+        "verse": "Do not be anxious about anything, but in everything, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
+        "book": "Philippians",
+        "reference": "4:6-7",
+        "subpack": "A",
+        "cardUid": "562305394528284f"
       },
       {
         "id": 14,
@@ -121,7 +134,8 @@
         "verse": "For where two or three come together in My name, there am I with them.",
         "book": "Matthew",
         "reference": "18:20",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "46608870776328c5"
       },
       {
         "id": 15,
@@ -129,7 +143,8 @@
         "verse": "And let us consider how we may spur one another on toward love and good deeds. Let us not give up meeting together, as some are in the habit of doing, but let us encourage one another - and all the more as you see the Day approaching.",
         "book": "Hebrews",
         "reference": "10:24-25",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "eb451a402d0e4159"
       },
       {
         "id": 16,
@@ -137,7 +152,8 @@
         "verse": "\"Come, follow Me,\" Jesus said, \"and I will make you fishers of men.\"",
         "book": "Matthew",
         "reference": "4:19",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "8af4b22a031ac015"
       },
       {
         "id": 17,
@@ -145,7 +161,8 @@
         "verse": "I am not ashamed of the gospel, because it is the power of God for the salvation of everyone who believes: first for the Jew, then for the Gentile.",
         "book": "Romans",
         "reference": "1:16",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "30dcd7c855eb750e"
       },
       {
         "id": 18,
@@ -153,7 +170,8 @@
         "verse": "For all have sinned and fall short of the glory of God.",
         "book": "Romans",
         "reference": "3:23",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "231c64df0c7f4a01"
       },
       {
         "id": 19,
@@ -161,7 +179,8 @@
         "verse": "We all, like sheep, have gone astray, each of us has turned to his own way; and the Lord has laid on Him the iniquity of us all.",
         "book": "Isaiah",
         "reference": "53:6",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "0dc817b15fe06097"
       },
       {
         "id": 20,
@@ -169,7 +188,8 @@
         "verse": "For the wages of sin is death, but the gift of God is eternal life in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "6:23",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "7265b7d0775f29a9"
       },
       {
         "id": 21,
@@ -177,7 +197,8 @@
         "verse": "Just as man is destined to die once, and after that to face judgment.",
         "book": "Hebrews",
         "reference": "9:27",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "e0988cac53b19e29"
       },
       {
         "id": 22,
@@ -185,7 +206,8 @@
         "verse": "But God demonstrates his own love for us in this: While we were still sinners, Christ died for us.",
         "book": "Romans",
         "reference": "5:8",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "35bc616433dc90ff"
       },
       {
         "id": 23,
@@ -193,7 +215,8 @@
         "verse": "For Christ died for sins once for all, the righteous for the unrighteous, to bring you to God. He was put to death in the body but made alive by the Spirit.",
         "book": "1 Peter",
         "reference": "3:18",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "6e971140dffdb60a"
       },
       {
         "id": 24,
@@ -201,7 +224,8 @@
         "verse": "For it is by grace you have been saved, through faith- and this not from yourselves, it is the gift of God- not by works, so that no one can boast.",
         "book": "Ephesians",
         "reference": "2:8-9",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "8b983188fd0b6aa4"
       },
       {
         "id": 25,
@@ -209,7 +233,8 @@
         "verse": "He saved us, not because of righteous things we had done, but because of His mercy. He saved us through the washing of rebirth and renewal by the Holy Spirit.",
         "book": "Titus",
         "reference": "3:5",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "bdd9f73f2124968e"
       },
       {
         "id": 26,
@@ -217,7 +242,8 @@
         "verse": "Yet to all who received Him, to those who believed in His name, He gave the right to become children of God.",
         "book": "John",
         "reference": "1:12",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "9eddec605ec52aa7"
       },
       {
         "id": 27,
@@ -225,7 +251,8 @@
         "verse": "Here I am! I stand at the door and knock. If anyone hears My voice and opens the door, I will come in and eat with him, and he with Me.",
         "book": "Revelation",
         "reference": "3:20",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "34d348cd32d990a1"
       },
       {
         "id": 28,
@@ -233,7 +260,8 @@
         "verse": "I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.",
         "book": "1 John",
         "reference": "5:13",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "bf74e67d86182c89"
       },
       {
         "id": 29,
@@ -241,7 +269,8 @@
         "verse": "I tell you the truth, whoever hears My word and believes Him who sent Me has eternal life and will not be condemned; he has crossed over from death to life.",
         "book": "John",
         "reference": "5:24",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "c87a17e2d505bde8"
       },
       {
         "id": 30,
@@ -249,7 +278,8 @@
         "verse": "Don't you know that you yourselves are God's temple and that God's Spirit lives in you?",
         "book": "1 Corinthians",
         "reference": "3:16",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "7f8dd7d587baa579"
       },
       {
         "id": 31,
@@ -257,7 +287,8 @@
         "verse": "We have not received the spirit of the world but the Spirit who is from God, that we may understand what God has freely given us.",
         "book": "1 Corinthians",
         "reference": "2:12",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "5bf5dd6b94a7fb33"
       },
       {
         "id": 32,
@@ -265,7 +296,8 @@
         "verse": "So do not fear, for I am with you; do not be dismayed, for I am your God. I will strengthen you and help you; I will uphold you with My righteous right hand.",
         "book": "Isaiah",
         "reference": "41:10",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "eb6a7e3bf0a647d7"
       },
       {
         "id": 33,
@@ -273,7 +305,8 @@
         "verse": "I can do everything through Him who gives me strength.",
         "book": "Philippians",
         "reference": "4:13",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "37608aa5debc6a44"
       },
       {
         "id": 34,
@@ -281,7 +314,8 @@
         "verse": "Because of the Lord's great love we are not consumed, for His compassions never fail. They are new every morning; great is Your faithfulness.",
         "book": "Lamentations",
         "reference": "3:22-23",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "eeaed8f34fa04572"
       },
       {
         "id": 35,
@@ -289,7 +323,8 @@
         "verse": "God is not a man, that He should lie, nor a son of man, that He should change His mind. Does He speak and then not act? Does he promise and not fulfill?",
         "book": "Numbers",
         "reference": "23:19",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "2bc7e82bd320dea4"
       },
       {
         "id": 36,
@@ -297,7 +332,8 @@
         "verse": "You will keep in perfect peace him whose mind is steadfast, because he trusts in You.",
         "book": "Isaiah",
         "reference": "26:3",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "61d5a30a41db651b"
       },
       {
         "id": 37,
@@ -305,7 +341,8 @@
         "verse": "Cast all your anxiety on Him because He cares for you.",
         "book": "1 Peter",
         "reference": "5:7",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "c9991056657dbe0d"
       },
       {
         "id": 38,
@@ -313,7 +350,8 @@
         "verse": "He who did not spare His own Son, but gave Him up for us all- how will He not also, along with Him, graciously give us all things?",
         "book": "Romans",
         "reference": "8:32",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "02e10c5e7b88b61b"
       },
       {
         "id": 39,
@@ -321,7 +359,8 @@
         "verse": "And my God will meet all your needs according to His glorious riches in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:19",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "6a148ad77d80b512"
       },
       {
         "id": 40,
@@ -329,7 +368,8 @@
         "verse": "Because he Himself suffered when He was tempted. He is able to help those who are being tempted.",
         "book": "Hebrews",
         "reference": "2:18",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "8ffaf0c764684e46"
       },
       {
         "id": 41,
@@ -337,7 +377,8 @@
         "verse": "How can a young man keep his way pure? By living according to Your word. I have hidden Your word in my heart that I might not sin against you.",
         "book": "Psalm",
         "reference": "119:9,11",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "6d79dd06e97ed827"
       },
       {
         "id": 42,
@@ -345,7 +386,8 @@
         "verse": "But seek first His kingdom and His righteousness, and all these things will be given to you as well.",
         "book": "Matthew",
         "reference": "6:33",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8e04f9616557a02d"
       },
       {
         "id": 43,
@@ -353,7 +395,8 @@
         "verse": "Then He said to them all: \"If anyone would come after Me, he must deny himself and take up his cross daily and follow Me.\"",
         "book": "Luke",
         "reference": "9:23",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "2f0870229caa1861"
       },
       {
         "id": 44,
@@ -361,7 +404,8 @@
         "verse": "Do not love the world or anything in the world. If anyone loves the world, the love of the Father is not in him. For everything in the world- the cravings of sinful man, the lust of his eyes and the boasting of what he has and does- comes not from the Father but from the world.",
         "book": "1 John",
         "reference": "2:15-16",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8c133f82ddf2c9a3"
       },
       {
         "id": 45,
@@ -369,7 +413,8 @@
         "verse": "Do not conform any longer to the pattern of this world, but be transformed by the renewing of your mind. Then you will be able to test and approve what God's will is- His good, pleasing and perfect will.",
         "book": "Romans",
         "reference": "12:2",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "5ccf3f464bc71678"
       },
       {
         "id": 46,
@@ -377,7 +422,8 @@
         "verse": "Therefore, my dear brothers, stand firm. Let nothing move you. Always give yourselves fully to the work of the Lord, because you know that your labor in the Lord is not in vain.",
         "book": "1 Corinthians",
         "reference": "15:58",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "38809a8ee4625c35"
       },
       {
         "id": 47,
@@ -385,7 +431,8 @@
         "verse": "Consider Him who endured such opposition from sinful men, so that you will not grow weary and lose heart.",
         "book": "Hebrews",
         "reference": "12:3",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "0ba0e96ab20782ec"
       },
       {
         "id": 48,
@@ -393,7 +440,8 @@
         "verse": "For even the Son of Man did not come to be served, but to serve and to give His life as a ransom for many.",
         "book": "Mark",
         "reference": "10:45",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "ed03829732f65aaa"
       },
       {
         "id": 49,
@@ -401,7 +449,8 @@
         "verse": "For we do not preach ourselves, but Jesus Christ as Lord, and ourselves as your servants for Jesus' sake.",
         "book": "2 Corinthians",
         "reference": "4:5",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8d92ff0adf25db9f"
       },
       {
         "id": 50,
@@ -409,7 +458,8 @@
         "verse": "Honor the Lord with your wealth, with the firstfruits of all your crops; then your barns will be filled to overflowing, and your vats will brim over with new wine.",
         "book": "Proverbs",
         "reference": "3:9-10",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "81bab1223673735b"
       },
       {
         "id": 51,
@@ -417,7 +467,8 @@
         "verse": "Remember this: Whoever sows sparingly will also reap sparingly, and whoever sows generously will also reap generously. Each man should give what he has decided in his heart to give, not reluctantly or under compulsion, for God loves a cheerful giver.",
         "book": "2 Corinthians",
         "reference": "9:6-7",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "1d99e5849dd8a561"
       },
       {
         "id": 52,
@@ -425,7 +476,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be My witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "966a7aedcdf41bf4"
       },
       {
         "id": 53,
@@ -433,7 +485,8 @@
         "verse": "Therefore go and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, and teaching them to obey everything I have commanded you. And surely I am with you always, to the very end of the age.",
         "book": "Matthew",
         "reference": "28:19-20",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "90d9a3fdf0884281"
       },
       {
         "id": 54,
@@ -441,7 +494,8 @@
         "verse": "A new command I give you: Love one another. As I have loved you so you must love one another. By this all men will know that you are my disciples if you love one another.",
         "book": "John",
         "reference": "13:34-35",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "9174078704200578"
       },
       {
         "id": 55,
@@ -449,7 +503,8 @@
         "verse": "Dear children, let us not love with words or tongue but with actions and in truth.",
         "book": "1 John",
         "reference": "3:18",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "19dc4033735f46e6"
       },
       {
         "id": 56,
@@ -457,7 +512,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit, but in humility consider others better than yourselves. Each of you should look not only to your own interests, but also to the interests of others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "6a408d83f2fd0458"
       },
       {
         "id": 57,
@@ -465,7 +521,8 @@
         "verse": "Young men, in the same way be submissive to those who are older. All of you, clothe yourselves with humility toward one another, because, \"God opposes the proud but gives grace to the humble.\" Humble yourselves, therefore, under God's mighty hand, that He may lift you up in due time.",
         "book": "1 Peter",
         "reference": "5:5-6",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "389b7246404883b7"
       },
       {
         "id": 58,
@@ -473,7 +530,8 @@
         "verse": "But among you there must not be even a hint of sexual immorality, or of any kind of impurity, or of greed, because these are improper for God's holy people.",
         "book": "Ephesians",
         "reference": "5:3",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "d73ed31c598b149d"
       },
       {
         "id": 59,
@@ -481,7 +539,8 @@
         "verse": "Dear friends, I urge you, as aliens and strangers in the world, to abstain from sinful desires, which war against your soul.",
         "book": "1 Peter",
         "reference": "2:11",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "ae32bc994c08d3da"
       },
       {
         "id": 60,
@@ -489,7 +548,8 @@
         "verse": "Do not steal. Do not lie. Do not deceive one another.",
         "book": "Leviticus",
         "reference": "19:11",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "bd9061d90bf42f4d"
       },
       {
         "id": 61,
@@ -497,7 +557,8 @@
         "verse": "So I strive always to keep my conscience clear before God and man.",
         "book": "Acts",
         "reference": "24:16",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "4ad12cf7a062aa2e"
       },
       {
         "id": 62,
@@ -505,7 +566,8 @@
         "verse": "And without faith, it is impossible to please God, because anyone who comes to Him must believe that He exists and that He rewards those who earnestly seek Him.",
         "book": "Hebrews",
         "reference": "11:6",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "3f703d666890bed4"
       },
       {
         "id": 63,
@@ -513,7 +575,8 @@
         "verse": "Yet he did not waver through unbelief regarding the promise of God, but was strengthened in his faith and gave glory to God, being fully persuaded that God had power to do what he had promised.",
         "book": "Romans",
         "reference": "4:20-21",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "7bae649880268eb2"
       },
       {
         "id": 64,
@@ -521,7 +584,8 @@
         "verse": "Let us not become weary in doing good, for at the proper time we will reap a harvest if we do not give up. Therefore, as we have opportunity, let us do good to all people, especially to those who belong to the family of believers.",
         "book": "Galatians",
         "reference": "6:9-10",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "051e68aa7a21d9d2"
       },
       {
         "id": 65,
@@ -529,13 +593,14 @@
         "verse": "In the same way, let your light shine before men, that they may see your good deeds and praise your Father in heaven.",
         "book": "Matthew",
         "reference": "5:16",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "08094b02b5ae4429"
       }
     ]
   },
   {
     "name": "DEP 1: Assurance of Salvation",
-    "color": "#0a1fbe",
+    "color": "#F4F2ED",
     "accentText": "1",
     "verses": [
       {
@@ -544,7 +609,8 @@
         "verse": "Examine yourselves to see whether you are in the faith; test yourselves. Do you not realize that Christ Jesus is in you--unless, of course, you fail the test?",
         "book": "2 Corinthians",
         "reference": "13:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0e2bab06044065ed"
       },
       {
         "id": 67,
@@ -552,7 +618,8 @@
         "verse": "And this is the testimony: God has given us eternal life, and this life is in his Son. He who has the Son has life; he who does not have the Son of God does not have life.",
         "book": "1 John",
         "reference": "5:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "155e176802031f30"
       },
       {
         "id": 68,
@@ -560,7 +627,8 @@
         "verse": "I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.",
         "book": "1 John",
         "reference": "5:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "24f285489498cf08"
       },
       {
         "id": 69,
@@ -568,7 +636,8 @@
         "verse": "I tell you the truth, he who believes has everlasting life.",
         "book": "John",
         "reference": "6:47",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce4dae5f20085e0e"
       },
       {
         "id": 70,
@@ -576,7 +645,8 @@
         "verse": "In him we have redemption through his blood, the forgiveness of sins, in accordance with the riches of God's grace",
         "book": "Ephesians",
         "reference": "1:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "356bf23affe195dc"
       },
       {
         "id": 71,
@@ -584,7 +654,8 @@
         "verse": "Therefore, there is now no condemnation for those who are in Christ Jesus,",
         "book": "Romans",
         "reference": "8:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "124dcae76ec1de3c"
       },
       {
         "id": 72,
@@ -592,7 +663,8 @@
         "verse": "and are justified freely by his grace through the redemption that came by Christ Jesus.",
         "book": "Romans",
         "reference": "3:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d19a3af57928844f"
       },
       {
         "id": 73,
@@ -600,7 +672,8 @@
         "verse": "Therefore, since we have been justified through faith, we have peace with God through our Lord Jesus Christ,",
         "book": "Romans",
         "reference": "5:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "177610a779cfe686"
       },
       {
         "id": 74,
@@ -608,7 +681,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ! In his great mercy he has given us new birth into a living hope through the resurrection of Jesus Christ from the dead,",
         "book": "1 Peter",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4affcbadc906794e"
       },
       {
         "id": 75,
@@ -616,7 +690,8 @@
         "verse": "he saved us, not because of righteous things we had done, but because of his mercy. He saved us through the washing of rebirth and renewal by the Holy Spirit,",
         "book": "Titus",
         "reference": "3:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0b9ab87550629a32"
       },
       {
         "id": 76,
@@ -624,7 +699,8 @@
         "verse": "You are all sons of God through faith in Christ Jesus,",
         "book": "Galatians",
         "reference": "3:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f24f86d449d5956a"
       },
       {
         "id": 77,
@@ -632,7 +708,8 @@
         "verse": "because those who are led by the Spirit of God are sons of God.",
         "book": "Romans",
         "reference": "8:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2653c8e785a182ff"
       },
       {
         "id": 78,
@@ -640,7 +717,8 @@
         "verse": "You, however, are controlled not by the sinful nature but by the Spirit, if the Spirit of God lives in you. And if anyone does not have the Spirit of Christ, he does not belong to Christ.",
         "book": "Romans",
         "reference": "8:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1279a17374989e96"
       },
       {
         "id": 79,
@@ -648,7 +726,8 @@
         "verse": "And I will ask the Father, and he will give you another Counselor to be with you forever--the Spirit of truth. The world cannot accept him, because it neither sees him nor knows him. But you know him, for he lives with you and will be in you.",
         "book": "John",
         "reference": "14:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "faff1c45e55487a4"
       },
       {
         "id": 80,
@@ -656,7 +735,8 @@
         "verse": "I give them eternal life, and they shall never perish; no one can snatch them out of my hand. My Father, who has given them to me, is greater than all; no one can snatch them out of my Father's hand.",
         "book": "John",
         "reference": "10:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e555e2f95c975096"
       },
       {
         "id": 81,
@@ -664,7 +744,8 @@
         "verse": "neither height nor depth, nor anything else in all creation, will be able to separate us from the love of God that is in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "8:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "588208e5b2268765"
       },
       {
         "id": 82,
@@ -672,7 +753,8 @@
         "verse": "For you have been born again, not of perishable seed, but of imperishable, through the living and enduring word of God.",
         "book": "1 Peter",
         "reference": "1:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89110f6e275ec935"
       },
       {
         "id": 83,
@@ -680,13 +762,14 @@
         "verse": "And you also were included in Christ when you heard the word of truth, the gospel of your salvation. Having believed, you were marked in him with a seal, the promised Holy Spirit,",
         "book": "Ephesians",
         "reference": "1:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "260a2c48298b927b"
       }
     ]
   },
   {
     "name": "DEP 2: Quiet Time",
-    "color": "#07c387",
+    "color": "#E14C30",
     "accentText": "2",
     "verses": [
       {
@@ -695,7 +778,8 @@
         "verse": "God, who has called you into fellowship with his Son Jesus Christ our Lord, is faithful.",
         "book": "1 Corinthians",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8a38fe982d5b7f6"
       },
       {
         "id": 85,
@@ -703,7 +787,8 @@
         "verse": "Yet the Lord longs to be gracious to you; he rises to show you compassion. For the Lord is a God of justice. Blessed are all who wait for him!",
         "book": "Isaiah",
         "reference": "30:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "610ea4478365ac01"
       },
       {
         "id": 86,
@@ -711,15 +796,18 @@
         "verse": "Seek the LORD while he may be found; call on him while he is near.",
         "book": "Isaiah",
         "reference": "55:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f64edcbb29649141"
       },
       {
         "id": 87,
         "title": "God's command",
-        "verse": "My heart says of you, \"Seek his face!\" Your face, LORD, I will seek.",
+        "verse": "When thou saidst, Seek ye my face; my heart said unto thee, Thy face, LORD, will I seek.",
         "book": "Psalm",
         "reference": "27:8",
-        "subpack": ""
+        "subpack": "",
+        "version": "KJV",
+        "cardUid": "7d381e53a1f7c058"
       },
       {
         "id": 88,
@@ -727,7 +815,8 @@
         "verse": "\"I am the vine; you are the branches. If a man remains in me and I in him, he will bear much fruit; apart from me you can do nothing.",
         "book": "John",
         "reference": "15:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9387bd5b5bf89779"
       },
       {
         "id": 89,
@@ -735,7 +824,8 @@
         "verse": "The lions may grow weak and hungry, but those who seek the LORD lack no good thing.",
         "book": "Psalm",
         "reference": "34:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0ad16d0c4a6153d3"
       },
       {
         "id": 90,
@@ -743,7 +833,8 @@
         "verse": "I will stand at my watch and station myself on the ramparts; I will look to see what he will say to me, and what answer I am to give to this complaint.",
         "book": "Habakkuk",
         "reference": "2:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6eb300883f979db5"
       },
       {
         "id": 91,
@@ -751,7 +842,8 @@
         "verse": "Let the morning bring me word of your unfailing love, for I have put my trust in you. Show me the way I should go, for to you I lift up my soul. Teach me to do your will, for you are my God; may your good Spirit lead me on level ground.",
         "book": "Psalm",
         "reference": "143:8, 10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2f6336d23a165bf8"
       },
       {
         "id": 92,
@@ -759,7 +851,8 @@
         "verse": "Let us fix our eyes on Jesus, the author and perfecter of our faith, who for the joy set before him endured the cross, scorning its shame, and sat down at the right hand of the throne of God.",
         "book": "Hebrews",
         "reference": "12:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e1b2445ad26a4e7a"
       },
       {
         "id": 93,
@@ -767,7 +860,8 @@
         "verse": "Why are you downcast, O my soul? Why so disturbed within me? Put your hope in God, for I will yet praise him, my Savior and my God.",
         "book": "Psalm",
         "reference": "42:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "74fa1b0dd4703efd"
       },
       {
         "id": 94,
@@ -775,7 +869,8 @@
         "verse": "As the deer pants for streams of water, so my soul pants for you, O God.",
         "book": "Psalm",
         "reference": "42:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ea2d78cf67dade2f"
       },
       {
         "id": 95,
@@ -783,7 +878,8 @@
         "verse": "I wait for the Lord, my soul waits, and in his word I put my hope. My soul waits for the Lord more than watchmen wait for the morning, more than watchmen wait for the morning.",
         "book": "Psalm",
         "reference": "130:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "db5c5dc7b06313ec"
       },
       {
         "id": 96,
@@ -791,7 +887,8 @@
         "verse": "Cast your cares on the LORD and he will sustain you; he will never let the righteous fall.",
         "book": "Psalm",
         "reference": "55:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6309e2059c55f512"
       },
       {
         "id": 97,
@@ -799,7 +896,8 @@
         "verse": "Praise be to the Lord, to God our Savior, who daily bears our burdens. Selah",
         "book": "Psalm",
         "reference": "68:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "83daff7c5f11a20a"
       },
       {
         "id": 98,
@@ -807,7 +905,8 @@
         "verse": "If you make the Most High your dwelling--even the LORD, who is my refuge--then no harm will befall you, no disaster will come near your tent.",
         "book": "Psalm",
         "reference": "91:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2afe3a6f7a6946c6"
       },
       {
         "id": 99,
@@ -815,7 +914,8 @@
         "verse": "\"Come to me, all you who are weary and burdened, and I will give you rest. Take my yoke upon you and learn from me, for I am gentle and humble in heart, and you will find rest for your souls.",
         "book": "Matthew",
         "reference": "11:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "58030c53fe7edc27"
       },
       {
         "id": 100,
@@ -823,7 +923,8 @@
         "verse": "I rise before dawn and cry for help; I have put my hope in your word. My eyes stay open through the watches of the night, that I may meditate on your promises.",
         "book": "Psalm",
         "reference": "119:147-148",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0537398623c0c329"
       },
       {
         "id": 101,
@@ -831,7 +932,8 @@
         "verse": "In the morning, O LORD, you hear my voice; in the morning I lay my requests before you and wait in expectation.",
         "book": "Psalm",
         "reference": "5:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dbd6f710d18f9e6a"
       },
       {
         "id": 102,
@@ -839,7 +941,8 @@
         "verse": "Come, let us bow down in worship, let us kneel before the LORD our Maker;",
         "book": "Psalm",
         "reference": "95:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c868d7c0a301bf1f"
       },
       {
         "id": 103,
@@ -847,7 +950,8 @@
         "verse": "Through Jesus, therefore, let us continually offer to God a sacrifice of praise--the fruit of lips that confess his name.",
         "book": "Hebrews",
         "reference": "13:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "88773a5d3f90c574"
       },
       {
         "id": 104,
@@ -855,7 +959,8 @@
         "verse": "Satisfy us in the morning with your unfailing love, that we may sing for joy and be glad all our days.",
         "book": "Psalm",
         "reference": "90:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fa793c2e682161ba"
       },
       {
         "id": 105,
@@ -863,7 +968,8 @@
         "verse": "for he satisfies the thirsty and fills the hungry with good things.",
         "book": "Psalm",
         "reference": "107:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e0ae746c2031d91d"
       },
       {
         "id": 106,
@@ -871,15 +977,17 @@
         "verse": "Very early in the morning, while it was still dark, Jesus got up, left the house and went off to a solitary place, where he prayed.",
         "book": "Mark",
         "reference": "1:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6938e6832d16b354"
       },
       {
         "id": 107,
-        "title": "Moses - personal fellowship wtih the Lord",
+        "title": "Moses - personal fellowship with the Lord",
         "verse": "The Lord would speak to Moses face to face, as a man speaks with his friend. Then Moses would return to the camp, but his young aide Joshua son of Nun did not leave the tent.",
         "book": "Exodus",
         "reference": "33:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4c2ee4ef34127f9a"
       },
       {
         "id": 108,
@@ -887,7 +995,8 @@
         "verse": "Now when Daniel learned that the decree had been published, he went home to his upstairs room where the windows opened toward Jerusalem. Three times a day he got down on his knees and prayed, giving thanks to his God, just as he had done before.",
         "book": "Daniel",
         "reference": "6:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "928c8ef407266ab9"
       },
       {
         "id": 109,
@@ -895,13 +1004,14 @@
         "verse": "He did not say anything to them without using a parable. But when he was alone with his own disciples, he explained everything.",
         "book": "Mark",
         "reference": "4:34",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "536aa72dc5ba8b27"
       }
     ]
   },
   {
     "name": "DEP 3: The Word",
-    "color": "#ce4611",
+    "color": "#EA8A2E",
     "accentText": "3",
     "verses": [
       {
@@ -910,7 +1020,8 @@
         "verse": "All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness,",
         "book": "2 Timothy",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "41e9f49d662c3fb0"
       },
       {
         "id": 111,
@@ -918,7 +1029,8 @@
         "verse": "For prophecy never had its origin in the will of man, but men spoke from God as they were carried along by the Holy Spirit.",
         "book": "2 Peter",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bcc053f14eb3ca2a"
       },
       {
         "id": 112,
@@ -926,7 +1038,8 @@
         "verse": "Heaven and earth will pass away, but my words will never pass away.",
         "book": "Matthew",
         "reference": "24:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ff0d767910589063"
       },
       {
         "id": 113,
@@ -934,7 +1047,8 @@
         "verse": "For, \"All men are like grass, and all their glory is like the flowers of the field; the grass withers and the flowers fall, but the word of the Lord stands forever.\" And this is the word that was preached to you.",
         "book": "1 Peter",
         "reference": "1:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b37c299901343771"
       },
       {
         "id": 114,
@@ -942,7 +1056,8 @@
         "verse": "Sanctify them by the truth; your word is truth.",
         "book": "John",
         "reference": "17:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c09456b627a90939"
       },
       {
         "id": 115,
@@ -950,7 +1065,8 @@
         "verse": "O Sovereign Lord, you are God! Your words are trustworthy, and you have promised these good things to your servant.",
         "book": "2 Samuel",
         "reference": "7:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "863a2df833973eb4"
       },
       {
         "id": 116,
@@ -958,7 +1074,8 @@
         "verse": "\"Is not my word like fire,\" declares the LORD, \"and like a hammer that breaks a rock in pieces?",
         "book": "Jeremiah",
         "reference": "23:29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2a4be0be16ab5e3b"
       },
       {
         "id": 117,
@@ -966,7 +1083,8 @@
         "verse": "for which I am suffering even to the point of being chained like a criminal. But God's word is not chained.",
         "book": "2 Timothy",
         "reference": "2:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4281202ad18ef4cd"
       },
       {
         "id": 118,
@@ -974,7 +1092,8 @@
         "verse": "Jesus answered, \"It is written: 'Man does not live on bread alone, but on every word that comes from the mouth of God.' \"",
         "book": "Matthew",
         "reference": "4:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "00ea10323a7baa38"
       },
       {
         "id": 119,
@@ -982,7 +1101,8 @@
         "verse": "And beginning with Moses and all the Prophets, he explained to them what was said in all the Scriptures concerning himself.",
         "book": "Luke",
         "reference": "24:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "05513ffc4f3c1009"
       },
       {
         "id": 120,
@@ -990,7 +1110,8 @@
         "verse": "For you have been born again, not of perishable seed, but of imperishable, through the living and enduring word of God.",
         "book": "1 Peter",
         "reference": "1:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "77619ffd87cc4ba2"
       },
       {
         "id": 121,
@@ -998,7 +1119,8 @@
         "verse": "He chose to give us birth through the word of truth, that we might be a kind of firstfruits of all he created.",
         "book": "James",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b32ba9135981a05b"
       },
       {
         "id": 122,
@@ -1006,7 +1128,8 @@
         "verse": "Like newborn babies, crave pure spiritual milk, so that by it you may grow up in your salvation,",
         "book": "1 Peter",
         "reference": "2:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "77bf3666b3c2f7cf"
       },
       {
         "id": 123,
@@ -1014,7 +1137,8 @@
         "verse": "\"Now I commit you to God and to the word of his grace, which can build you up and give you an inheritance among all those who are sanctified.",
         "book": "Acts",
         "reference": "20:32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9834b498706d7ca5"
       },
       {
         "id": 124,
@@ -1022,7 +1146,8 @@
         "verse": "Your word is a lamp to my feet and a light for my path.",
         "book": "Psalm",
         "reference": "119:105",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1fb56d8174ecee4e"
       },
       {
         "id": 125,
@@ -1030,7 +1155,8 @@
         "verse": "When you walk, they will guide you; when you sleep, they will watch over you; when you awake, they will speak to you. For these commands are a lamp, this teaching is a light, and the corrections of discipline are the way to life,",
         "book": "Proverbs",
         "reference": "6:22-23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8c88e1af380bf5c9"
       },
       {
         "id": 126,
@@ -1038,7 +1164,8 @@
         "verse": "He sent forth his word and healed them; he rescued them from the grave.",
         "book": "Psalm",
         "reference": "107:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a6aeabdf3d7070df"
       },
       {
         "id": 127,
@@ -1046,7 +1173,8 @@
         "verse": "The centurion replied, \"Lord, I do not deserve to have you come under my roof. But just say the word, and my servant will be healed.",
         "book": "Matthew",
         "reference": "8:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7394e849e15310dc"
       },
       {
         "id": 128,
@@ -1054,7 +1182,8 @@
         "verse": "When your words came, I ate them; they were my joy and my heart's delight, for I bear your name, O LORD God Almighty.",
         "book": "Jeremiah",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7cba35edad20071c"
       },
       {
         "id": 129,
@@ -1062,7 +1191,8 @@
         "verse": "Your statutes are my heritage forever; they are the joy of my heart.",
         "book": "Psalm",
         "reference": "119:111",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d14dada176dda455"
       },
       {
         "id": 130,
@@ -1070,7 +1200,8 @@
         "verse": "Take the helmet of salvation and the sword of the Spirit, which is the word of God.",
         "book": "Ephesians",
         "reference": "6:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "585e176d3ef39175"
       },
       {
         "id": 131,
@@ -1078,7 +1209,8 @@
         "verse": "For the word of God is living and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "96fff2a526f1f9dd"
       },
       {
         "id": 132,
@@ -1086,7 +1218,8 @@
         "verse": "Now the Bereans were of more noble character than the Thessalonians, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89872cec45a5b4a9"
       },
       {
         "id": 133,
@@ -1094,7 +1227,8 @@
         "verse": "Oh, how I love your law! I meditate on it all day long.",
         "book": "Psalm",
         "reference": "119:97",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "358efb055edf013e"
       },
       {
         "id": 134,
@@ -1102,7 +1236,8 @@
         "verse": "For Ezra had devoted himself to the study and observance of the Law of the LORD, and to teaching its decrees and laws in Israel.",
         "book": "Ezra",
         "reference": "7:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "199cf40b89ae47ce"
       },
       {
         "id": 135,
@@ -1110,7 +1245,8 @@
         "verse": "I have not departed from the commands of his lips; I have treasured the words of his mouth more than my daily bread.",
         "book": "Job",
         "reference": "23:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c02acd6cdc6e4810"
       },
       {
         "id": 136,
@@ -1118,7 +1254,8 @@
         "verse": "Simon answered, \"Master, we've worked hard all night and haven't caught anything. But because you say so, I will let down the nets.\" When they had done so, they caught such a large number of fish that their nets began to break.",
         "book": "Luke",
         "reference": "5:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba0832ae172f6218"
       },
       {
         "id": 137,
@@ -1126,7 +1263,8 @@
         "verse": "Consequently, faith comes from hearing the message, and the message is heard through the word of Christ.",
         "book": "Romans",
         "reference": "10:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6ebeaffe80b2478b"
       },
       {
         "id": 138,
@@ -1134,7 +1272,8 @@
         "verse": "He replied, \"Blessed rather are those who hear the word of God and obey it.\"",
         "book": "Luke",
         "reference": "11:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da74bd2494677d7a"
       },
       {
         "id": 139,
@@ -1142,7 +1281,8 @@
         "verse": "Blessed is the one who reads the words of this prophecy, and blessed are those who hear it and take to heart what is written in it, because the time is near.",
         "book": "Revelation",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "083b6b056ab901f5"
       },
       {
         "id": 140,
@@ -1150,7 +1290,8 @@
         "verse": "It is to be with him, and he is to read it all the days of his life so that he may learn to revere the LORD his God and follow carefully all the words of this law and these decrees",
         "book": "Deuteronomy",
         "reference": "17:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "14127cfdb253b4f7"
       },
       {
         "id": 141,
@@ -1158,7 +1299,8 @@
         "verse": "Now the Bereans were of more noble character than the Thessalonians, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b79e8bb18c430fa3"
       },
       {
         "id": 142,
@@ -1166,7 +1308,8 @@
         "verse": "Do your best to present yourself to God as one approved, a workman who does not need to be ashamed and who correctly handles the word of truth.",
         "book": "2 Timothy",
         "reference": "2:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "80b138b461ac5d8e"
       },
       {
         "id": 143,
@@ -1174,7 +1317,8 @@
         "verse": "These commandments that I give you today are to be upon your hearts.",
         "book": "Deuteronomy",
         "reference": "6:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5430702f3c837b7a"
       },
       {
         "id": 144,
@@ -1182,7 +1326,8 @@
         "verse": "My son, keep my words and store up my commands within you. Keep my commands and you will live; guard my teachings as the apple of your eye. Bind them on your fingers; write them on the tablet of your heart.",
         "book": "Proverbs",
         "reference": "7:1-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03c1d4d9f4304548"
       },
       {
         "id": 145,
@@ -1190,7 +1335,8 @@
         "verse": "Blessed is the man who does not walk in the counsel of the wicked or stand in the way of sinners or sit in the seat of mockers. But his delight is in the law of the LORD, and on his law he meditates day and night.",
         "book": "Psalm",
         "reference": "1:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "66373c8376855260"
       },
       {
         "id": 146,
@@ -1198,22 +1344,25 @@
         "verse": "Do not let this Book of the Law depart from your mouth; meditate on it day and night, so that you may be careful to do everything written in it. Then you will be prosperous and successful.",
         "book": "Joshua",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d38f615ecae4a277"
       }
     ]
   },
   {
     "name": "DEP 4: Prayer",
-    "color": "#f3a937",
+    "color": "#E7AF21",
     "accentText": "",
     "verses": [
       {
         "id": 276,
         "title": "Cease not to pray",
-        "verse": "pray continually;",
+        "verse": "Pray without ceasing.",
         "book": "1 Thessalonians",
         "reference": "5:17",
-        "subpack": ""
+        "subpack": "",
+        "version": "KJV",
+        "cardUid": "9d12f07eadc1c641"
       },
       {
         "id": 277,
@@ -1221,7 +1370,8 @@
         "verse": "Devote yourselves to prayer, being watchful and thankful.",
         "book": "Colossians",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cd28506d2f6db7b1"
       },
       {
         "id": 278,
@@ -1229,7 +1379,8 @@
         "verse": "The end of all things is near. Therefore be clear minded and self-controlled so that you can pray.",
         "book": "1 Peter",
         "reference": "4:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bf1ea21825142f90"
       },
       {
         "id": 279,
@@ -1237,7 +1388,8 @@
         "verse": "I urge, then, first of all, that requests, prayers, intercession and thanksgiving be made for everyone--for kings and all those in authority, that we may live peaceful and quiet lives in all godliness and holiness.",
         "book": "1 Timothy",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "85397800fdfa7915"
       },
       {
         "id": 280,
@@ -1245,7 +1397,8 @@
         "verse": "And I will do whatever you ask in my name, so that the Son may bring glory to the Father. You may ask me for anything in my name, and I will do it.",
         "book": "John",
         "reference": "14:13-14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8861483a5122975"
       },
       {
         "id": 281,
@@ -1253,7 +1406,8 @@
         "verse": "Now to him who is able to do immeasurably more than all we ask or imagine, according to his power that is at work within us,",
         "book": "Ephesians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba010795e70ab8bd"
       },
       {
         "id": 282,
@@ -1261,7 +1415,8 @@
         "verse": "'Call to me and I will answer you and tell you great and unsearchable things you do not know.'",
         "book": "Jeremiah",
         "reference": "33:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f1d8fed3a717d4a7"
       },
       {
         "id": 283,
@@ -1269,7 +1424,8 @@
         "verse": "If any of you lacks wisdom, he should ask God, who gives generously to all without finding fault, and it will be given to him.",
         "book": "James",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "98a7e1ed66c68ffd"
       },
       {
         "id": 284,
@@ -1277,7 +1433,8 @@
         "verse": "I sought the Lord, and he answered me; he delivered me from all my fears.",
         "book": "Psalm",
         "reference": "34:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c16a62eba9399c81"
       },
       {
         "id": 285,
@@ -1285,7 +1442,8 @@
         "verse": "and call upon me in the day of trouble; I will deliver you, and you will honor me.",
         "book": "Psalm",
         "reference": "50:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "617d4239d9bd6d98"
       },
       {
         "id": 286,
@@ -1293,7 +1451,8 @@
         "verse": "After they prayed, the place where they were meeting was shaken. And they were all filled with the Holy Spirit and spoke the word of God boldly.",
         "book": "Acts",
         "reference": "4:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "422163800b78aebd"
       },
       {
         "id": 287,
@@ -1301,7 +1460,8 @@
         "verse": "And pray for us, too, that God may open a door for our message, so that we may proclaim the mystery of Christ, for which I am in chains.",
         "book": "Colossians",
         "reference": "4:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "56cdbfa495a7f20a"
       },
       {
         "id": 288,
@@ -1309,7 +1469,8 @@
         "verse": "Until now you have not asked for anything in my name. Ask and you will receive, and your joy will be complete.",
         "book": "John",
         "reference": "16:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef7995099e124a44"
       },
       {
         "id": 289,
@@ -1317,7 +1478,8 @@
         "verse": "If you believe, you will receive whatever you ask for in prayer.",
         "book": "Matthew",
         "reference": "21:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "eb1b4a517bffe747"
       },
       {
         "id": 290,
@@ -1325,7 +1487,8 @@
         "verse": "And pray in the Spirit on all occasions with all kinds of prayers and requests. With this in mind, be alert and always keep on praying for all the saints.",
         "book": "Ephesians",
         "reference": "6:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "783a0516c2505f17"
       },
       {
         "id": 291,
@@ -1333,7 +1496,8 @@
         "verse": "This is the confidence we have in approaching God: that if we ask anything according to his will, he hears us. And if we know that he hears us-whatever we ask--we know that we have what we asked of him.",
         "book": "1 John",
         "reference": "5:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da5ce14426f3e06f"
       },
       {
         "id": 292,
@@ -1341,7 +1505,8 @@
         "verse": "If I had cherished sin in my heart, the Lord would not have listened;",
         "book": "Psalm",
         "reference": "66:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dd51dc12ad9f6509"
       },
       {
         "id": 293,
@@ -1349,7 +1514,8 @@
         "verse": "and receive from him anything we ask, because we obey his commands and do what pleases him.",
         "book": "1 John",
         "reference": "3:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5e4d596248082e94"
       },
       {
         "id": 294,
@@ -1357,7 +1523,8 @@
         "verse": "Again, I tell you that if two of you on earth agree about anything you ask for, it will be done for you by my Father in heaven.",
         "book": "Matthew",
         "reference": "18:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1b094edea388136c"
       },
       {
         "id": 295,
@@ -1365,7 +1532,8 @@
         "verse": "Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; he who seeks finds; and to him who knocks, the door will be opened.",
         "book": "Matthew",
         "reference": "7:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a6ad9f702b683a16"
       },
       {
         "id": 296,
@@ -1373,7 +1541,8 @@
         "verse": "Then you will call upon me and come and pray to me, and I will listen to you. You will seek me and find me when you seek me with all your heart.",
         "book": "Jeremiah",
         "reference": "29:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "35b18764f19d2183"
       },
       {
         "id": 297,
@@ -1381,7 +1550,8 @@
         "verse": "Remember the instruction you gave your servant Moses, saying, 'If you are unfaithful, I will scatter you among the nations, but if you return to me and obey my commands, then even if your exiled people are at the farthest horizon, I will gather them from there and bring them to the place I have chosen as a dwelling for my Name.'",
         "book": "Nehemiah",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c6142208318970d4"
       },
       {
         "id": 298,
@@ -1389,7 +1559,8 @@
         "verse": "Now when Daniel learned that the decree had been published, he went home to his upstairs room where the windows opened toward Jerusalem. Three times a day he got down on his knees and prayed, giving thanks to his God, just as he had done before.",
         "book": "Daniel",
         "reference": "6:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8f7c17711adcc2db"
       },
       {
         "id": 299,
@@ -1397,7 +1568,8 @@
         "verse": "Yet the news about him spread all the more, so that crowds of people came to hear him and to be healed of their sicknesses. But Jesus often withdrew to lonely places and prayed.",
         "book": "Luke",
         "reference": "5:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "de1a6f417466abe3"
       },
       {
         "id": 300,
@@ -1405,7 +1577,8 @@
         "verse": "One of those days Jesus went out to a mountainside to pray, and spent the night praying to God.",
         "book": "Luke",
         "reference": "6:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5874d64db44ec733"
       },
       {
         "id": 301,
@@ -1413,7 +1586,8 @@
         "verse": "Elijah was a man just like us. He prayed earnestly that it would not rain, and it did not rain on the land for three and a half years. Again he prayed, and the heavens gave rain, and the earth produced its crops.",
         "book": "James",
         "reference": "5:17-18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4f3c8571456577ef"
       },
       {
         "id": 302,
@@ -1421,7 +1595,8 @@
         "verse": "About midnight Paul and Silas were praying and singing hymns to God, and the other prisoners were listening to them.",
         "book": "Acts",
         "reference": "16:25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89e735c0e94ee1b1"
       },
       {
         "id": 303,
@@ -1429,7 +1604,8 @@
         "verse": "Yours, O LORD, is the greatness and the power and the glory and the majesty and the splendor, for everything in heaven and earth is yours. Yours, O LORD, is the kingdom; you are exalted as head over all. Wealth and honor come from you; you are the ruler of all things. In your hands are strength and power to exalt and give strength to all. Now, our God, we give you thanks, and praise your glorious name.",
         "book": "1 Chronicles",
         "reference": "29:11-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "325f2fbdd4b36141"
       },
       {
         "id": 304,
@@ -1437,7 +1613,8 @@
         "verse": "I urge, then, first of all, that requests, prayers, intercession and thanksgiving be made for everyone--for kings and all those in authority, that we may live peaceful and quiet lives in all godliness and holiness.",
         "book": "1 Timothy",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc1d5b9ae92bf91f"
       },
       {
         "id": 305,
@@ -1445,7 +1622,8 @@
         "verse": "give thanks in all circumstances, for this is God's will for you in Christ Jesus.",
         "book": "1 Thessalonians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce2211af189d824c"
       },
       {
         "id": 306,
@@ -1453,7 +1631,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e8f42f860d2fdcd1"
       },
       {
         "id": 307,
@@ -1461,13 +1640,14 @@
         "verse": "Do not be anxious about anything, but in everything, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6eac8319747cf265"
       }
     ]
   },
   {
     "name": "DEP 5: Fellowship",
-    "color": "#00ff07",
+    "color": "#019A4E",
     "accentText": "5",
     "verses": [
       {
@@ -1476,7 +1656,8 @@
         "verse": "But now in Christ Jesus you who once were far away have been brought near through the blood of Christ.",
         "book": "Ephesians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "851be69006bec95c"
       },
       {
         "id": 148,
@@ -1484,7 +1665,8 @@
         "verse": "and through him to reconcile to himself all things, whether things on earth or things in heaven, by making peace through his blood, shed on the cross.",
         "book": "Colossians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e37fc1d869cd48c3"
       },
       {
         "id": 149,
@@ -1492,7 +1674,8 @@
         "verse": "We proclaim to you what we have seen and heard, so that you also may have fellowship with us. And our fellowship is with the Father and with his Son, Jesus Christ.",
         "book": "1 John",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "82c58b4a3869dc98"
       },
       {
         "id": 150,
@@ -1500,7 +1683,8 @@
         "verse": "May the grace of the Lord Jesus Christ, and the love of God, and the fellowship of the Holy Spirit be with you all.",
         "book": "2 Corinthians",
         "reference": "13:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "364a4ecdcce4d565"
       },
       {
         "id": 151,
@@ -1508,7 +1692,8 @@
         "verse": "For where two or three come together in my name, there am I with them.\"",
         "book": "Matthew",
         "reference": "18:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9a03ddf552b9aca7"
       },
       {
         "id": 152,
@@ -1516,7 +1701,8 @@
         "verse": "How good and pleasant it is when brothers live together in unity! It is like precious oil poured on the head, running down on the beard, running down on Aaron's beard, down upon the collar of his robes. It is as if the dew of Hermon were falling on Mount Zion. For there the Lord bestows his blessing, even life forevermore.",
         "book": "Psalm",
         "reference": "133:1-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57f2966ff215d17a"
       },
       {
         "id": 153,
@@ -1524,7 +1710,8 @@
         "verse": "But encourage one another daily, as long as it is called Today, so that none of you may be hardened by sin's deceitfulness.",
         "book": "Hebrews",
         "reference": "3:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d2b7ae572091d2e7"
       },
       {
         "id": 154,
@@ -1532,7 +1719,8 @@
         "verse": "Two are better than one, because they have a good return for their work: If one falls down, his friend can help him up. But pity the man who falls and has no one to help him up!",
         "book": "Ecclesiastes",
         "reference": "4:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cfab94960a4230be"
       },
       {
         "id": 155,
@@ -1540,7 +1728,8 @@
         "verse": "Flee the evil desires of youth, and pursue righteousness, faith, love and peace, along with those who call on the Lord out of a pure heart.",
         "book": "2 Timothy",
         "reference": "2:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cbf94210a8eb820a"
       },
       {
         "id": 156,
@@ -1548,7 +1737,8 @@
         "verse": "As iron sharpens iron, so one man sharpens another. As water reflects a face, so a man's heart reflects the man.",
         "book": "Proverbs",
         "reference": "27:17,19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1c0a9bb6e909d064"
       },
       {
         "id": 157,
@@ -1556,7 +1746,8 @@
         "verse": "He who walks with the wise grows wise, but a companion of fools suffers harm.",
         "book": "Proverbs",
         "reference": "13:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "91b229f53594fb7d"
       },
       {
         "id": 158,
@@ -1564,7 +1755,8 @@
         "verse": "until we all reach unity in the faith and in the knowledge of the Son of God and become mature, attaining to the whole measure of the fullness of Christ.",
         "book": "Ephesians",
         "reference": "4:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "255248f46b9ff9a4"
       },
       {
         "id": 159,
@@ -1572,7 +1764,8 @@
         "verse": "They devoted themselves to the apostles' teaching and to the fellowship, to the breaking of bread and to prayer. praising God and enjoying the favor of all the people. And the Lord added to their number daily those who were being saved.",
         "book": "Acts",
         "reference": "2:42,47",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "391a5138580066f7"
       },
       {
         "id": 160,
@@ -1580,7 +1773,8 @@
         "verse": "because of your partnership in the gospel from the first day until now, Whatever happens, conduct yourselves in a manner worthy of the gospel of Christ. Then, whether I come and see you or only hear about you in my absence, I will know that you stand firm in one spirit, contending as one man for the faith of the gospel",
         "book": "Philippians",
         "reference": "1:5,27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0c9b1f24e70a1d22"
       },
       {
         "id": 161,
@@ -1588,7 +1782,8 @@
         "verse": "And let us consider how we may spur one another on toward love and good deeds. Let us not give up meeting together, as some are in the habit of doing, but let us encourage one another--and all the more as you see the Day approaching.",
         "book": "Hebrews",
         "reference": "10:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "efb9cea35522b581"
       },
       {
         "id": 162,
@@ -1596,7 +1791,8 @@
         "verse": "For I testify that they gave as much as they were able, and even beyond their ability. Entirely on their own, they urgently pleaded with us for the privilege of sharing in this service to the saints.",
         "book": "2 Corinthians",
         "reference": "8:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e62106982323de23"
       },
       {
         "id": 163,
@@ -1604,7 +1800,8 @@
         "verse": "But rejoice that you participate in the sufferings of Christ, so that you may be overjoyed when his glory is revealed.",
         "book": "1 Peter",
         "reference": "4:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2ec3dead68c10958"
       },
       {
         "id": 164,
@@ -1612,7 +1809,8 @@
         "verse": "Carry each other's burdens, and in this way you will fulfill the law of Christ.",
         "book": "Galatians",
         "reference": "6:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8f6124a735424219"
       },
       {
         "id": 165,
@@ -1620,7 +1818,8 @@
         "verse": "If you have any encouragement from being united with Christ, if any comfort from his love, if any fellowship with the Spirit, if any tenderness and compassion, then make my joy complete by being like-minded, having the same love, being one in spirit and purpose.",
         "book": "Philippians",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "05ffe60782e4a962"
       },
       {
         "id": 166,
@@ -1628,7 +1827,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit, but in humility consider others better than yourselves. Each of you should look not only to your own interests, but also to the interests of others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "003eb8b4dd2d5b93"
       },
       {
         "id": 167,
@@ -1636,7 +1836,8 @@
         "verse": "We are not withholding our affection from you, but you are withholding yours from us. As a fair exchange--I speak as to my children--open wide your hearts also.",
         "book": "2 Corinthians",
         "reference": "6:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b234bfdf8e881b59"
       },
       {
         "id": 168,
@@ -1644,7 +1845,8 @@
         "verse": "Submit to one another out of reverence for Christ.",
         "book": "Ephesians",
         "reference": "5:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3b1332a9c553db15"
       },
       {
         "id": 169,
@@ -1652,7 +1854,8 @@
         "verse": "But they kept quiet because on the way they had argued about who was the greatest. Sitting down, Jesus called the Twelve and said, \"If anyone wants to be first, he must be the very last, and the servant of all.\"",
         "book": "Mark",
         "reference": "9:34-35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c0cd2d9fe5522d18"
       },
       {
         "id": 170,
@@ -1660,7 +1863,8 @@
         "verse": "See to it that no one misses the grace of God and that no bitter root grows up to cause trouble and defile many.",
         "book": "Hebrews",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f3c6d9738b6fdd41"
       },
       {
         "id": 171,
@@ -1668,7 +1872,8 @@
         "verse": "Have nothing to do with the fruitless deeds of darkness, but rather expose them.",
         "book": "Ephesians",
         "reference": "5:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d1687f3357b758c2"
       },
       {
         "id": 172,
@@ -1676,7 +1881,8 @@
         "verse": "No one serving as a soldier gets involved in civilian affairs--he wants to please his commanding officer.",
         "book": "2 Timothy",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "82cfaf89158bfaa5"
       },
       {
         "id": 173,
@@ -1684,7 +1890,8 @@
         "verse": "\"Therefore, if you are offering your gift at the altar and there remember that your brother has something against you, leave your gift there in front of the altar. First go and be reconciled to your brother; then come and offer your gift.",
         "book": "Matthew",
         "reference": "5:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70766a8c061484a1"
       },
       {
         "id": 174,
@@ -1692,7 +1899,8 @@
         "verse": "\"If your brother sins against you, go and show him his fault, just between the two of you. If he listens to you, you have won your brother over.",
         "book": "Matthew",
         "reference": "18:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f98e381dfc5609ee"
       },
       {
         "id": 175,
@@ -1700,7 +1908,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ecbc539fcd01bb79"
       },
       {
         "id": 176,
@@ -1708,13 +1917,14 @@
         "verse": "He who conceals his sins does not prosper, but whoever confesses and renounces them finds mercy.",
         "book": "Proverbs",
         "reference": "28:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2c71d56fa3d0e05b"
       }
     ]
   },
   {
     "name": "DEP 6: Witnessing",
-    "color": "#14f7ff",
+    "color": "#0090D0",
     "accentText": "6",
     "verses": [
       {
@@ -1723,7 +1933,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\"",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "42d32896a4d2dbc4"
       },
       {
         "id": 178,
@@ -1731,7 +1942,8 @@
         "verse": "All this is from God, who reconciled us to himself through Christ and gave us the ministry of reconciliation: that God was reconciling the world to himself in Christ, not counting men's sins against them. And he has committed to us the message of reconciliation.",
         "book": "2 Corinthians",
         "reference": "5:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "18fd8b95b8493fe0"
       },
       {
         "id": 179,
@@ -1739,7 +1951,8 @@
         "verse": "In the presence of God and of Christ Jesus, who will judge the living and the dead, and in view of his appearing and his kingdom, I give you this charge: Preach the Word; be prepared in season and out of season; correct, rebuke and encourage--with great patience and careful instruction.",
         "book": "2 Timothy",
         "reference": "4:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8450d0c69ccff067"
       },
       {
         "id": 180,
@@ -1747,7 +1960,8 @@
         "verse": "For the Son of Man came to seek and to save what was lost.\"",
         "book": "Luke",
         "reference": "19:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a3c641f0768b66f6"
       },
       {
         "id": 181,
@@ -1755,7 +1969,8 @@
         "verse": "On the contrary, we speak as men approved by God to be entrusted with the gospel. We are not trying to please men but God, who tests our hearts.",
         "book": "1 Thessalonians",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "796de829c27a8b0f"
       },
       {
         "id": 182,
@@ -1763,7 +1978,8 @@
         "verse": "Yet when I preach the gospel, I cannot boast, for I am compelled to preach. Woe to me if I do not preach the gospel!",
         "book": "1 Corinthians",
         "reference": "9:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "47f50bd3719f9dd9"
       },
       {
         "id": 183,
@@ -1771,7 +1987,8 @@
         "verse": "How, then, can they call on the one they have not believed in? And how can they believe in the one of whom they have not heard? And how can they hear without someone preaching to them?",
         "book": "Romans",
         "reference": "10:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87b64570af3a0ecc"
       },
       {
         "id": 184,
@@ -1779,15 +1996,17 @@
         "verse": "This is good, and pleases God our Savior, who wants all men to be saved and to come to a knowledge of the truth.",
         "book": "1 Timothy",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03c1259b89eb0d13"
       },
       {
         "id": 185,
         "title": "God's great concern for men",
-        "verse": "But the LORD said, \"You have been concerned about this vine, though you did not tend it or make it grow. It sprang up overnight and died overnight. But Nineveh has more than a hundred and twenty thousand people who cannot tell their right hand from their left, and many cattle as well. Should I not be concerned about that great city?\" \u001a",
+        "verse": "But the LORD said, \"You have been concerned about this vine, though you did not tend it or make it grow. It sprang up overnight and died overnight. But Nineveh has more than a hundred and twenty thousand people who cannot tell their right hand from their left, and many cattle as well. Should I not be concerned about that great city?\"",
         "book": "Jonah",
         "reference": "4:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "14ca94f31b70f845"
       },
       {
         "id": 186,
@@ -1795,7 +2014,8 @@
         "verse": "I tell you that in the same way there will be more rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent.",
         "book": "Luke",
         "reference": "15:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f4b72ea2ac2df154"
       },
       {
         "id": 187,
@@ -1803,7 +2023,8 @@
         "verse": "We proclaim to you what we have seen and heard, so that you also may have fellowship with us. And our fellowship is with the Father and with his Son, Jesus Christ.",
         "book": "1 John",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1b4e207919ef5a98"
       },
       {
         "id": 188,
@@ -1811,7 +2032,8 @@
         "verse": "Those who are wise will shine like the brightness of the heavens, and those who lead many to righteousness, like the stars for ever and ever.",
         "book": "Daniel",
         "reference": "12:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "471a02f6807cfe9b"
       },
       {
         "id": 189,
@@ -1819,7 +2041,8 @@
         "verse": "\"Come, follow me,\" Jesus said, \"and I will make you fishers of men.\"",
         "book": "Matthew",
         "reference": "4:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a562c26b910f45c"
       },
       {
         "id": 190,
@@ -1827,7 +2050,8 @@
         "verse": "so that you may become blameless and pure, children of God without fault in a crooked and depraved generation, in which you shine like stars in the universe as you hold out the word of life--in order that I may boast on the day of Christ that I did not run or labor for nothing.",
         "book": "Philippians",
         "reference": "2:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6caa572ca7098f83"
       },
       {
         "id": 191,
@@ -1835,7 +2059,8 @@
         "verse": "Pray also for me, that whenever I open my mouth, words may be given me so that I will fearlessly make known the mystery of the gospel,",
         "book": "Ephesians",
         "reference": "6:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a726b675872941c8"
       },
       {
         "id": 192,
@@ -1843,7 +2068,8 @@
         "verse": "But in your hearts set apart Christ as Lord. Always be prepared to give an answer to everyone who asks you to give the reason for the hope that you have. But do this with gentleness and respect,",
         "book": "1 Peter",
         "reference": "3:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fdd0269c8535ec8f"
       },
       {
         "id": 193,
@@ -1851,7 +2077,8 @@
         "verse": "Many of the Samaritans from that town believed in him because of the woman's testimony, \"He told me everything I ever did.\"",
         "book": "John",
         "reference": "4:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5e6de217dbf7f892"
       },
       {
         "id": 194,
@@ -1859,7 +2086,8 @@
         "verse": "For the word of God is living and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7100d4f006d43f0b"
       },
       {
         "id": 195,
@@ -1867,7 +2095,8 @@
         "verse": "so is my word that goes out from my mouth: It will not return to me empty, but will accomplish what I desire and achieve the purpose for which I sent it.",
         "book": "Isaiah",
         "reference": "55:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e71ee053bb84e1f2"
       },
       {
         "id": 196,
@@ -1875,7 +2104,8 @@
         "verse": "but we preach Christ crucified: a stumbling block to Jews and foolishness to Gentiles, but to those whom God has called, both Jews and Greeks, Christ the power of God and the wisdom of God.",
         "book": "1 Corinthians",
         "reference": "1:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "90b0ff12647b90ca"
       },
       {
         "id": 197,
@@ -1883,7 +2113,8 @@
         "verse": "because our gospel came to you not simply with words, but also with power, with the Holy Spirit and with deep conviction. You know how we lived among you for your sake.",
         "book": "1 Thessalonians",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bfb5bd8e3ae7ad5e"
       },
       {
         "id": 198,
@@ -1891,7 +2122,8 @@
         "verse": "That if you confess with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you confess and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d84c71c21053f92c"
       },
       {
         "id": 199,
@@ -1899,7 +2131,8 @@
         "verse": "For he says, \"In the time of my favor I heard you, and in the day of salvation I helped you.\" I tell you, now is the time of God's favor, now is the day of salvation.",
         "book": "2 Corinthians",
         "reference": "6:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ed585ba601cbbd9b"
       },
       {
         "id": 200,
@@ -1907,7 +2140,8 @@
         "verse": "Examine yourselves to see whether you are in the faith; test yourselves. Do you not realize that Christ Jesus is in you--unless, of course, you fail the test?",
         "book": "2 Corinthians",
         "reference": "13:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "27843920558c8d5f"
       },
       {
         "id": 201,
@@ -1915,7 +2149,8 @@
         "verse": "As his custom was, Paul went into the synagogue, and on three Sabbath days he reasoned with them from the Scriptures, explaining and proving that the Christ had to suffer and rise from the dead. \"This Jesus I am proclaiming to you is the Christ,\" he said.",
         "book": "Acts",
         "reference": "17:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9622580e7c6b1191"
       },
       {
         "id": 202,
@@ -1923,7 +2158,8 @@
         "verse": "However, I consider my life worth nothing to me, if only I may finish the race and complete the task the Lord Jesus has given me--the task of testifying to the gospel of God's grace.",
         "book": "Acts",
         "reference": "20:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a68b0cf6a363059c"
       },
       {
         "id": 203,
@@ -1931,7 +2167,8 @@
         "verse": "The Spirit told Philip, \"Go to that chariot and stay near it.\" Then Philip ran up to the chariot and heard the man reading Isaiah the prophet. \"Do you understand what you are reading?\" Philip asked.",
         "book": "Acts",
         "reference": "8:29-30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba5726b0240962b4"
       },
       {
         "id": 204,
@@ -1939,7 +2176,8 @@
         "verse": "For we cannot help speaking about what we have seen and heard.\"",
         "book": "Acts",
         "reference": "4:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef7c5e1ce7b05012"
       },
       {
         "id": 205,
@@ -1947,7 +2185,8 @@
         "verse": "So God created man in his own image, in the image of God he created him; male and female he created them.",
         "book": "Genesis",
         "reference": "1:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "74ad102a507ac9de"
       },
       {
         "id": 206,
@@ -1955,7 +2194,8 @@
         "verse": "Surely the arm of the LORD is not too short to save, nor his ear too dull to hear. But your iniquities have separated you from your God; your sins have hidden his face from you, so that he will not hear.",
         "book": "Isaiah",
         "reference": "59:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d92ff2297902730a"
       },
       {
         "id": 207,
@@ -1963,7 +2203,8 @@
         "verse": "Therefore, just as sin entered the world through one man, and death through sin, and in this way death came to all men, because all sinned--",
         "book": "Romans",
         "reference": "5:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "df6c5ddf2a846315"
       },
       {
         "id": 208,
@@ -1971,7 +2212,8 @@
         "verse": "for all have sinned and fall short of the glory of God,",
         "book": "Romans",
         "reference": "3:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6fc02e7f3d5a1a92"
       },
       {
         "id": 209,
@@ -1979,7 +2221,8 @@
         "verse": "Just as man is destined to die once, and after that to face judgment,",
         "book": "Hebrews",
         "reference": "9:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b15fc4f39cc45bb4"
       },
       {
         "id": 210,
@@ -1987,7 +2230,8 @@
         "verse": "He will punish those who do not know God and do not obey the gospel of our Lord Jesus. They will be punished with everlasting destruction and shut out from the presence of the Lord and from the majesty of his power",
         "book": "2 Thessalonians",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a91aa9bf635fee8"
       },
       {
         "id": 211,
@@ -1995,7 +2239,8 @@
         "verse": "For the wages of sin is death, but the gift of God is eternal life in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "6:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "46f486793eff08bc"
       },
       {
         "id": 212,
@@ -2003,7 +2248,8 @@
         "verse": "But the cowardly, the unbelieving, the vile, the murderers, the sexually immoral, those who practice magic arts, the idolaters and all liars--their place will be in the fiery lake of burning sulfur. This is the second death.\"",
         "book": "Revelation",
         "reference": "21:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "16d56d1c1c607084"
       },
       {
         "id": 213,
@@ -2011,7 +2257,8 @@
         "verse": "For it is by grace you have been saved, through faith--and this not from yourselves, it is the gift of God--not by works, so that no one can boast.",
         "book": "Ephesians",
         "reference": "2:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f7cd4531c1748fa5"
       },
       {
         "id": 214,
@@ -2019,7 +2266,8 @@
         "verse": "I do not set aside the grace of God, for if righteousness could be gained through the law, Christ died for nothing!\"",
         "book": "Galatians",
         "reference": "2:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4042588b4b1ae2a2"
       },
       {
         "id": 215,
@@ -2027,7 +2275,8 @@
         "verse": "Salvation is found in no one else, for there is no other name under heaven given to men by which we must be saved.\"",
         "book": "Acts",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cdfb48caaad46ba7"
       },
       {
         "id": 216,
@@ -2035,7 +2284,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your forefathers,",
         "book": "1 Peter",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9e407216615ea0ac"
       },
       {
         "id": 217,
@@ -2043,7 +2293,8 @@
         "verse": "Jews demand miraculous signs and Greeks look for wisdom, but we preach Christ crucified: a stumbling block to Jews and foolishness to Gentiles,",
         "book": "1 Corinthians",
         "reference": "1:22-23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "25ec47827abd1293"
       },
       {
         "id": 218,
@@ -2051,7 +2302,8 @@
         "verse": "For since in the wisdom of God the world through its wisdom did not know him, God was pleased through the foolishness of what was preached to save those who believe.",
         "book": "1 Corinthians",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b6176d2da12b6302"
       },
       {
         "id": 219,
@@ -2059,7 +2311,8 @@
         "verse": "See to it that no one takes you captive through hollow and deceptive philosophy, which depends on human tradition and the basic principles of this world rather than on Christ.",
         "book": "Colossians",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "655f8c5a96949696"
       },
       {
         "id": 220,
@@ -2067,7 +2320,8 @@
         "verse": "children born not of natural descent, nor of human decision or a husband's will, but born of God.",
         "book": "John",
         "reference": "1:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2e9f0b24bb32ca91"
       },
       {
         "id": 221,
@@ -2075,7 +2329,8 @@
         "verse": "Flesh gives birth to flesh, but the Spirit gives birth to spirit. You should not be surprised at my saying, 'You must be born again.'",
         "book": "John",
         "reference": "3:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bc4301af4d3bc643"
       },
       {
         "id": 222,
@@ -2083,7 +2338,8 @@
         "verse": "The Spirit gives life; the flesh counts for nothing. The words I have spoken to you are spirit and they are life.",
         "book": "John",
         "reference": "6:63",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b4007135935d86d9"
       },
       {
         "id": 223,
@@ -2091,7 +2347,8 @@
         "verse": "For Christ died for sins once for all, the righteous for the unrighteous, to bring you to God. He was put to death in the body but made alive by the Spirit,",
         "book": "1 Peter",
         "reference": "3:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9cd43164e840fbf8"
       },
       {
         "id": 224,
@@ -2099,7 +2356,8 @@
         "verse": "\"For God so loved the world that he gave his one and only Son, that whoever believes in him shall not perish but have eternal life.",
         "book": "John",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61cb35edc10396cf"
       },
       {
         "id": 225,
@@ -2107,7 +2365,8 @@
         "verse": "But God demonstrates his own love for us in this: While we were still sinners, Christ died for us.",
         "book": "Romans",
         "reference": "5:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a90ad23df1b8716c"
       },
       {
         "id": 226,
@@ -2115,7 +2374,8 @@
         "verse": "For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day according to the Scriptures,",
         "book": "1 Corinthians",
         "reference": "15:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e9a225100315dfa4"
       },
       {
         "id": 227,
@@ -2123,7 +2383,8 @@
         "verse": "When you were dead in your sins and in the uncircumcision of your sinful nature, God made you alive with Christ. He forgave us all our sins,",
         "book": "Colossians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f5ec7373c98e59aa"
       },
       {
         "id": 228,
@@ -2131,7 +2392,8 @@
         "verse": "\"I tell you the truth, whoever hears my word and believes him who sent me has eternal life and will not be condemned; he has crossed over from death to life.",
         "book": "John",
         "reference": "5:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f3fb749fb62914c5"
       },
       {
         "id": 229,
@@ -2139,7 +2401,8 @@
         "verse": "Yet to all who received him, to those who believed in his name, he gave the right to become children of God--",
         "book": "John",
         "reference": "1:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b0423d531d0ff503"
       },
       {
         "id": 230,
@@ -2147,7 +2410,8 @@
         "verse": "Here I am! I stand at the door and knock. If anyone hears my voice and opens the door, I will come in and eat with him, and he with me.",
         "book": "Revelation",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bf12ed32e00a4544"
       },
       {
         "id": 231,
@@ -2155,13 +2419,14 @@
         "verse": "That if you confess with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you confess and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57bb2d28e2cb658d"
       }
     ]
   },
   {
     "name": "DEP 7: The Lordship of Christ",
-    "color": "#0032ff",
+    "color": "#01409E",
     "accentText": "7",
     "verses": [
       {
@@ -2170,7 +2435,8 @@
         "verse": "He was with God in the beginning. Through him all things were made; without him nothing was made that has been made.",
         "book": "John",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e3826d02963fa08f"
       },
       {
         "id": 233,
@@ -2178,7 +2444,8 @@
         "verse": "For by him all things were created: things in heaven and on earth, visible and invisible, whether thrones or powers or rulers or authorities; all things were created by him and for him. He is before all things, and in him all things hold together.",
         "book": "Colossians",
         "reference": "1:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f68a939769d759fb"
       },
       {
         "id": 234,
@@ -2186,7 +2453,8 @@
         "verse": "And he is the head of the body, the church; he is the beginning and the firstborn from among the dead, so that in everything he might have the supremacy.",
         "book": "Colossians",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "678639d1f4e8c15c"
       },
       {
         "id": 235,
@@ -2194,7 +2462,8 @@
         "verse": "far above all rule and authority, power and dominion, and every title that can be given, not only in the present age but also in the one to come.",
         "book": "Ephesians",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "680faf2e6e7e691a"
       },
       {
         "id": 236,
@@ -2202,7 +2471,8 @@
         "verse": "that at the name of Jesus every knee should bow, in heaven and on earth and under the earth, and every tongue confess that Jesus Christ is Lord, to the glory of God the Father.",
         "book": "Philippians",
         "reference": "2:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dff34281e8231c62"
       },
       {
         "id": 237,
@@ -2210,7 +2480,8 @@
         "verse": "For this very reason, Christ died and returned to life so that he might be the Lord of both the dead and the living.",
         "book": "Romans",
         "reference": "14:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f971219321809d88"
       },
       {
         "id": 238,
@@ -2218,7 +2489,8 @@
         "verse": "Do you not know that your body is a temple of the Holy Spirit, who is in you, whom you have received from God? You are not your own; you were bought at a price. Therefore honor God with your body.",
         "book": "1 Corinthians",
         "reference": "6:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb77cab02059d213"
       },
       {
         "id": 239,
@@ -2226,7 +2498,8 @@
         "verse": "And he died for all, that those who live should no longer live for themselves but for him who died for them and was raised again.",
         "book": "2 Corinthians",
         "reference": "5:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b5ceb1d868294633"
       },
       {
         "id": 240,
@@ -2234,7 +2507,8 @@
         "verse": "But seek first his kingdom and his righteousness, and all these things will be given to you as well.",
         "book": "Matthew",
         "reference": "6:33",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5fea29f2b0512d37"
       },
       {
         "id": 241,
@@ -2242,7 +2516,8 @@
         "verse": "\"I tell you the truth,\" Jesus replied, \"no one who has left home or brothers or sisters or mother or father or children or fields for me and the gospel will fail to receive a hundred times as much in this present age (homes, brothers, sisters, mothers, children and fields--and with them, persecutions) and in the age to come, eternal life.",
         "book": "Mark",
         "reference": "10:29-30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "30072efb63ad246d"
       },
       {
         "id": 242,
@@ -2250,7 +2525,8 @@
         "verse": "and said, \"I swear by myself, declares the LORD, that because you have done this and have not withheld your son, your only son, I will surely bless you and make your descendants as numerous as the stars in the sky and as the sand on the seashore. Your descendants will take possession of the cities of their enemies,",
         "book": "Genesis",
         "reference": "22:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "60b184454c2177e2"
       },
       {
         "id": 243,
@@ -2258,7 +2534,8 @@
         "verse": "\"And you, my son Solomon, acknowledge the God of your father, and serve him with wholehearted devotion and with a willing mind, for the LORD searches every heart and understands every motive behind the thoughts. If you seek him, he will be found by you; but if you forsake him, he will reject you forever.",
         "book": "1 Chronicles",
         "reference": "28:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c00a83066f8068a4"
       },
       {
         "id": 244,
@@ -2266,7 +2543,8 @@
         "verse": "For the eyes of the LORD range throughout the earth to strengthen those whose hearts are fully committed to him. You have done a foolish thing, and from now on you will be at war.\"",
         "book": "2 Chronicles",
         "reference": "16:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2192a04982adea91"
       },
       {
         "id": 245,
@@ -2274,7 +2552,8 @@
         "verse": "\"Because he loves me,\" says the LORD, \"I will rescue him; I will protect him, for he acknowledges my name.",
         "book": "Psalm",
         "reference": "91:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb292fec34bc3108"
       },
       {
         "id": 246,
@@ -2282,7 +2561,8 @@
         "verse": "\"Therefore the LORD, the God of Israel, declares: 'I promised that your house and your father's house would minister before me forever.' But now the LORD declares: 'Far be it from me! Those who honor me I will honor, but those who despise me will be disdained.",
         "book": "1 Samuel",
         "reference": "2:30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e704bcbdab78a580"
       },
       {
         "id": 247,
@@ -2290,7 +2570,8 @@
         "verse": "Then he said to them all: \"If anyone would come after me, he must deny himself and take up his cross daily and follow me.",
         "book": "Luke",
         "reference": "9:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0871aa32bb0314d1"
       },
       {
         "id": 248,
@@ -2298,7 +2579,8 @@
         "verse": "When a man's ways are pleasing to the LORD, he makes even his enemies live at peace with him.",
         "book": "Proverbs",
         "reference": "16:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5d7456b07d13bad5"
       },
       {
         "id": 249,
@@ -2306,7 +2588,8 @@
         "verse": "Trust in the LORD with all your heart and lean not on your own understanding; in all your ways acknowledge him, and he will make your paths straight.",
         "book": "Proverbs",
         "reference": "3:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d981c28f08240492"
       },
       {
         "id": 250,
@@ -2314,7 +2597,8 @@
         "verse": "You were taught, with regard to your former way of life, to put off your old self, which is being corrupted by its deceitful desires; to be made new in the attitude of your minds; and to put on the new self, created to be like God in true righteousness and holiness.",
         "book": "Ephesians",
         "reference": "4:22-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "136a02728eed50c4"
       },
       {
         "id": 251,
@@ -2322,7 +2606,8 @@
         "verse": "Flee the evil desires of youth, and pursue righteousness, faith, love and peace, along with those who call on the Lord out of a pure heart.",
         "book": "2 Timothy",
         "reference": "2:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3c64366969cc14f9"
       },
       {
         "id": 252,
@@ -2330,7 +2615,8 @@
         "verse": "For we brought nothing into the world, and we can take nothing out of it. But if we have food and clothing, we will be content with that. People who want to get rich fall into temptation and a trap and into many foolish and harmful desires that plunge men into ruin and destruction.",
         "book": "1 Timothy",
         "reference": "6:7-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b7ec843291b0f424"
       },
       {
         "id": 253,
@@ -2338,7 +2624,8 @@
         "verse": "Be very careful, then, how you live--not as unwise but as wise, making the most of every opportunity, because the days are evil.",
         "book": "Ephesians",
         "reference": "5:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc7985a0e5111596"
       },
       {
         "id": 254,
@@ -2346,7 +2633,8 @@
         "verse": "Without delay he called them, and they left their father Zebedee in the boat with the hired men and followed him.",
         "book": "Mark",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a5458d5f99fc5526"
       },
       {
         "id": 255,
@@ -2354,7 +2642,8 @@
         "verse": "I eagerly expect and hope that I will in no way be ashamed, but will have sufficient courage so that now as always Christ will be exalted in my body, whether by life or by death.",
         "book": "Philippians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4910b66021ad4396"
       },
       {
         "id": 256,
@@ -2362,7 +2651,8 @@
         "verse": "For everyone looks out for his own interests, not those of Jesus Christ. But you know that Timothy has proved himself, because as a son with his father he has served with me in the work of the gospel.",
         "book": "Philippians",
         "reference": "2:21-22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "845ecb9a20404bf1"
       },
       {
         "id": 257,
@@ -2370,13 +2660,14 @@
         "verse": "Some faced jeers and flogging, while still others were chained and put in prison. They were stoned; they were sawed in two; they were put to death by the sword. They went about in sheepskins and goatskins, destitute, persecuted and mistreated--the world was not worthy of them. They wandered in deserts and mountains, and in caves and holes in the ground.",
         "book": "Hebrews",
         "reference": "11:36-38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "81acad9ea2995c82"
       }
     ]
   },
   {
     "name": "DEP 8: World Vision",
-    "color": "#8900ff",
+    "color": "#362B8A",
     "accentText": "8",
     "verses": [
       {
@@ -2385,7 +2676,8 @@
         "verse": "\"I will make you into a great nation and I will bless you; I will make your name great, and you will be a blessing. I will bless those who bless you, and whoever curses you I will curse; and all peoples on earth will be blessed through you.\"",
         "book": "Genesis",
         "reference": "12:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e23696a3eda4308c"
       },
       {
         "id": 259,
@@ -2393,7 +2685,8 @@
         "verse": "he says: \"It is too small a thing for you to be my servant to restore the tribes of Jacob and bring back those of Israel I have kept. I will also make you a light for the Gentiles, that you may bring my salvation to the ends of the earth.\"",
         "book": "Isaiah",
         "reference": "49:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "250ae3d6a5c53191"
       },
       {
         "id": 260,
@@ -2401,7 +2694,8 @@
         "verse": "Therefore go and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, and teaching them to obey everything I have commanded you. And surely I am with you always, to the very end of the age.\"",
         "book": "Matthew",
         "reference": "28:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f50834c9f82a1676"
       },
       {
         "id": 261,
@@ -2409,7 +2703,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\"",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f9754a40a89ec8ba"
       },
       {
         "id": 262,
@@ -2417,7 +2712,8 @@
         "verse": "Then I heard the voice of the Lord saying, \"Whom shall I send? And who will go for us?\" And I said, \"Here am I. Send me!\"",
         "book": "Isaiah",
         "reference": "6:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ada587118a33373a"
       },
       {
         "id": 263,
@@ -2425,7 +2721,8 @@
         "verse": "to be a minister of Christ Jesus to the Gentiles with the priestly duty of proclaiming the gospel of God, so that the Gentiles might become an offering acceptable to God, sanctified by the Holy Spirit.",
         "book": "Romans",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e10b720b0f11e070"
       },
       {
         "id": 264,
@@ -2433,7 +2730,8 @@
         "verse": "Ask of me, and I will make the nations your inheritance, the ends of the earth your possession.",
         "book": "Psalm",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bde180e4c954cd94"
       },
       {
         "id": 265,
@@ -2441,7 +2739,8 @@
         "verse": "Be exalted, O God, above the heavens; let your glory be over all the earth.",
         "book": "Psalm",
         "reference": "57:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "72e8ed68e7724c16"
       },
       {
         "id": 266,
@@ -2449,7 +2748,8 @@
         "verse": "a faith and knowledge resting on the hope of eternal life, which God, who does not lie, promised before the beginning of time, and at his appointed season he brought his word to light through the preaching entrusted to me by the command of God our Savior,",
         "book": "Titus",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7d1f3d4844590cb7"
       },
       {
         "id": 267,
@@ -2457,7 +2757,8 @@
         "verse": "But the Lord stood at my side and gave me strength, so that through me the message might be fully proclaimed and all the Gentiles might hear it. And I was delivered from the lion's mouth.",
         "book": "2 Timothy",
         "reference": "4:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b54223f0569d385b"
       },
       {
         "id": 268,
@@ -2465,7 +2766,8 @@
         "verse": "We proclaim him, admonishing and teaching everyone with all wisdom, so that we may present everyone perfect in Christ. To this end I labor, struggling with all his energy, which so powerfully works in me.",
         "book": "Colossians",
         "reference": "1:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6717dd3397b469ca"
       },
       {
         "id": 269,
@@ -2473,7 +2775,8 @@
         "verse": "And this is my prayer: that your love may abound more and more in knowledge and depth of insight, so that you may be able to discern what is best and may be pure and blameless until the day of Christ, filled with the fruit of righteousness that comes through Jesus Christ--to the glory and praise of God.",
         "book": "Philippians",
         "reference": "1:9-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "91188675a80c177d"
       },
       {
         "id": 270,
@@ -2481,7 +2784,8 @@
         "verse": "And the things you have heard me say in the presence of many witnesses entrust to reliable men who will also be qualified to teach others.",
         "book": "2 Timothy",
         "reference": "2:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da0386c36c4a831c"
       },
       {
         "id": 271,
@@ -2489,7 +2793,8 @@
         "verse": "The least of you will become a thousand, the smallest a mighty nation. I am the LORD; in its time I will do this swiftly.\"",
         "book": "Isaiah",
         "reference": "60:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0fb59b1a61e73bf6"
       },
       {
         "id": 272,
@@ -2497,7 +2802,8 @@
         "verse": "Therefore, since we are surrounded by such a great cloud of witnesses, let us throw off everything that hinders and the sin that so easily entangles, and let us run with perseverance the race marked out for us.",
         "book": "Hebrews",
         "reference": "12:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "672305c21d39dbc4"
       },
       {
         "id": 273,
@@ -2505,7 +2811,8 @@
         "verse": "For the eyes of the LORD range throughout the earth to strengthen those whose hearts are fully committed to him. You have done a foolish thing, and from now on you will be at war.\"",
         "book": "2 Chronicles",
         "reference": "16:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6e316c176c8737d8"
       },
       {
         "id": 274,
@@ -2513,7 +2820,8 @@
         "verse": "For the earth will be filled with the knowledge of the glory of the LORD, as the waters cover the sea.",
         "book": "Habakkuk",
         "reference": "2:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d1b556de7966dae4"
       },
       {
         "id": 275,
@@ -2521,13 +2829,14 @@
         "verse": "My name will be great among the nations, from the rising to the setting of the sun. In every place incense and pure offerings will be brought to my name, because my name will be great among the nations,\" says the Lord Almighty.",
         "book": "Malachi",
         "reference": "1:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "16c71d811b477a8b"
       }
     ]
   },
   {
     "name": "TMS 180 · Getting to Know God",
-    "color": "#6A4C93",
+    "color": "#5E3A87",
     "accentText": "1",
     "verses": [
       {
@@ -2536,7 +2845,8 @@
         "verse": "In the beginning was the Word, and the Word was with God, and the Word was God. The Word became flesh and made his dwelling among us. We have seen his glory, the glory of the One and Only, who came from the Father, full of grace and truth.",
         "book": "John",
         "reference": "1:1,14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ad0fd6a5607c6206"
       },
       {
         "id": 10002,
@@ -2544,7 +2854,8 @@
         "verse": "But about the Son he says, \"Your throne, O God, will last for ever and ever, and righteousness will be the scepter of your kingdom.",
         "book": "Hebrews",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6acde3c43628147f"
       },
       {
         "id": 10003,
@@ -2552,7 +2863,8 @@
         "verse": "For we do not have a high priest who is unable to sympathize with our weaknesses, but we have one who has been tempted in every way, just as we are—yet was without sin.",
         "book": "Hebrews",
         "reference": "4:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7d9b9e7292cd2201"
       },
       {
         "id": 10004,
@@ -2560,7 +2872,8 @@
         "verse": "And Jesus grew in wisdom and stature, and in favor with God and men.",
         "book": "Luke",
         "reference": "2:52",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2888e1e2bd72d8c8"
       },
       {
         "id": 10005,
@@ -2568,7 +2881,8 @@
         "verse": "For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day according to the Scriptures,",
         "book": "1 Corinthians",
         "reference": "15:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e01fa1abc4c824dc"
       },
       {
         "id": 10006,
@@ -2576,7 +2890,8 @@
         "verse": "But Christ has indeed been raised from the dead, the firstfruits of those who have fallen asleep.",
         "book": "1 Corinthians",
         "reference": "15:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "088c7dbc0517e935"
       },
       {
         "id": 10007,
@@ -2584,7 +2899,8 @@
         "verse": "No one has ever seen God, but God the One and Only, who is at the Father's side, has made him known.",
         "book": "John",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce14c2ec2ccf422b"
       },
       {
         "id": 10008,
@@ -2592,7 +2908,8 @@
         "verse": "The Son is the radiance of God's glory and the exact representation of his being, sustaining all things by his powerful word. After he had provided purification for sins, he sat down at the right hand of the Majesty in heaven.",
         "book": "Hebrews",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ca24432e0ba3341a"
       },
       {
         "id": 10009,
@@ -2600,7 +2917,8 @@
         "verse": "For the Son of Man came to seek and to save what was lost.\"",
         "book": "Luke",
         "reference": "19:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ab2695c0099c3ddf"
       },
       {
         "id": 10010,
@@ -2608,7 +2926,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your forefathers, but with the precious blood of Christ, a lamb without blemish or defect.",
         "book": "1 Peter",
         "reference": "1:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c084bca16a5249b1"
       },
       {
         "id": 10011,
@@ -2616,7 +2935,8 @@
         "verse": "For the Lord himself will come down from heaven, with a loud command, with the voice of the archangel and with the trumpet call of God, and the dead in Christ will rise first. After that, we who are still alive and are left will be caught up together with them in the clouds to meet the Lord in the air. And so we will be with the Lord forever.",
         "book": "1 Thessalonians",
         "reference": "4:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e40a5387c97e290c"
       },
       {
         "id": 10012,
@@ -2624,7 +2944,8 @@
         "verse": "Dear friends, now we are children of God, and what we will be has not yet been made known. But we know that when he appears, we shall be like him, for we shall see him as he is. Everyone who has this hope in him purifies himself, just as he is pure.",
         "book": "1 John",
         "reference": "3:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cb877f495a4fe3d5"
       },
       {
         "id": 10013,
@@ -2632,7 +2953,8 @@
         "verse": "But when he, the Spirit of truth, comes, he will guide you into all truth. He will not speak on his own; he will speak only what he hears, and he will tell you what is yet to come. He will bring glory to me by taking from what is mine and making it known to you.",
         "book": "John",
         "reference": "16:13-14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6c11e294ab00721e"
       },
       {
         "id": 10014,
@@ -2640,7 +2962,8 @@
         "verse": "Therefore I tell you that no one who is speaking by the Spirit of God says, \"Jesus be cursed,\" and no one can say, \"Jesus is Lord,\" except by the Holy Spirit.",
         "book": "1 Corinthians",
         "reference": "12:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "94590e66b55fbf56"
       },
       {
         "id": 10015,
@@ -2648,7 +2971,8 @@
         "verse": "You, however, are controlled not by the sinful nature but by the Spirit, if the Spirit of God lives in you. And if anyone does not have the Spirit of Christ, he does not belong to Christ.",
         "book": "Romans",
         "reference": "8:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f84e56d9698659ed"
       },
       {
         "id": 10016,
@@ -2656,7 +2980,8 @@
         "verse": "Because you are sons, God sent the Spirit of his Son into our hearts, the Spirit who calls out, \"Abba, Father.\"",
         "book": "Galatians",
         "reference": "4:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2d0c0113984c1c62"
       },
       {
         "id": 10017,
@@ -2664,7 +2989,8 @@
         "verse": "Do not get drunk on wine, which leads to debauchery. Instead, be filled with the Spirit.",
         "book": "Ephesians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "934cf5ee6c5e0793"
       },
       {
         "id": 10018,
@@ -2672,7 +2998,8 @@
         "verse": "So I say, live by the Spirit, and you will not gratify the desires of the sinful nature.",
         "book": "Galatians",
         "reference": "5:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a9a55158fafd358d"
       },
       {
         "id": 10019,
@@ -2680,7 +3007,8 @@
         "verse": "However, as it is written: \"No eye has seen, no ear has heard, no mind has conceived what God has prepared for those who love him\"—but God has revealed it to us by his Spirit. The Spirit searches all things, even the deep things of God.",
         "book": "1 Corinthians",
         "reference": "2:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fb52c890d7c702fe"
       },
       {
         "id": 10020,
@@ -2688,7 +3016,8 @@
         "verse": "But the Counselor, the Holy Spirit, whom the Father will send in my name, will teach you all things and will remind you of everything I have said to you.",
         "book": "John",
         "reference": "14:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7e5b8f2a9ce2f2ec"
       },
       {
         "id": 10021,
@@ -2696,7 +3025,8 @@
         "verse": "My message and my preaching were not with wise and persuasive words, but with a demonstration of the Spirit's power, so that your faith might not rest on men's wisdom, but on God's power.",
         "book": "1 Corinthians",
         "reference": "2:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c94d71e4e1be5f02"
       },
       {
         "id": 10022,
@@ -2704,7 +3034,8 @@
         "verse": "because our gospel came to you not simply with words, but also with power, with the Holy Spirit and with deep conviction. You know how we lived among you for your sake.",
         "book": "1 Thessalonians",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "346c64a29af2dffa"
       },
       {
         "id": 10023,
@@ -2712,7 +3043,8 @@
         "verse": "All these are the work of one and the same Spirit, and he gives them to each one, just as he determines.",
         "book": "1 Corinthians",
         "reference": "12:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8e9590712ff9022e"
       },
       {
         "id": 10024,
@@ -2720,7 +3052,8 @@
         "verse": "There are different kinds of gifts, but the same Spirit. There are different kinds of service, but the same Lord. There are different kinds of working, but the same God works all of them in all men.",
         "book": "1 Corinthians",
         "reference": "12:4-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d0a67cdcb1ca8032"
       },
       {
         "id": 10025,
@@ -2728,7 +3061,8 @@
         "verse": "\"Ah, Sovereign LORD, you have made the heavens and the earth by your great power and outstretched arm. Nothing is too hard for you.",
         "book": "Jeremiah",
         "reference": "32:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "63af1504260b6d44"
       },
       {
         "id": 10026,
@@ -2736,7 +3070,8 @@
         "verse": "Oh, the depth of the riches of the wisdom and knowledge of God! How unsearchable his judgments, and his paths beyond tracing out!",
         "book": "Romans",
         "reference": "11:33",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9a1d29c7f5d1cba9"
       },
       {
         "id": 10027,
@@ -2744,7 +3079,8 @@
         "verse": "Can anyone hide in secret places so that I cannot see him?\" declares the LORD. \"Do not I fill heaven and earth?\" declares the LORD.",
         "book": "Jeremiah",
         "reference": "23:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ffec9be019bc9028"
       },
       {
         "id": 10028,
@@ -2752,7 +3088,8 @@
         "verse": "And God is able to make all grace abound to you, so that in all things at all times, having all that you need, you will abound in every good work.",
         "book": "2 Corinthians",
         "reference": "9:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a2f3f455fd612c0a"
       },
       {
         "id": 10029,
@@ -2760,7 +3097,8 @@
         "verse": "Yours, O LORD, is the greatness and the power and the glory and the majesty and the splendor, for everything in heaven and earth is yours. Yours, O LORD, is the kingdom; you are exalted as head over all. Wealth and honor come from you; you are the ruler of all things. In your hands are strength and power to exalt and give strength to all. Now, our God, we give you thanks, and praise your glorious name.",
         "book": "1 Chronicles",
         "reference": "29:11-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b458144f068a002c"
       },
       {
         "id": 10030,
@@ -2768,7 +3106,8 @@
         "verse": "But the Lord is faithful, and he will strengthen and protect you from the evil one.",
         "book": "2 Thessalonians",
         "reference": "3:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d3623bbdfbd7a5e6"
       },
       {
         "id": 10031,
@@ -2776,7 +3115,8 @@
         "verse": "God is spirit, and his worshipers must worship in spirit and in truth.\"",
         "book": "John",
         "reference": "4:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0c1e0ff9f5051499"
       },
       {
         "id": 10032,
@@ -2784,7 +3124,8 @@
         "verse": "But just as he who called you is holy, so be holy in all you do; for it is written: \"Be holy, because I am holy.\"",
         "book": "1 Peter",
         "reference": "1:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87c3b0c2b4922da5"
       },
       {
         "id": 10033,
@@ -2792,7 +3133,8 @@
         "verse": "Great is the LORD and most worthy of praise; his greatness no one can fathom.",
         "book": "Psalm",
         "reference": "145:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "414d0b41aca470cd"
       },
       {
         "id": 10034,
@@ -2800,7 +3142,8 @@
         "verse": "This is love: not that we loved God, but that he loved us and sent his Son as an atoning sacrifice for our sins.",
         "book": "1 John",
         "reference": "4:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e005d0657d7a7677"
       },
       {
         "id": 10035,
@@ -2808,7 +3151,8 @@
         "verse": "But you, O Lord, are a compassionate and gracious God, slow to anger, abounding in love and faithfulness.",
         "book": "Psalm",
         "reference": "86:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "37af79e3a159dfce"
       },
       {
         "id": 10036,
@@ -2816,13 +3160,14 @@
         "verse": "And we know that in all things God works for the good of those who love him, who have been called according to his purpose.",
         "book": "Romans",
         "reference": "8:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "21a48c3904b01d89"
       }
     ]
   },
   {
     "name": "TMS 180 · Growing in Love",
-    "color": "#C9184A",
+    "color": "#8E3339",
     "accentText": "2",
     "verses": [
       {
@@ -2831,7 +3176,8 @@
         "verse": "Instead, speaking the truth in love, we will in all things grow up into him who is the Head, that is, Christ.",
         "book": "Ephesians",
         "reference": "4:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "11e78ee8c60ce5c3"
       },
       {
         "id": 10038,
@@ -2839,7 +3185,8 @@
         "verse": "Do not lie to each other, since you have taken off your old self with its practices",
         "book": "Colossians",
         "reference": "3:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "872a33c8833cb8c0"
       },
       {
         "id": 10039,
@@ -2847,7 +3194,8 @@
         "verse": "He who covers over an offense promotes love, but whoever repeats the matter separates close friends.",
         "book": "Proverbs",
         "reference": "17:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d75462755ef041c9"
       },
       {
         "id": 10040,
@@ -2855,7 +3203,8 @@
         "verse": "A gossip betrays a confidence, but a trustworthy man keeps a secret.",
         "book": "Proverbs",
         "reference": "11:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "efa987c982d29584"
       },
       {
         "id": 10041,
@@ -2863,7 +3212,8 @@
         "verse": "Pray that I may proclaim it clearly, as I should. Be wise in the way you act toward outsiders; make the most of every opportunity. Let your conversation be always full of grace, seasoned with salt, so that you may know how to answer everyone.",
         "book": "Colossians",
         "reference": "4:4-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8722804ef75a7d5e"
       },
       {
         "id": 10042,
@@ -2871,7 +3221,8 @@
         "verse": "A gentle answer turns away wrath, but a harsh word stirs up anger.",
         "book": "Proverbs",
         "reference": "15:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5c132d4b09302f09"
       },
       {
         "id": 10043,
@@ -2879,7 +3230,8 @@
         "verse": "Therefore confess your sins to each other and pray for each other so that you may be healed. The prayer of a righteous man is powerful and effective.",
         "book": "James",
         "reference": "5:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "813c49277fd475c3"
       },
       {
         "id": 10044,
@@ -2887,7 +3239,8 @@
         "verse": "\"Therefore, if you are offering your gift at the altar and there remember that your brother has something against you, leave your gift there in front of the altar. First go and be reconciled to your brother; then come and offer your gift.",
         "book": "Matthew",
         "reference": "5:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c9ecfd87bb0a09ca"
       },
       {
         "id": 10045,
@@ -2895,7 +3248,8 @@
         "verse": "My dear brothers, take note of this: Everyone should be quick to listen, slow to speak and slow to become angry,",
         "book": "James",
         "reference": "1:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "85649b891714205e"
       },
       {
         "id": 10046,
@@ -2903,7 +3257,8 @@
         "verse": "He who answers before listening—that is his folly and his shame.",
         "book": "Proverbs",
         "reference": "18:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "18089a507336ab09"
       },
       {
         "id": 10047,
@@ -2911,7 +3266,8 @@
         "verse": "Do not rebuke a mocker or he will hate you; rebuke a wise man and he will love you. Instruct a wise man and he will be wiser still; teach a righteous man and he will add to his learning.",
         "book": "Proverbs",
         "reference": "9:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "048db2ee06b91498"
       },
       {
         "id": 10048,
@@ -2919,7 +3275,8 @@
         "verse": "\"If your brother sins against you, go and show him his fault, just between the two of you. If he listens to you, you have won your brother over.",
         "book": "Matthew",
         "reference": "18:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ccba60cd59c75916"
       },
       {
         "id": 10049,
@@ -2927,7 +3284,8 @@
         "verse": "Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you.",
         "book": "Ephesians",
         "reference": "4:32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "53a7b4e11dacac07"
       },
       {
         "id": 10050,
@@ -2935,7 +3293,8 @@
         "verse": "Bear with each other and forgive whatever grievances you may have against one another. Forgive as the Lord forgave you.",
         "book": "Colossians",
         "reference": "3:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8decb3b7b3a54386"
       },
       {
         "id": 10051,
@@ -2943,7 +3302,8 @@
         "verse": "Be completely humble and gentle; be patient, bearing with one another in love.",
         "book": "Ephesians",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a43d9a576dbbca87"
       },
       {
         "id": 10052,
@@ -2951,7 +3311,8 @@
         "verse": "And the Lord's servant must not quarrel; instead, he must be kind to everyone, able to teach, not resentful. Those who oppose him he must gently instruct, in the hope that God will grant them repentance leading them to a knowledge of the truth,",
         "book": "2 Timothy",
         "reference": "2:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "75e6c58cbc58e778"
       },
       {
         "id": 10053,
@@ -2959,7 +3320,8 @@
         "verse": "\"In your anger do not sin\": Do not let the sun go down while you are still angry,",
         "book": "Ephesians",
         "reference": "4:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4ac16250f278b4d1"
       },
       {
         "id": 10054,
@@ -2967,7 +3329,8 @@
         "verse": "But now you must rid yourselves of all such things as these: anger, rage, malice, slander, and filthy language from your lips.",
         "book": "Colossians",
         "reference": "3:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a438dd5a60ce77f4"
       },
       {
         "id": 10055,
@@ -2975,7 +3338,8 @@
         "verse": "See to it that no one misses the grace of God and that no bitter root grows up to cause trouble and defile many.",
         "book": "Hebrews",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5fc9ab7e18196f69"
       },
       {
         "id": 10056,
@@ -2983,7 +3347,8 @@
         "verse": "Get rid of all bitterness, rage and anger, brawling and slander, along with every form of malice.",
         "book": "Ephesians",
         "reference": "4:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "26023181f40150cb"
       },
       {
         "id": 10057,
@@ -2991,7 +3356,17 @@
         "verse": "But how is it to your credit if you receive a beating for doing wrong and endure it? But if you suffer for doing good and you endure it, this is commendable before God. To this you were called, because Christ suffered for you, leaving you an example, that you should follow in his steps.",
         "book": "1 Peter",
         "reference": "2:20-21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2536ca7cdf835907"
+      },
+      {
+        "id": 20001,
+        "title": "Endure Injustice",
+        "verse": "Do not take revenge, my friends, but leave room for God's wrath, for it is written: \"It is mine to avenge; I will repay,\" says the Lord.",
+        "book": "Romans",
+        "reference": "12:19",
+        "subpack": "",
+        "cardUid": "2f0b947e5be05ec1"
       },
       {
         "id": 10058,
@@ -2999,7 +3374,8 @@
         "verse": "Anger is cruel and fury overwhelming, but who can stand before jealousy?",
         "book": "Proverbs",
         "reference": "27:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6e481bccd76cb08e"
       },
       {
         "id": 10059,
@@ -3007,7 +3383,8 @@
         "verse": "For where you have envy and selfish ambition, there you find disorder and every evil practice.",
         "book": "James",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4e0aa82a4f2980dd"
       },
       {
         "id": 10060,
@@ -3015,7 +3392,8 @@
         "verse": "May the God who gives endurance and encouragement give you a spirit of unity among yourselves as you follow Christ Jesus, so that with one heart and mouth you may glorify the God and Father of our Lord Jesus Christ.",
         "book": "Romans",
         "reference": "15:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc3a406c36c50e6e"
       },
       {
         "id": 10061,
@@ -3023,7 +3401,8 @@
         "verse": "I appeal to you, brothers, in the name of our Lord Jesus Christ, that all of you agree with one another so that there may be no divisions among you and that you may be perfectly united in mind and thought.",
         "book": "1 Corinthians",
         "reference": "1:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "36846201f0e81be8"
       },
       {
         "id": 10062,
@@ -3031,7 +3410,8 @@
         "verse": "Not so with you. Instead, whoever wants to become great among you must be your servant, and whoever wants to be first must be your slave—",
         "book": "Matthew",
         "reference": "20:26-27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7f072ea7763a22c8"
       },
       {
         "id": 10063,
@@ -3039,7 +3419,8 @@
         "verse": "You, my brothers, were called to be free. But do not use your freedom to indulge the sinful nature; rather, serve one another in love.",
         "book": "Galatians",
         "reference": "5:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9b82340a369679d6"
       },
       {
         "id": 10064,
@@ -3047,7 +3428,8 @@
         "verse": "Each of us should please his neighbor for his good, to build him up.",
         "book": "Romans",
         "reference": "15:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "41aa402b865a4118"
       },
       {
         "id": 10065,
@@ -3055,7 +3437,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit, but in humility consider others better than yourselves. Each of you should look not only to your own interests, but also to the interests of others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03667fb75c855075"
       },
       {
         "id": 10066,
@@ -3063,7 +3446,8 @@
         "verse": "Therefore encourage one another and build each other up, just as in fact you are doing.",
         "book": "1 Thessalonians",
         "reference": "5:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "78201e7718866680"
       },
       {
         "id": 10067,
@@ -3071,7 +3455,8 @@
         "verse": "Two are better than one, because they have a good return for their work: If one falls down, his friend can help him up. But pity the man who falls and has no one to help him up!",
         "book": "Ecclesiastes",
         "reference": "4:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3336f4844b76863d"
       },
       {
         "id": 10068,
@@ -3079,7 +3464,8 @@
         "verse": "When he saw the crowds, he had compassion on them, because they were harassed and helpless, like sheep without a shepherd.",
         "book": "Matthew",
         "reference": "9:36",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "835f9cba837bbe84"
       },
       {
         "id": 10069,
@@ -3087,7 +3473,8 @@
         "verse": "Rejoice with those who rejoice; mourn with those who mourn.",
         "book": "Romans",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "06b7b9c92c05840d"
       },
       {
         "id": 10070,
@@ -3095,7 +3482,8 @@
         "verse": "But the wisdom that comes from heaven is first of all pure; then peace-loving, considerate, submissive, full of mercy and good fruit, impartial and sincere.",
         "book": "James",
         "reference": "3:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "890ba6720c15bbdb"
       },
       {
         "id": 10071,
@@ -3103,13 +3491,14 @@
         "verse": "Brothers, if someone is caught in a sin, you who are spiritual should restore him gently. But watch yourself, or you also may be tempted.",
         "book": "Galatians",
         "reference": "6:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "71db06fd0bdcf929"
       }
     ]
   },
   {
     "name": "TMS 180 · Growing in Faith",
-    "color": "#1B998B",
+    "color": "#2E86B8",
     "accentText": "3",
     "verses": [
       {
@@ -3118,7 +3507,8 @@
         "verse": "His divine power has given us everything we need for life and godliness through our knowledge of him who called us by his own glory and goodness. Through these he has given us his very great and precious promises, so that through them you may participate in the divine nature and escape the corruption in the world caused by evil desires.",
         "book": "2 Peter",
         "reference": "1:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef02d3aee1d50539"
       },
       {
         "id": 10073,
@@ -3126,7 +3516,8 @@
         "verse": "For no matter how many promises God has made, they are \"Yes\" in Christ. And so through him the \"Amen\" is spoken by us to the glory of God.",
         "book": "2 Corinthians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "774e855fbdabfd6e"
       },
       {
         "id": 10074,
@@ -3134,7 +3525,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ, the Father of compassion and the God of all comfort, who comforts us in all our troubles, so that we can comfort those in any trouble with the comfort we ourselves have received from God.",
         "book": "2 Corinthians",
         "reference": "1:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d08a657e650c3eda"
       },
       {
         "id": 10075,
@@ -3142,7 +3534,8 @@
         "verse": "So neither he who plants nor he who waters is anything, but only God, who makes things grow. The man who plants and the man who waters have one purpose, and each will be rewarded according to his own labor.",
         "book": "1 Corinthians",
         "reference": "3:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "56a51c22bcb41dcf"
       },
       {
         "id": 10076,
@@ -3150,7 +3543,8 @@
         "verse": "But his delight is in the law of the LORD, and on his law he meditates day and night. He is like a tree planted by streams of water, which yields its fruit in season and whose leaf does not wither. Whatever he does prospers.",
         "book": "Psalm",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "591b37ed6ad03f6c"
       },
       {
         "id": 10077,
@@ -3158,7 +3552,8 @@
         "verse": "For if you possess these qualities in increasing measure, they will keep you from being ineffective and unproductive in your knowledge of our Lord Jesus Christ.",
         "book": "2 Peter",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a5bf10ed89a6439"
       },
       {
         "id": 10078,
@@ -3166,7 +3561,17 @@
         "verse": "And the God of all grace, who called you to his eternal glory in Christ, after you have suffered a little while, will himself restore you and make you strong, firm and steadfast.",
         "book": "1 Peter",
         "reference": "5:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce5bf5d8dc8629ae"
+      },
+      {
+        "id": 20002,
+        "title": "Promises for Help in Trouble",
+        "verse": "But he said to me, \"My grace is sufficient for you, for my power is made perfect in weakness.\" Therefore I will boast all the more gladly about my weaknesses, so that Christ's power may rest on me.",
+        "book": "2 Corinthians",
+        "reference": "12:9",
+        "subpack": "",
+        "cardUid": "79ef8e7360ce5484"
       },
       {
         "id": 10079,
@@ -3174,7 +3579,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ, who has blessed us in the heavenly realms with every spiritual blessing in Christ.",
         "book": "Ephesians",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "25cd3f2672c6a6ed"
       },
       {
         "id": 10080,
@@ -3182,7 +3588,8 @@
         "verse": "Delight yourself in the LORD and he will give you the desires of your heart. Commit your way to the LORD; trust in him and he will do this:",
         "book": "Psalm",
         "reference": "37:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5f19e5534fa2f7ea"
       },
       {
         "id": 10081,
@@ -3190,7 +3597,8 @@
         "verse": "My dear children, I write this to you so that you will not sin. But if anybody does sin, we have one who speaks to the Father in our defense—Jesus Christ, the Righteous One. He is the atoning sacrifice for our sins, and not only for ours but also for the sins of the whole world.",
         "book": "1 John",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "692cffe3a091d7f5"
       },
       {
         "id": 10082,
@@ -3198,7 +3606,8 @@
         "verse": "as far as the east is from the west, so far has he removed our transgressions from us.",
         "book": "Psalm",
         "reference": "103:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5b91eda5d730a0b4"
       },
       {
         "id": 10083,
@@ -3206,7 +3615,8 @@
         "verse": "For the word of God is living and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1abaf7aa796fed7a"
       },
       {
         "id": 10084,
@@ -3214,7 +3624,8 @@
         "verse": "As the rain and the snow come down from heaven, and do not return to it without watering the earth and making it bud and flourish, so that it yields seed for the sower and bread for the eater, so is my word that goes out from my mouth: It will not return to me empty, but will accomplish what I desire and achieve the purpose for which I sent it.",
         "book": "Isaiah",
         "reference": "55:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d7cbbf0256f7201f"
       },
       {
         "id": 10085,
@@ -3222,7 +3633,8 @@
         "verse": "Above all, you must understand that no prophecy of Scripture came about by the prophet's own interpretation. For prophecy never had its origin in the will of man, but men spoke from God as they were carried along by the Holy Spirit.",
         "book": "2 Peter",
         "reference": "1:20-21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "20350effdd439fc0"
       },
       {
         "id": 10086,
@@ -3230,7 +3642,8 @@
         "verse": "And we also thank God continually because, when you received the word of God, which you heard from us, you accepted it not as the word of men, but as it actually is, the word of God, which is at work in you who believe.",
         "book": "1 Thessalonians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6dbe34129bc8feed"
       },
       {
         "id": 10087,
@@ -3238,7 +3651,8 @@
         "verse": "When your words came, I ate them; they were my joy and my heart's delight, for I bear your name, O LORD God Almighty.",
         "book": "Jeremiah",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "76da5408958980a0"
       },
       {
         "id": 10088,
@@ -3246,7 +3660,8 @@
         "verse": "I have not departed from the commands of his lips; I have treasured the words of his mouth more than my daily bread.",
         "book": "Job",
         "reference": "23:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "96115d4dcdaf863d"
       },
       {
         "id": 10089,
@@ -3254,7 +3669,8 @@
         "verse": "Now the Bereans were of more noble character than the Thessalonians, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "86e6550aa5bf9704"
       },
       {
         "id": 10090,
@@ -3262,7 +3678,8 @@
         "verse": "You diligently study the Scriptures because you think that by them you possess eternal life. These are the Scriptures that testify about me, yet you refuse to come to me to have life.",
         "book": "John",
         "reference": "5:39-40",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87370dc5ed549d87"
       },
       {
         "id": 10091,
@@ -3270,7 +3687,17 @@
         "verse": "To the Jews who had believed him, Jesus said, \"If you hold to my teaching, you are really my disciples. Then you will know the truth, and the truth will set you free.\"",
         "book": "John",
         "reference": "8:31-32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c5d3591e1fce395"
+      },
+      {
+        "id": 20003,
+        "title": "Obey",
+        "verse": "Jesus answered, \"It is written: 'Man does not live on bread alone, but on every word that comes from the mouth of God.' \"",
+        "book": "Matthew",
+        "reference": "4:4",
+        "subpack": "",
+        "cardUid": "4668ba1f5984f1be"
       },
       {
         "id": 10092,
@@ -3278,7 +3705,8 @@
         "verse": "Heaven and earth will pass away, but my words will never pass away.",
         "book": "Matthew",
         "reference": "24:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "280e3df0637ff130"
       },
       {
         "id": 10093,
@@ -3286,7 +3714,8 @@
         "verse": "Sanctify them by the truth; your word is truth.",
         "book": "John",
         "reference": "17:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b908bbcdb8145961"
       },
       {
         "id": 10094,
@@ -3294,7 +3723,8 @@
         "verse": "In this you greatly rejoice, though now for a little while you may have had to suffer grief in all kinds of trials. These have come so that your faith—of greater worth than gold, which perishes even though refined by fire—may be proved genuine and may result in praise, glory and honor when Jesus Christ is revealed.",
         "book": "1 Peter",
         "reference": "1:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c371f333631da31e"
       },
       {
         "id": 10095,
@@ -3302,7 +3732,8 @@
         "verse": "Consider it pure joy, my brothers, whenever you face trials of many kinds, because you know that the testing of your faith develops perseverance. Perseverance must finish its work so that you may be mature and complete, not lacking anything.",
         "book": "James",
         "reference": "1:2-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "83e832f8a88050d3"
       },
       {
         "id": 10096,
@@ -3310,7 +3741,8 @@
         "verse": "For we also have had the gospel preached to us, just as they did; but the message they heard was of no value to them, because those who heard did not combine it with faith.",
         "book": "Hebrews",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57b01b90544057f4"
       },
       {
         "id": 10097,
@@ -3318,7 +3750,8 @@
         "verse": "But my righteous one will live by faith. And if he shrinks back, I will not be pleased with him.\"",
         "book": "Hebrews",
         "reference": "10:38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "948aa9d522b1120e"
       },
       {
         "id": 10098,
@@ -3326,7 +3759,8 @@
         "verse": "In addition to all this, take up the shield of faith, with which you can extinguish all the flaming arrows of the evil one.",
         "book": "Ephesians",
         "reference": "6:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "db33ab280862de77"
       },
       {
         "id": 10099,
@@ -3334,7 +3768,8 @@
         "verse": "But you, man of God, flee from all this, and pursue righteousness, godliness, faith, love, endurance and gentleness. Fight the good fight of the faith. Take hold of the eternal life to which you were called when you made your good confession in the presence of many witnesses.",
         "book": "1 Timothy",
         "reference": "6:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "868850efc43ddab2"
       },
       {
         "id": 10100,
@@ -3342,7 +3777,8 @@
         "verse": "Now faith is being sure of what we hope for and certain of what we do not see.",
         "book": "Hebrews",
         "reference": "11:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9d1b38928487cc90"
       },
       {
         "id": 10101,
@@ -3350,7 +3786,8 @@
         "verse": "Consequently, faith comes from hearing the message, and the message is heard through the word of Christ.",
         "book": "Romans",
         "reference": "10:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9bc115188c1202e5"
       },
       {
         "id": 10102,
@@ -3358,7 +3795,8 @@
         "verse": "We do not want you to become lazy, but to imitate those who through faith and patience inherit what has been promised.",
         "book": "Hebrews",
         "reference": "6:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e1f5cbc358126d5d"
       },
       {
         "id": 10103,
@@ -3366,7 +3804,8 @@
         "verse": "In the same way, faith by itself, if it is not accompanied by action, is dead.",
         "book": "James",
         "reference": "2:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "10911412e968ced8"
       },
       {
         "id": 10104,
@@ -3374,7 +3813,8 @@
         "verse": "know that a man is not justified by observing the law, but by faith in Jesus Christ. So we, too, have put our faith in Christ Jesus that we may be justified by faith in Christ and not by observing the law, because by observing the law no one will be justified.",
         "book": "Galatians",
         "reference": "2:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6f3150a9d0bc3da4"
       },
       {
         "id": 10105,
@@ -3382,13 +3822,14 @@
         "verse": "Therefore, since we have been justified through faith, we have peace with God through our Lord Jesus Christ,",
         "book": "Romans",
         "reference": "5:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5ae61635c33dbfc0"
       }
     ]
   },
   {
     "name": "TMS 180 · Walking in Victory",
-    "color": "#BC6C25",
+    "color": "#8E9A3C",
     "accentText": "4",
     "verses": [
       {
@@ -3397,7 +3838,8 @@
         "verse": "But thanks be to God! He gives us the victory through our Lord Jesus Christ.",
         "book": "1 Corinthians",
         "reference": "15:57",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef6c99115ef786a8"
       },
       {
         "id": 10107,
@@ -3405,7 +3847,8 @@
         "verse": "But thanks be to God, who always leads us in triumphal procession in Christ and through us spreads everywhere the fragrance of the knowledge of him.",
         "book": "2 Corinthians",
         "reference": "2:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8d6ce4c3d4eb0f37"
       },
       {
         "id": 10108,
@@ -3413,7 +3856,8 @@
         "verse": "The weapons we fight with are not the weapons of the world. On the contrary, they have divine power to demolish strongholds. We demolish arguments and every pretension that sets itself up against the knowledge of God, and we take captive every thought to make it obedient to Christ.",
         "book": "2 Corinthians",
         "reference": "10:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ab11c93d756bb064"
       },
       {
         "id": 10109,
@@ -3421,7 +3865,8 @@
         "verse": "Finally, be strong in the Lord and in his mighty power. Put on the full armor of God so that you can take your stand against the devil's schemes.",
         "book": "Ephesians",
         "reference": "6:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3f13bfde408474b3"
       },
       {
         "id": 10110,
@@ -3429,7 +3874,8 @@
         "verse": "They overcame him by the blood of the Lamb and by the word of their testimony; they did not love their lives so much as to shrink from death.",
         "book": "Revelation",
         "reference": "12:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d10c20d806e12f0c"
       },
       {
         "id": 10111,
@@ -3437,7 +3883,8 @@
         "verse": "Submit yourselves, then, to God. Resist the devil, and he will flee from you. Come near to God and he will come near to you. Wash your hands, you sinners, and purify your hearts, you double-minded.",
         "book": "James",
         "reference": "4:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b6d5b270920d8bc0"
       },
       {
         "id": 10112,
@@ -3445,7 +3892,8 @@
         "verse": "Those who live according to the sinful nature have their minds set on what that nature desires; but those who live in accordance with the Spirit have their minds set on what the Spirit desires. The mind of sinful man is death, but the mind controlled by the Spirit is life and peace;",
         "book": "Romans",
         "reference": "8:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8c18bfc3c5f8ed00"
       },
       {
         "id": 10113,
@@ -3453,7 +3901,8 @@
         "verse": "Rather, clothe yourselves with the Lord Jesus Christ, and do not think about how to gratify the desires of the sinful nature.",
         "book": "Romans",
         "reference": "13:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "af95e96ed1bd7d3e"
       },
       {
         "id": 10114,
@@ -3461,7 +3910,8 @@
         "verse": "You, dear children, are from God and have overcome them, because the one who is in you is greater than the one who is in the world.",
         "book": "1 John",
         "reference": "4:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61714393f371382a"
       },
       {
         "id": 10115,
@@ -3469,7 +3919,8 @@
         "verse": "for everyone born of God overcomes the world. This is the victory that has overcome the world, even our faith. Who is it that overcomes the world? Only he who believes that Jesus is the Son of God.",
         "book": "1 John",
         "reference": "5:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7de51f8bb243f450"
       },
       {
         "id": 10116,
@@ -3477,7 +3928,8 @@
         "verse": "The law of his God is in his heart; his feet do not slip.",
         "book": "Psalm",
         "reference": "37:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6427e7a6ce996c44"
       },
       {
         "id": 10117,
@@ -3485,7 +3937,8 @@
         "verse": "Therefore do not let sin reign in your mortal body so that you obey its evil desires. Do not offer the parts of your body to sin, as instruments of wickedness, but rather offer yourselves to God, as those who have been brought from death to life; and offer the parts of your body to him as instruments of righteousness.",
         "book": "Romans",
         "reference": "6:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f4e8bf8bcbd51cd1"
       },
       {
         "id": 10118,
@@ -3493,7 +3946,8 @@
         "verse": "Finally, brothers, whatever is true, whatever is noble, whatever is right, whatever is pure, whatever is lovely, whatever is admirable—if anything is excellent or praiseworthy—think about such things.",
         "book": "Philippians",
         "reference": "4:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6c813d6dbaa848c7"
       },
       {
         "id": 10119,
@@ -3501,7 +3955,8 @@
         "verse": "To the pure, all things are pure, but to those who are corrupted and do not believe, nothing is pure. In fact, both their minds and consciences are corrupted.",
         "book": "Titus",
         "reference": "1:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8dffcfa2f90c604a"
       },
       {
         "id": 10120,
@@ -3509,7 +3964,8 @@
         "verse": "The good man brings good things out of the good stored up in his heart, and the evil man brings evil things out of the evil stored up in his heart. For out of the overflow of his heart his mouth speaks.",
         "book": "Luke",
         "reference": "6:45",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "69f78182e31c7a2d"
       },
       {
         "id": 10121,
@@ -3517,7 +3973,8 @@
         "verse": "Above all else, guard your heart, for it is the wellspring of life.",
         "book": "Proverbs",
         "reference": "4:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "490592c80f9eefb9"
       },
       {
         "id": 10122,
@@ -3525,7 +3982,8 @@
         "verse": "\"The eye is the lamp of the body. If your eyes are good, your whole body will be full of light.",
         "book": "Matthew",
         "reference": "6:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb88344e7ad33eca"
       },
       {
         "id": 10123,
@@ -3533,7 +3991,8 @@
         "verse": "But I tell you that anyone who looks at a woman lustfully has already committed adultery with her in his heart.",
         "book": "Matthew",
         "reference": "5:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9e6f2af10e2c4a16"
       },
       {
         "id": 10124,
@@ -3541,7 +4000,8 @@
         "verse": "It is God's will that you should be sanctified: that you should avoid sexual immorality;",
         "book": "1 Thessalonians",
         "reference": "4:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3ce1baf4bc851270"
       },
       {
         "id": 10125,
@@ -3549,7 +4009,8 @@
         "verse": "\"Food for the stomach and the stomach for food\"—but God will destroy them both. The body is not meant for sexual immorality, but for the Lord, and the Lord for the body.",
         "book": "1 Corinthians",
         "reference": "6:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8fe292821bd17612"
       },
       {
         "id": 10126,
@@ -3557,7 +4018,8 @@
         "verse": "Do not let any unwholesome talk come out of your mouths, but only what is helpful for building others up according to their needs, that it may benefit those who listen.",
         "book": "Ephesians",
         "reference": "4:29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d7921a27159b212e"
       },
       {
         "id": 10127,
@@ -3565,7 +4027,8 @@
         "verse": "But I tell you that men will have to give account on the day of judgment for every careless word they have spoken. For by your words you will be acquitted, and by your words you will be condemned.\"",
         "book": "Matthew",
         "reference": "12:36-37",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8a2f67d1c9858cf9"
       },
       {
         "id": 10128,
@@ -3573,7 +4036,8 @@
         "verse": "Avoid every kind of evil.",
         "book": "1 Thessalonians",
         "reference": "5:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0ac40c30429e4bbe"
       },
       {
         "id": 10129,
@@ -3581,7 +4045,8 @@
         "verse": "Do not rebuke an older man harshly, but exhort him as if he were your father. Treat younger men as brothers, older women as mothers, and younger women as sisters, with absolute purity.",
         "book": "1 Timothy",
         "reference": "5:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3622acb13fa16041"
       },
       {
         "id": 10130,
@@ -3589,7 +4054,8 @@
         "verse": "If you believe, you will receive whatever you ask for in prayer.\"",
         "book": "Matthew",
         "reference": "21:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d8e4fa462c36c12c"
       },
       {
         "id": 10131,
@@ -3597,7 +4063,8 @@
         "verse": "\"Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; he who seeks finds; and to him who knocks, the door will be opened.",
         "book": "Matthew",
         "reference": "7:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dbfd98060dcce681"
       },
       {
         "id": 10132,
@@ -3605,7 +4072,8 @@
         "verse": "But when you pray, go into your room, close the door and pray to your Father, who is unseen. Then your Father, who sees what is done in secret, will reward you.",
         "book": "Matthew",
         "reference": "6:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fe37a295cf9d21d4"
       },
       {
         "id": 10133,
@@ -3613,7 +4081,8 @@
         "verse": "Very early in the morning, while it was still dark, Jesus got up, left the house and went off to a solitary place, where he prayed.",
         "book": "Mark",
         "reference": "1:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "17903a9c2ecb61d8"
       },
       {
         "id": 10134,
@@ -3621,7 +4090,8 @@
         "verse": "'Call to me and I will answer you and tell you great and unsearchable things you do not know.'",
         "book": "Jeremiah",
         "reference": "33:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "72db4a4990f5a4d3"
       },
       {
         "id": 10135,
@@ -3629,7 +4099,8 @@
         "verse": "Now to him who is able to do immeasurably more than all we ask or imagine, according to his power that is at work within us,",
         "book": "Ephesians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a1910f617cadeb45"
       },
       {
         "id": 10136,
@@ -3637,7 +4108,8 @@
         "verse": "This is the confidence we have in approaching God: that if we ask anything according to his will, he hears us. And if we know that he hears us—whatever we ask—we know that we have what we asked of him.",
         "book": "1 John",
         "reference": "5:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0e1c038620d70bcb"
       },
       {
         "id": 10137,
@@ -3645,7 +4117,8 @@
         "verse": "pray continually; give thanks in all circumstances, for this is God's will for you in Christ Jesus.",
         "book": "1 Thessalonians",
         "reference": "5:17-18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b7b2f14446f05d48"
       },
       {
         "id": 10138,
@@ -3653,7 +4126,8 @@
         "verse": "As for me, far be it from me that I should sin against the LORD by failing to pray for you. And I will teach you the way that is good and right.",
         "book": "1 Samuel",
         "reference": "12:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fa5b4c14979333b6"
       },
       {
         "id": 10139,
@@ -3661,7 +4135,8 @@
         "verse": "Then he said to his disciples, \"The harvest is plentiful but the workers are few. Ask the Lord of the harvest, therefore, to send out workers into his harvest field.\"",
         "book": "Matthew",
         "reference": "9:37-38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7cee46d467f5d565"
       },
       {
         "id": 10140,
@@ -3669,7 +4144,8 @@
         "verse": "Through Jesus, therefore, let us continually offer to God a sacrifice of praise—the fruit of lips that confess his name.",
         "book": "Hebrews",
         "reference": "13:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "396c741fc9c6e29c"
       },
       {
         "id": 10141,
@@ -3677,13 +4153,14 @@
         "verse": "Praise the LORD. Praise the LORD, O my soul. I will praise the LORD all my life; I will sing praise to my God as long as I live.",
         "book": "Psalm",
         "reference": "146:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d47cb34c1082651e"
       }
     ]
   },
   {
     "name": "TMS 180 · Sharing Christ with Others",
-    "color": "#277DA1",
+    "color": "#D9925C",
     "accentText": "5",
     "verses": [
       {
@@ -3692,7 +4169,8 @@
         "verse": "To them God has chosen to make known among the Gentiles the glorious riches of this mystery, which is Christ in you, the hope of glory. We proclaim him, admonishing and teaching everyone with all wisdom, so that we may present everyone perfect in Christ.",
         "book": "Colossians",
         "reference": "1:27-28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2d8f6a42022b4fac"
       },
       {
         "id": 10143,
@@ -3700,7 +4178,8 @@
         "verse": "that God was reconciling the world to himself in Christ, not counting men's sins against them. And he has committed to us the message of reconciliation. We are therefore Christ's ambassadors, as though God were making his appeal through us. We implore you on Christ's behalf: Be reconciled to God.",
         "book": "2 Corinthians",
         "reference": "5:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "79bc265815fe3cf9"
       },
       {
         "id": 10144,
@@ -3708,7 +4187,8 @@
         "verse": "On the contrary, we speak as men approved by God to be entrusted with the gospel. We are not trying to please men but God, who tests our hearts.",
         "book": "1 Thessalonians",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "29658bfc39ef6394"
       },
       {
         "id": 10145,
@@ -3716,7 +4196,8 @@
         "verse": "Though I am free and belong to no man, I make myself a slave to everyone, to win as many as possible.",
         "book": "1 Corinthians",
         "reference": "9:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7b857eb429d1d40e"
       },
       {
         "id": 10146,
@@ -3724,7 +4205,8 @@
         "verse": "Do you not say, 'Four months more and then the harvest'? I tell you, open your eyes and look at the fields! They are ripe for harvest.",
         "book": "John",
         "reference": "4:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7a0695f18c11f66c"
       },
       {
         "id": 10147,
@@ -3732,7 +4214,8 @@
         "verse": "We loved you so much that we were delighted to share with you not only the gospel of God but our lives as well, because you had become so dear to us.",
         "book": "1 Thessalonians",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "11d5b9f231cbc1d7"
       },
       {
         "id": 10148,
@@ -3740,7 +4223,8 @@
         "verse": "As it is written: \"There is no one righteous, not even one; there is no one who understands, no one who seeks God. All have turned away, they have together become worthless; there is no one who does good, not even one.\"",
         "book": "Romans",
         "reference": "3:10-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "02796341ce14ceb2"
       },
       {
         "id": 10149,
@@ -3748,7 +4232,8 @@
         "verse": "He will punish those who do not know God and do not obey the gospel of our Lord Jesus. They will be punished with everlasting destruction and shut out from the presence of the Lord and from the majesty of his power",
         "book": "2 Thessalonians",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cadae55e55fb7885"
       },
       {
         "id": 10150,
@@ -3756,7 +4241,8 @@
         "verse": "He himself bore our sins in his body on the tree, so that we might die to sins and live for righteousness; by his wounds you have been healed.",
         "book": "1 Peter",
         "reference": "2:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4dfdaa57ba457f40"
       },
       {
         "id": 10151,
@@ -3764,7 +4250,8 @@
         "verse": "who has saved us and called us to a holy life—not because of anything we have done but because of his own purpose and grace. This grace was given us in Christ Jesus before the beginning of time,",
         "book": "2 Timothy",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c15a1d646552214e"
       },
       {
         "id": 10152,
@@ -3772,7 +4259,8 @@
         "verse": "That if you confess with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you confess and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d4c353e0a264a83e"
       },
       {
         "id": 10153,
@@ -3780,7 +4268,8 @@
         "verse": "I give them eternal life, and they shall never perish; no one can snatch them out of my hand. My Father, who has given them to me, is greater than all; no one can snatch them out of my Father's hand.",
         "book": "John",
         "reference": "10:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "09068f9544a53662"
       },
       {
         "id": 10154,
@@ -3788,7 +4277,8 @@
         "verse": "All a man's ways seem right to him, but the LORD weighs the heart.",
         "book": "Proverbs",
         "reference": "21:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1af4487bab249a9c"
       },
       {
         "id": 10155,
@@ -3796,7 +4286,8 @@
         "verse": "What good is it for a man to gain the whole world, yet forfeit his soul?",
         "book": "Mark",
         "reference": "8:36",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f876bef822c59b06"
       },
       {
         "id": 10156,
@@ -3804,7 +4295,8 @@
         "verse": "If anyone chooses to do God's will, he will find out whether my teaching comes from God or whether I speak on my own.",
         "book": "John",
         "reference": "7:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "418086039ff57dc3"
       },
       {
         "id": 10157,
@@ -3812,7 +4304,8 @@
         "verse": "Jesus answered them, \"It is not the healthy who need a doctor, but the sick. I have not come to call the righteous, but sinners to repentance.\"",
         "book": "Luke",
         "reference": "5:31-32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70040b779965a43c"
       },
       {
         "id": 10158,
@@ -3820,7 +4313,8 @@
         "verse": "How can you believe if you accept praise from one another, yet make no effort to obtain the praise that comes from the only God?",
         "book": "John",
         "reference": "5:44",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f730075719c00814"
       },
       {
         "id": 10159,
@@ -3828,7 +4322,8 @@
         "verse": "Therefore he is able to save completely those who come to God through him, because he always lives to intercede for them.",
         "book": "Hebrews",
         "reference": "7:25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4d949afb30fea4b3"
       },
       {
         "id": 10160,
@@ -3836,7 +4331,8 @@
         "verse": "Do not boast about tomorrow, for you do not know what a day may bring forth.",
         "book": "Proverbs",
         "reference": "27:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ed25837ecf494348"
       },
       {
         "id": 10161,
@@ -3844,7 +4340,8 @@
         "verse": "So then, each of us will give an account of himself to God.",
         "book": "Romans",
         "reference": "14:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "553bb10cea9b3131"
       },
       {
         "id": 10162,
@@ -3852,7 +4349,8 @@
         "verse": "You diligently study the Scriptures because you think that by them you possess eternal life. These are the Scriptures that testify about me,",
         "book": "John",
         "reference": "5:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "aa4048b283e6efe8"
       },
       {
         "id": 10163,
@@ -3860,7 +4358,17 @@
         "verse": "There is a way that seems right to a man, but in the end it leads to death.",
         "book": "Proverbs",
         "reference": "14:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dcd1353504785dec"
+      },
+      {
+        "id": 20004,
+        "title": "God Won't Send Anyone to Hell",
+        "verse": "\"Then he will say to those on his left, 'Depart from me, you who are cursed, into the eternal fire prepared for the devil and his angels.",
+        "book": "Matthew",
+        "reference": "25:41",
+        "subpack": "",
+        "cardUid": "fa49520b7758dc6f"
       },
       {
         "id": 10164,
@@ -3868,7 +4376,8 @@
         "verse": "For since the creation of the world God's invisible qualities—his eternal power and divine nature—have been clearly seen, being understood from what has been made, so that men are without excuse.",
         "book": "Romans",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3ebb7a5a67e9f8cb"
       },
       {
         "id": 10165,
@@ -3876,7 +4385,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your forefathers, but with the precious blood of Christ, a lamb without blemish or defect.",
         "book": "1 Peter",
         "reference": "1:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "485db829f2e09ccc"
       },
       {
         "id": 10166,
@@ -3884,7 +4394,8 @@
         "verse": "All this is from God, who reconciled us to himself through Christ and gave us the ministry of reconciliation:",
         "book": "2 Corinthians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8e7d2b351b78ec2"
       },
       {
         "id": 10167,
@@ -3892,7 +4403,8 @@
         "verse": "In him we have redemption through his blood, the forgiveness of sins, in accordance with the riches of God's grace",
         "book": "Ephesians",
         "reference": "1:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c87d19b4c2a8d0f4"
       },
       {
         "id": 10168,
@@ -3900,7 +4412,8 @@
         "verse": "For sin shall not be your master, because you are not under law, but under grace. What then? Shall we sin because we are not under law but under grace? By no means!",
         "book": "Romans",
         "reference": "6:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61526805bbcdd38e"
       },
       {
         "id": 10169,
@@ -3908,7 +4421,8 @@
         "verse": "You are all sons of God through faith in Christ Jesus,",
         "book": "Galatians",
         "reference": "3:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f894c2e7cb721d7d"
       },
       {
         "id": 10170,
@@ -3916,7 +4430,8 @@
         "verse": "But you are a chosen people, a royal priesthood, a holy nation, a people belonging to God, that you may declare the praises of him who called you out of darkness into his wonderful light.",
         "book": "1 Peter",
         "reference": "2:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "716b640fd19e2c92"
       },
       {
         "id": 10171,
@@ -3924,7 +4439,8 @@
         "verse": "God made him who had no sin to be sin for us, so that in him we might become the righteousness of God.",
         "book": "2 Corinthians",
         "reference": "5:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0097805421838754"
       },
       {
         "id": 10172,
@@ -3932,7 +4448,8 @@
         "verse": "It is because of him that you are in Christ Jesus, who has become for us wisdom from God—that is, our righteousness, holiness and redemption.",
         "book": "1 Corinthians",
         "reference": "1:30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c130b394973678e"
       },
       {
         "id": 10173,
@@ -3940,7 +4457,8 @@
         "verse": "because by one sacrifice he has made perfect forever those who are being made holy.",
         "book": "Hebrews",
         "reference": "10:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "34454e430a4ecbe6"
       },
       {
         "id": 10174,
@@ -3948,7 +4466,8 @@
         "verse": "and are justified freely by his grace through the redemption that came by Christ Jesus.",
         "book": "Romans",
         "reference": "3:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "011f81407de1aca9"
       },
       {
         "id": 10175,
@@ -3956,7 +4475,8 @@
         "verse": "But our citizenship is in heaven. And we eagerly await a Savior from there, the Lord Jesus Christ,",
         "book": "Philippians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f94f3170e8b1b787"
       },
       {
         "id": 10176,
@@ -3964,7 +4484,8 @@
         "verse": "For in Christ all the fullness of the Deity lives in bodily form, and you have been given fullness in Christ, who is the head over every power and authority.",
         "book": "Colossians",
         "reference": "2:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70c389041d50c7bb"
       }
     ]
   }

--- a/Tests/SRSCoreTests/DiffEngineTests.swift
+++ b/Tests/SRSCoreTests/DiffEngineTests.swift
@@ -114,4 +114,55 @@ final class DiffEngineTests: XCTestCase {
             XCTAssertEqual(consumedTyped, typed.count)
         }
     }
+
+    // MARK: - Punctuation-only tokens
+
+    /// Around thirty cards title themselves "Man - the sinner". The standalone
+    /// dash used to be scored as a target word, so not typing it was reported as
+    /// a missing word and the card could never come out perfect.
+    func testStandalonePunctuationIsNotScored() {
+        let target = ["Man", "-", "the", "sinner"]
+        let diffs  = DiffEngine.buildDiffs(typed: ["Man", "the", "sinner"], target: target)
+        XCTAssertTrue(diffs.allSatisfy { $0.kind == .correct },
+                      "a dash the user can't reasonably type must not count against them")
+        XCTAssertEqual(diffs.count, 3)
+    }
+
+    /// Typing the dash is still fine — it just isn't required either way.
+    func testTypingThePunctuationIsAlsoAccepted() {
+        let diffs = DiffEngine.buildDiffs(typed: ["Man", "-", "the", "sinner"],
+                                          target: ["Man", "-", "the", "sinner"])
+        XCTAssertTrue(diffs.allSatisfy { $0.kind == .correct })
+    }
+
+    // MARK: - British / American spelling
+
+    func testBritishSpellingAccepted() {
+        for (british, american) in [("saviour", "savior"), ("honour", "honor"),
+                                    ("neighbour", "neighbor"), ("realise", "realize"),
+                                    ("baptised", "baptized"), ("defence", "defense"),
+                                    ("judgement", "judgment"), ("fulfilled", "fulfilled")] {
+            XCTAssertTrue(DiffEngine.normalizedMatch(british, american),
+                          "\(british) should match \(american)")
+            XCTAssertTrue(DiffEngine.normalizedMatch(american, british),
+                          "\(american) should match \(british)")
+        }
+    }
+
+    func testSpellingEquivalenceDoesNotMergeUnrelatedWords() {
+        // Words that merely *look* like they'd be caught by an "-our -> -or"
+        // or "-ise -> -ize" rule must stay distinct.
+        XCTAssertFalse(DiffEngine.normalizedMatch("four", "for"))
+        XCTAssertFalse(DiffEngine.normalizedMatch("hour", "hor"))
+        XCTAssertFalse(DiffEngine.normalizedMatch("wise", "wize"))
+        XCTAssertFalse(DiffEngine.normalizedMatch("praise", "praize"))
+        XCTAssertFalse(DiffEngine.normalizedMatch("honour", "honesty"))
+    }
+
+    func testBritishSpellingInAFullDiff() {
+        let diffs = DiffEngine.buildDiffs(
+            typed:  ["our", "saviour", "showed", "favour"],
+            target: ["our", "savior",  "showed", "favor"])
+        XCTAssertTrue(diffs.allSatisfy { $0.kind == .correct })
+    }
 }

--- a/scripture memory/App.swift
+++ b/scripture memory/App.swift
@@ -11,6 +11,13 @@ import SwiftUI
 struct ScriptureMemoryApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
+    init() {
+        // Before anything else: the stores below read their defaults on first
+        // access and cache them, so progress has to be moved onto the permanent
+        // card ids while nothing has loaded yet. No-op after the first launch.
+        IdentityMigration.runIfNeeded()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -23,10 +30,27 @@ struct ScriptureMemoryApp: App {
                     // launch (the OS keeps the repeating trigger, but this keeps
                     // it in sync if permission or the time changed out of band).
                     await NotificationManager.refreshFromSettings()
+                    // Pick up any published verse corrections. Writes a cache
+                    // file and nothing else — this launch keeps the catalog it
+                    // started with, and the next one reads the new one. See
+                    // `VerseCatalog`. No-op unless Supabase is configured.
+                    await VerseCatalog.refreshIfNeeded()
                 }
         }
         .onChange(of: scenePhase) { _, phase in
-            if phase == .active { StreakStore.shared.recordToday() }
+            if phase == .active {
+                StreakStore.shared.recordToday()
+                // Also on resume, not just on launch. `.task` above runs once per
+                // cold start, and iOS keeps apps suspended for days — so relying
+                // on it alone meant a published correction needed two launches to
+                // appear: one to download it, another to read it. Fetching here
+                // means the cache is usually already current by the time the app
+                // is next started cold, leaving one restart instead of two.
+                //
+                // Still only writes the cache; nothing changes mid-session. See
+                // `VerseCatalog`.
+                Task { await VerseCatalog.refreshIfNeeded() }
+            }
             // Re-arm the reminder window on backgrounding so its pre-scheduled
             // due counts reflect any reviews just completed.
             if phase == .background {

--- a/scripture memory/Model/AppSettings.swift
+++ b/scripture memory/Model/AppSettings.swift
@@ -46,8 +46,17 @@ enum BibleVersion: String, CaseIterable {
         }
     }
 
+    /// Packs that have no NIV 2011 edition in the material we're tested on. Their
+    /// cards stay on NIV 1984 whichever translation is selected — otherwise the
+    /// user would memorise wording that the test doesn't accept.
+    static let niv84OnlyPackNames: Set<String> = ["5 Assurances"]
+
     var packs: [Pack] {
-        self == .niv11 ? packsNIV11 : packsNIV84
+        guard self == .niv11 else { return packsNIV84 }
+        return packsNIV11.map { pack in
+            guard Self.niv84OnlyPackNames.contains(pack.name) else { return pack }
+            return packsNIV84.first { $0.name == pack.name } ?? pack
+        }
     }
 }
 

--- a/scripture memory/Model/AppSettings.swift
+++ b/scripture memory/Model/AppSettings.swift
@@ -51,13 +51,17 @@ enum BibleVersion: String, CaseIterable {
     /// user would memorise wording that the test doesn't accept.
     static let niv84OnlyPackNames: Set<String> = ["5 Assurances"]
 
-    var packs: [Pack] {
-        guard self == .niv11 else { return packsNIV84 }
-        return packsNIV11.map { pack in
-            guard Self.niv84OnlyPackNames.contains(pack.name) else { return pack }
-            return packsNIV84.first { $0.name == pack.name } ?? pack
-        }
+    /// Built once rather than per access. `packs` is read inside `body` on
+    /// several screens — which means once per frame of any animation running on
+    /// them — and rebuilding 15 pack values each time is enough copying to show
+    /// up as dropped frames in a system transition. The two bundles are fixed for
+    /// the life of the process (see `VerseCatalog`), so this can be a constant.
+    private static let niv11Packs: [Pack] = packsNIV11.map { pack in
+        guard niv84OnlyPackNames.contains(pack.name) else { return pack }
+        return packsNIV84.first { $0.name == pack.name } ?? pack
     }
+
+    var packs: [Pack] { self == .niv11 ? Self.niv11Packs : packsNIV84 }
 }
 
 // MARK: - Home Verse Start Mode

--- a/scripture memory/Model/CardFooter.swift
+++ b/scripture memory/Model/CardFooter.swift
@@ -26,34 +26,12 @@ enum CardFooter {
         "5 Assurances": "Beginning with Christ",
     ]
 
-    /// Each verse's 1-based position within its series, keyed by `srsKey` so the
-    /// numbering survives a translation switch.
-    ///
-    /// Taken from the pack's published order rather than the list on screen. The
-    /// session's own order is reordered by shuffle and by picking a subset for a
-    /// quiz, which would renumber a card whose number is fixed in the booklet —
-    /// A-12 has to stay A-12 wherever it turns up.
-    private static let positions: [String: Int] = {
-        var map: [String: Int] = [:]
-        for packs in [packsNIV84, packsNIV11] {
-            for pack in packs {
-                var countsBySection: [String: Int] = [:]
-                for verse in pack.verses {
-                    let position = (countsBySection[verse.subpack] ?? 0) + 1
-                    countsBySection[verse.subpack] = position
-                    map[verse.srsKey] = position
-                }
-            }
-        }
-        return map
-    }()
-
     /// `fallbackPack` covers verses built outside the JSON (previews, ad-hoc
     /// construction) whose `packName` was never back-filled.
     static func label(for verse: Verse, fallbackPack: String = "") -> String {
         let pack = verse.packName.isEmpty ? fallbackPack : verse.packName
         guard let title = seriesTitle(pack: pack, section: verse.subpack),
-              let position = positions[verse.srsKey] else { return pack }
+              let position = VerseNumbering.position(of: verse) else { return pack }
         let number = verse.subpack.isEmpty ? "\(position)" : "\(verse.subpack)-\(position)"
         return "\(number) · \(title)"
     }

--- a/scripture memory/Model/CardFooter.swift
+++ b/scripture memory/Model/CardFooter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// The caption in a flashcard's bottom-left corner.
+///
+/// For packs published as numbered series — TMS 60's five lettered sections, and
+/// the five assurances of *Beginning with Christ* — the caption is the card's own
+/// printed number plus the series it belongs to (`"A-12 · Live the New Life"`).
+/// Every other pack keeps the plain pack name it has always shown, since there's
+/// no published series naming to put there.
+enum CardFooter {
+
+    /// Series names for packs whose cards are organised into lettered sections,
+    /// keyed pack → section letter.
+    private static let sectionTitles: [String: [String: String]] = [
+        "TMS 60": [
+            "A": "Live the New Life",
+            "B": "Proclaim Christ",
+            "C": "Rely on God's Resources",
+            "D": "Be Christ's Disciple",
+            "E": "Grow in Christ Likeness",
+        ],
+    ]
+
+    /// Series names for packs that are one straight numbered run with no letters.
+    private static let wholePackTitles: [String: String] = [
+        "5 Assurances": "Beginning with Christ",
+    ]
+
+    /// Each verse's 1-based position within its series, keyed by `srsKey` so the
+    /// numbering survives a translation switch.
+    ///
+    /// Taken from the pack's published order rather than the list on screen. The
+    /// session's own order is reordered by shuffle and by picking a subset for a
+    /// quiz, which would renumber a card whose number is fixed in the booklet —
+    /// A-12 has to stay A-12 wherever it turns up.
+    private static let positions: [String: Int] = {
+        var map: [String: Int] = [:]
+        for packs in [packsNIV84, packsNIV11] {
+            for pack in packs {
+                var countsBySection: [String: Int] = [:]
+                for verse in pack.verses {
+                    let position = (countsBySection[verse.subpack] ?? 0) + 1
+                    countsBySection[verse.subpack] = position
+                    map[verse.srsKey] = position
+                }
+            }
+        }
+        return map
+    }()
+
+    /// `fallbackPack` covers verses built outside the JSON (previews, ad-hoc
+    /// construction) whose `packName` was never back-filled.
+    static func label(for verse: Verse, fallbackPack: String = "") -> String {
+        let pack = verse.packName.isEmpty ? fallbackPack : verse.packName
+        guard let title = seriesTitle(pack: pack, section: verse.subpack),
+              let position = positions[verse.srsKey] else { return pack }
+        let number = verse.subpack.isEmpty ? "\(position)" : "\(verse.subpack)-\(position)"
+        return "\(number) · \(title)"
+    }
+
+    private static func seriesTitle(pack: String, section: String) -> String? {
+        section.isEmpty ? wholePackTitles[pack] : sectionTitles[pack]?[section]
+    }
+}

--- a/scripture memory/Model/Catalogue.swift
+++ b/scripture memory/Model/Catalogue.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// The visible verses, flattened out of their packs — memoized.
+///
+/// `packs.flatMap(\.verses)` reads as free and isn't: it allocates a fresh
+/// ~490-element array, and every `Verse` in it carries seven strings to retain.
+/// Screens ask for it inside `body`, and `body` runs on every frame of any
+/// animation touching the screen — the search bar sliding up, a row expanding.
+/// At that rate the copying is enough to drop frames and make a system
+/// animation look sluggish.
+///
+/// The pack set only changes when the translation, pack order or hidden set
+/// does, so the flattened list is computed once per such change and handed back
+/// unchanged in between (arrays are copy-on-write, so callers share storage).
+@MainActor
+enum Catalogue {
+
+    private static var cached: (token: Int, verses: [Verse])?
+
+    /// Every verse in `packs`, in pack order.
+    static func verses(in packs: [Pack]) -> [Verse] {
+        let token = fingerprint(packs)
+        if let cached, cached.token == token { return cached.verses }
+        let flattened = packs.flatMap(\.verses)
+        cached = (token, flattened)
+        return flattened
+    }
+
+    /// Cheap stand-in for "is this the same pack set?" — names and sizes. The
+    /// three things that change it in practice (translation, pack order, pack
+    /// visibility) all move one or the other.
+    static func fingerprint(_ packs: [Pack]) -> Int {
+        var hasher = Hasher()
+        for pack in packs {
+            hasher.combine(pack.name)
+            hasher.combine(pack.verses.count)
+        }
+        return hasher.finalize()
+    }
+}

--- a/scripture memory/Model/DiffEngine.swift
+++ b/scripture memory/Model/DiffEngine.swift
@@ -11,7 +11,15 @@ enum DiffEngine {
     // MARK: Public
 
     /// Builds an array of `DiffWord` annotations comparing `typed` words to `target` words.
-    static func buildDiffs(typed: [String], target: [String]) -> [DiffWord] {
+    ///
+    /// Tokens that are pure punctuation are dropped from both sides first.
+    /// Around thirty cards carry a standalone `-` in the title ("Man - the
+    /// sinner"), and scoring it meant the dash was reported missing unless the
+    /// user typed it as a word of its own — so those cards could never come out
+    /// perfect, and the mistake it named wasn't one.
+    static func buildDiffs(typed rawTyped: [String], target rawTarget: [String]) -> [DiffWord] {
+        let typed  = rawTyped.filter  { !normalize($0).isEmpty }
+        let target = rawTarget.filter { !normalize($0).isEmpty }
         let m = typed.count, n = target.count
         if m == 0 { return target.map { DiffWord(text: $0, kind: .missing) } }
         if n == 0 { return typed.map  { DiffWord(text: $0, kind: .extra)   } }
@@ -25,12 +33,15 @@ enum DiffEngine {
         normalize(a) == normalize(b)
     }
 
+    /// Lowercased, punctuation-stripped, and reduced to one spelling where
+    /// British and American differ — see `SpellingVariants`.
     static func normalize(_ word: String) -> String {
-        word.trimmingQuotationDelimitersOnEnds()
+        let stripped = word.trimmingQuotationDelimitersOnEnds()
             .lowercased()
             .components(separatedBy: CharacterSet.punctuationCharacters.union(.symbols))
             .joined()
             .trimmingCharacters(in: .whitespaces)
+        return SpellingVariants.canonical(stripped)
     }
 
     // MARK: Private

--- a/scripture memory/Model/FavoritesStore.swift
+++ b/scripture memory/Model/FavoritesStore.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Combine
+
+/// Verses the user has starred.
+///
+/// Keyed by `srsKey` (pack + book + reference) rather than `Verse.id`, for the
+/// same reason SRS and learning progress are: the two translation bundles give
+/// the same card different ids, and a favourite should survive switching
+/// between them — you starred the verse, not the edition.
+@MainActor
+final class FavoritesStore: ObservableObject {
+
+    static let shared = FavoritesStore()
+
+    /// The name the favourites collection goes by wherever it's shown as a pack.
+    static let packName = "Favourites"
+
+    @Published private(set) var keys: Set<String>
+
+    private let defaults = UserDefaults.standard
+    private static let storageKey = "favorites.verseKeys.v1"
+
+    private init() {
+        keys = Set(defaults.stringArray(forKey: Self.storageKey) ?? [])
+    }
+
+    func isFavorite(_ verse: Verse) -> Bool {
+        !verse.srsKey.isEmpty && keys.contains(verse.srsKey)
+    }
+
+    @discardableResult
+    func toggle(_ verse: Verse) -> Bool {
+        guard !verse.srsKey.isEmpty else { return false }
+        let nowFavorite: Bool
+        if keys.contains(verse.srsKey) {
+            keys.remove(verse.srsKey)
+            nowFavorite = false
+        } else {
+            keys.insert(verse.srsKey)
+            nowFavorite = true
+        }
+        persist()
+        return nowFavorite
+    }
+
+    func remove(_ verse: Verse) {
+        guard keys.remove(verse.srsKey) != nil else { return }
+        persist()
+    }
+
+    /// Starred verses from `packs`, in catalogue order.
+    ///
+    /// Filtered from the live pack list rather than stored as verse copies, so a
+    /// verse whose text is corrected — or whose pack the user has since hidden —
+    /// is reflected here without any migration.
+    ///
+    /// Memoized: the Packs grid asks for this inside `body`, which runs on every
+    /// frame of the search-bar animation, and scanning the catalogue that often
+    /// costs visible frames. Invalidated by the star set changing or the pack set
+    /// changing, which is everything it depends on.
+    func verses(in packs: [Pack]) -> [Verse] {
+        guard !keys.isEmpty else { return [] }
+        let token = Catalogue.fingerprint(packs) ^ keys.hashValue
+        if let cachedVerses, cachedVerses.token == token { return cachedVerses.verses }
+        let matched = Catalogue.verses(in: packs).filter { keys.contains($0.srsKey) }
+        cachedVerses = (token, matched)
+        return matched
+    }
+
+    private var cachedVerses: (token: Int, verses: [Verse])?
+
+    /// The favourites presented as a pack, so every surface that takes a `Pack`
+    /// — the study screen, the grid, the quiz picker — can show it with no
+    /// special-casing. `nil` when nothing is starred; there's nothing to open.
+    func pack(in packs: [Pack]) -> Pack? {
+        let verses = verses(in: packs)
+        guard !verses.isEmpty else { return nil }
+        return Pack(name: Self.packName, color: "#E5A50A",
+                    accentText: "\u{2605}", verses: verses)
+    }
+
+    func clear() {
+        guard !keys.isEmpty else { return }
+        keys = []
+        persist()
+    }
+
+    private func persist() {
+        cachedVerses = nil
+        defaults.set(Array(keys), forKey: Self.storageKey)
+    }
+}

--- a/scripture memory/Model/IdentityMigration.swift
+++ b/scripture memory/Model/IdentityMigration.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Moves saved progress from the old content-derived card key to `cardUid`.
+///
+/// Everything the user has earned — which verses they've learnt, which one is
+/// pinned, which are starred, and every SRS card's schedule — was filed under
+/// `pack name + book + reference`. This rewrites all of it, once, to the
+/// permanent id. See `Verse.cardUid` for why.
+///
+/// Runs before any store reads its defaults (see `ScriptureMemoryApp.init`),
+/// because those stores load once and cache; migrating underneath a loaded
+/// store would leave the in-memory copy on the old keys and persist them back.
+///
+/// Safe to call on every launch: it records completion and returns immediately
+/// afterwards, and it only ever rewrites keys it can find a mapping for.
+enum IdentityMigration {
+
+    private static let completionKey = "identity.cardUidMigration.v1"
+
+    static func runIfNeeded(defaults: UserDefaults = .standard,
+                            cloud: NSUbiquitousKeyValueStore = .default) {
+        guard !defaults.bool(forKey: completionKey) else { return }
+
+        let map = legacyToUid()
+        // No mapping means the catalog failed to load. Do nothing and stay
+        // un-migrated rather than writing a half-translated store — this runs
+        // again next launch.
+        guard !map.isEmpty else { return }
+
+        migrateStringArray("learning.learntKeys.v1", map: map, defaults: defaults)
+        migrateStringArray("favorites.verseKeys.v1", map: map, defaults: defaults)
+        migrateString("learning.pinnedKey.v1", map: map, defaults: defaults)
+        migrateCardStates(map: map, defaults: defaults, cloud: cloud)
+
+        defaults.set(true, forKey: completionKey)
+    }
+
+    /// Old key → new id, for every card in either edition.
+    ///
+    /// Three passages are printed on two different cards in the same pack (Acts
+    /// 17:11 in DEP 3, 1 Timothy 2:1-2 in DEP 4, Romans 10:9-10 in DEP 6). The
+    /// old key couldn't tell those apart, so on disk there is only one entry for
+    /// each pair and no way to know which card it meant. First occurrence wins;
+    /// the twin starts fresh. That's the honest outcome — the two were being
+    /// treated as one card, and one of them has to be the one that keeps the
+    /// history.
+    private static func legacyToUid() -> [String: String] {
+        var map: [String: String] = [:]
+        for packs in [packsNIV84, packsNIV11] {
+            for pack in packs {
+                for verse in pack.verses {
+                    guard let uid = verse.cardUid else { continue }
+                    let legacy = verse.legacyKey
+                    if map[legacy] == nil { map[legacy] = uid }
+                }
+            }
+        }
+        return map
+    }
+
+    private static func migrateStringArray(_ key: String, map: [String: String],
+                                           defaults: UserDefaults) {
+        guard let stored = defaults.stringArray(forKey: key), !stored.isEmpty else { return }
+        // Anything unmapped is kept as-is rather than dropped: it may belong to a
+        // pack that's temporarily missing from the catalog, and silently deleting
+        // someone's progress is far worse than carrying a stale key.
+        let migrated = stored.map { map[$0] ?? $0 }
+        defaults.set(Array(Set(migrated)), forKey: key)
+    }
+
+    private static func migrateString(_ key: String, map: [String: String],
+                                      defaults: UserDefaults) {
+        guard let stored = defaults.string(forKey: key), let uid = map[stored] else { return }
+        defaults.set(uid, forKey: key)
+    }
+
+    /// SRS schedules, which live in iCloud as well as locally.
+    ///
+    /// The key appears twice — as the dictionary key and inside each record —
+    /// and both have to move together or `SRSStore` will disagree with itself.
+    private static func migrateCardStates(map: [String: String],
+                                          defaults: UserDefaults,
+                                          cloud: NSUbiquitousKeyValueStore) {
+        let key = "srs.cardStates.v1"
+        let raw = cloud.data(forKey: key) ?? defaults.data(forKey: key)
+        guard let raw,
+              let states = try? JSONDecoder().decode([String: SRSCardState].self, from: raw)
+        else { return }
+
+        var migrated: [String: SRSCardState] = [:]
+        migrated.reserveCapacity(states.count)
+        for (legacy, state) in states {
+            let uid = map[legacy] ?? legacy
+            var moved = state
+            moved.key = uid
+            // Two legacy keys can't collide on one uid, but a partially-migrated
+            // store could already hold the target — keep whichever is further
+            // along rather than overwriting a real schedule with a fresh one.
+            if let existing = migrated[uid], existing.reps >= moved.reps { continue }
+            migrated[uid] = moved
+        }
+
+        guard let encoded = try? JSONEncoder().encode(migrated) else { return }
+        defaults.set(encoded, forKey: key)
+        cloud.set(encoded, forKey: key)
+        cloud.synchronize()
+    }
+}

--- a/scripture memory/Model/LearningStore.swift
+++ b/scripture memory/Model/LearningStore.swift
@@ -60,7 +60,7 @@ final class LearningStore: ObservableObject {
     /// ask "is this the current verse?" without the dashboard plumbing it through.
     var visibleOrdered: [Verse] {
         let version = BibleVersion(rawValue: defaults.string(forKey: "bibleVersion") ?? "") ?? .niv84
-        return PackPreferencesStore.shared.visible(from: version.packs).flatMap(\.verses)
+        return Catalogue.verses(in: PackPreferencesStore.shared.visible(from: version.packs))
     }
 
     /// Cheap fingerprint of everything `visibleOrdered` depends on except

--- a/scripture memory/Model/ModelData.swift
+++ b/scripture memory/Model/ModelData.swift
@@ -1,42 +1,8 @@
 import Foundation
 
-var packsNIV84: [Pack] = loadPacks("verseData.json")
-var packsNIV11: [Pack] = loadPacks("verseDataNIV11.json")
-
-/// Loads a packs JSON and back-fills `Verse.packName` so `Verse.srsKey` is valid.
-func loadPacks(_ filename: String) -> [Pack] {
-    let raw: [Pack] = load(filename)
-    return raw.map { pack in
-        let withPack: [Verse] = pack.verses.map { v in
-            var w = v
-            w.packName = pack.name
-            return w
-        }
-        return Pack(name: pack.name,
-                    color: pack.color,
-                    accentText: pack.accentText,
-                    verses: withPack)
-    }
-}
-
-func load<T: Decodable>(_ filename: String) -> T {
-    let data: Data
-
-    guard let file = Bundle.main.url(forResource: filename, withExtension: nil)
-        else {
-            fatalError("Couldn't find \(filename) in main bundle.")
-    }
-
-    do {
-        data = try Data(contentsOf: file)
-    } catch {
-        fatalError("Couldn't load \(filename) from main bundle:\n\(error)")
-    }
-
-    do {
-        let decoder = JSONDecoder()
-        return try decoder.decode(T.self, from: data)
-    } catch {
-        fatalError("Couldn't parse \(filename) as \(T.self):\n\(error)")
-    }
-}
+/// The two bundled editions, resolved through `VerseCatalog` so a remote
+/// correction can supersede the bundled JSON. Read once at first access and
+/// held for the life of the process — see `VerseCatalog` for why updates are
+/// deliberately deferred to the next launch.
+var packsNIV84: [Pack] = VerseCatalog.packs(edition: "NIV84", bundledFile: "verseData.json")
+var packsNIV11: [Pack] = VerseCatalog.packs(edition: "NIV11", bundledFile: "verseDataNIV11.json")

--- a/scripture memory/Model/SpellingVariants.swift
+++ b/scripture memory/Model/SpellingVariants.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// British and American spellings of the same word, treated as the same word.
+///
+/// The packs are printed in several editions and people learn from whichever
+/// they own, so someone who writes `saviour` against an NIV card reading
+/// `savior` has recalled the verse correctly and shouldn't be marked wrong.
+///
+/// A fixed list rather than a rule like "-our → -or". Scripture vocabulary is
+/// small enough to enumerate, and suffix rules misfire on ordinary words —
+/// `four`, `hour`, `pour`, `devour` all end in "our", and `wise`, `praise`,
+/// `promise`, `paradise` all end in "ise". A rule would have to carry a longer
+/// list of exceptions than this list of words.
+///
+/// Foundation-only so it stays unit-testable alongside `DiffEngine`.
+enum SpellingVariants {
+
+    /// British → American stems. Only the stem is listed; the common inflections
+    /// are generated below, so `honour` also covers `honours`, `honoured`,
+    /// `honouring` and `honourable`.
+    private static let stems: [(british: String, american: String)] = [
+        ("saviour",   "savior"),
+        ("honour",    "honor"),
+        ("favour",    "favor"),
+        ("labour",    "labor"),
+        ("neighbour", "neighbor"),
+        ("colour",    "color"),
+        ("splendour", "splendor"),
+        ("vigour",    "vigor"),
+        ("valour",    "valor"),
+        ("armour",    "armor"),
+        ("harbour",   "harbor"),
+        ("odour",     "odor"),
+        ("rumour",    "rumor"),
+        ("clamour",   "clamor"),
+        ("endeavour", "endeavor"),
+        ("behaviour", "behavior"),
+        ("humour",    "humor"),
+        ("marvellous","marvelous"),
+        ("counsellor","counselor"),
+        ("traveller", "traveler"),
+        ("worshipper","worshiper"),
+        ("defence",   "defense"),
+        ("offence",   "offense"),
+        ("pretence",  "pretense"),
+        ("realise",   "realize"),
+        ("baptise",   "baptize"),
+        ("recognise", "recognize"),
+        ("apologise", "apologize"),
+        ("centre",    "center"),
+        ("fulfil",    "fulfill"),
+        ("skilful",   "skillful"),
+        ("wilful",    "willful"),
+        ("judgement", "judgment"),
+        ("grey",      "gray"),
+        ("plough",    "plow"),
+        ("enrolment", "enrollment"),
+        ("practise",  "practice"),
+    ]
+
+    /// Suffixes applied to both sides of each pair. Some combinations aren't
+    /// real words (`greys`, `centreing`); an unreachable key costs nothing and
+    /// keeping the list uniform is simpler than curating per word.
+    private static let suffixes = ["", "s", "es", "ed", "d", "ing", "er", "ers", "able", "ably"]
+
+    /// Every accepted British form mapped to its American equivalent.
+    private static let map: [String: String] = {
+        var map: [String: String] = [:]
+        for (british, american) in stems {
+            for suffix in suffixes {
+                map[british + suffix] = american + suffix
+            }
+            // `fulfil`/`fulfill` and friends double the consonant before a vowel
+            // suffix, so the naive concatenation above misses `fulfilled`.
+            if let last = british.last, british.count == american.count - 1 {
+                for suffix in ["ed", "ing", "er", "ers"] {
+                    map[british + String(last) + suffix] = american + suffix
+                }
+            }
+        }
+        return map
+    }()
+
+    /// The American spelling when `word` is a known British variant, otherwise
+    /// `word` unchanged. Expects an already-lowercased, punctuation-stripped
+    /// token.
+    static func canonical(_ word: String) -> String {
+        map[word] ?? word
+    }
+}

--- a/scripture memory/Model/Verse.swift
+++ b/scripture memory/Model/Verse.swift
@@ -16,12 +16,40 @@ struct Verse: Hashable, Codable, Identifiable {
     let reference: String
     let subpack:   String
 
+    /// Translation this card is pinned to, when it differs from the edition the
+    /// rest of the pack uses. A handful of DEP cards are printed in KJV whatever
+    /// NIV edition surrounds them, and memorising the NIV wording for those would
+    /// mean reciting something the printed card doesn't say. `nil` — the common
+    /// case — means "whatever edition this file is".
+    let version: String?
+
+    /// Permanent, opaque card identity — the same value in every edition, and
+    /// the thing all user progress is filed under.
+    ///
+    /// Deliberately not derived from anything on screen. The old key was
+    /// `pack + book + reference`, which meant editorial tidying silently
+    /// destroyed data: renaming a pack, or writing `Psalms` where it used to say
+    /// `Psalm`, orphaned every bit of progress attached to it. Now that the
+    /// catalog is editable from a web console that failure mode was one careless
+    /// rename away.
+    ///
+    /// Optional only for verses built outside the catalog (previews, tests);
+    /// those fall back to the legacy key via `srsKey`.
+    let cardUid: String?
+
     /// Owning pack's name. Not present in JSON — injected by `ModelData`
-    /// after decode so the cross-version SRS key can be built.
+    /// after decode so the legacy key can still be built.
     var packName: String = ""
 
     private enum CodingKeys: String, CodingKey {
-        case id, title, verse, book, reference, subpack
+        case id, title, verse, book, reference, subpack, version, cardUid
+    }
+
+    /// The pinned translation, normalised — `nil` unless this card really does
+    /// override the file's edition, so callers can branch on presence alone.
+    var pinnedVersion: String? {
+        guard let v = version?.trimmingCharacters(in: .whitespaces), !v.isEmpty else { return nil }
+        return v.uppercased()
     }
 
     /// The title split into individual words.
@@ -30,10 +58,18 @@ struct Verse: Hashable, Codable, Identifiable {
     /// The verse body split into individual words.
     var verseWords: [String] { verse.wordTokens }
 
-    /// Stable cross-version SRS key: pack + canonical book + normalized reference.
-    /// Empty `packName` (e.g. ad-hoc Verse construction) yields a usable but
-    /// pack-less key — fine for non-SRS code paths.
-    var srsKey: String {
+    /// What every store files this verse's progress under: learnt, pinned,
+    /// starred, SRS scheduling.
+    ///
+    /// The `cardUid` when the verse came from the catalog, the legacy composite
+    /// otherwise. The fallback covers verses constructed in previews and tests,
+    /// never real cards — `IdentityMigration` has already rewritten anything
+    /// stored under the old form by the time this is read.
+    var srsKey: String { cardUid ?? legacyKey }
+
+    /// The pre-`cardUid` identity: pack + canonical book + normalized reference.
+    /// Kept solely so the one-time migration can look up what's on disk.
+    var legacyKey: String {
         SRSKey.make(packName: packName, book: book, reference: reference)
     }
 }

--- a/scripture memory/Model/VerseCatalog.swift
+++ b/scripture memory/Model/VerseCatalog.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+/// Where the app's verses come from.
+///
+/// The bundled JSON is the floor: it's always present, always complete, and is
+/// what a fresh install reads. On top of that sits an optional Supabase-hosted
+/// catalog, so a typo or a missing verse can be corrected without shipping a
+/// build through review.
+///
+/// **Updates land on the next launch, not mid-session.** Pack membership and
+/// ordering are baked into things computed once and held for the life of the
+/// process — printed card numbers (`VerseNumbering`), the search index, an
+/// in-flight quiz's verse list, the learning cursor's position in the
+/// catalogue. Swapping the catalogue underneath all of that while a session is
+/// open would renumber cards mid-quiz for a payoff nobody is waiting on. So the
+/// refresh writes to a cache file and stops; the next cold start picks it up.
+enum VerseCatalog {
+
+    // MARK: - Reading
+
+    /// Packs for one edition, from the newest catalog available on disk.
+    static func packs(edition: String, bundledFile: String) -> [Pack] {
+        if let cached = cachedDocument(), let packs = cached.editions[edition], !packs.isEmpty {
+            return withPackNames(packs)
+        }
+        return withPackNames(bundledPacks(bundledFile))
+    }
+
+    /// Back-fills `Verse.packName`, which isn't in the JSON (it's implied by
+    /// nesting) but is half of every `srsKey`.
+    private static func withPackNames(_ packs: [Pack]) -> [Pack] {
+        packs.map { pack in
+            Pack(name: pack.name, color: pack.color, accentText: pack.accentText,
+                 verses: pack.verses.map { verse in
+                     var copy = verse
+                     copy.packName = pack.name
+                     return copy
+                 })
+        }
+    }
+
+    private static func bundledPacks(_ filename: String) -> [Pack] {
+        guard let url = Bundle.main.url(forResource: filename, withExtension: nil) else {
+            fatalError("Couldn't find \(filename) in main bundle.")
+        }
+        do {
+            return try JSONDecoder().decode([Pack].self, from: Data(contentsOf: url))
+        } catch {
+            fatalError("Couldn't parse \(filename):\n\(error)")
+        }
+    }
+
+    // MARK: - Cache
+
+    /// A whole catalog: every edition, plus the version it was published at.
+    struct Document: Codable {
+        /// Shape of this file, not the content's publication number.
+        ///
+        /// Bumped whenever the app needs fields an older cache can't have. A
+        /// cache written before `cardUid` existed looked perfectly valid and
+        /// decoded fine — it just quietly shadowed the bundled JSON with verses
+        /// that had no identity, which disabled the migration and left every
+        /// card falling back to the old key. Requiring this field means such a
+        /// file fails to decode and gets discarded, which is the behaviour we
+        /// wanted all along.
+        let schema: Int
+        let catalogVersion: Int
+        let editions: [String: [Pack]]
+    }
+
+    /// Raise when a release needs something older caches don't carry.
+    static let currentSchema = 2
+
+    private static let cacheFilename = "verseCatalog.json"
+
+    /// In the shared App Group, not the app's private container.
+    ///
+    /// The widget is a separate process with its own bundle, so it can't read
+    /// the app's Application Support — which is why it fell back to its own
+    /// copy of the bundled JSON for the verse picker and went stale the moment
+    /// a pack changed remotely. Both targets already share this group for the
+    /// live snapshot; putting the catalog beside it means one downloaded file
+    /// serves both.
+    private static var cacheURL: URL? {
+        let shared = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: WidgetBridge.appGroup)?
+            .appendingPathComponent(cacheFilename)
+
+        // Move a cache written by an earlier build to the new home, so the first
+        // launch after updating doesn't throw away a good catalog and fall back
+        // to the bundle until the next refresh.
+        if let shared, !FileManager.default.fileExists(atPath: shared.path),
+           let legacy = legacyCacheURL, FileManager.default.fileExists(atPath: legacy.path) {
+            try? FileManager.default.moveItem(at: legacy, to: shared)
+        }
+        return shared ?? legacyCacheURL
+    }
+
+    private static var legacyCacheURL: URL? {
+        guard let dir = try? FileManager.default.url(for: .applicationSupportDirectory,
+                                                     in: .userDomainMask,
+                                                     appropriateFor: nil, create: true)
+        else { return nil }
+        return dir.appendingPathComponent(cacheFilename)
+    }
+
+    /// Parsed once per launch. A corrupt or truncated cache is discarded rather
+    /// than crashed on — the bundle is always there to fall back to, and a bad
+    /// download must never be able to brick the app.
+    private static let cachedDocumentOnce: Document? = {
+        guard let url = cacheURL, let data = try? Data(contentsOf: url) else { return nil }
+        do {
+            let document = try JSONDecoder().decode(Document.self, from: data)
+            guard document.schema == currentSchema else {
+                try? FileManager.default.removeItem(at: url)
+                return nil
+            }
+            return document
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+    }()
+
+    private static func cachedDocument() -> Document? { cachedDocumentOnce }
+
+    /// Version written by a refresh during this session, if any.
+    ///
+    /// `cachedDocumentOnce` is parsed once per launch and deliberately doesn't
+    /// re-read the file — the running session must keep the catalog it started
+    /// with. But that makes it the wrong thing to ask "have I already got this?":
+    /// after a download it still reports the *old* version, so the next check
+    /// would decide it was out of date and fetch the whole catalog again. With
+    /// the refresh now also running on every resume, that repeated for the life
+    /// of the session.
+    private static var downloadedVersion: Int?
+
+    /// Version of the catalog on disk — what the refresh compares against to
+    /// decide whether there's anything to download. Distinct from the version
+    /// *in use*, which is whatever was read at launch.
+    static var installedVersion: Int {
+        downloadedVersion ?? cachedDocument()?.catalogVersion ?? 0
+    }
+
+    // MARK: - Refresh
+
+    /// Pull a newer catalog if there is one. Safe to call on every launch: it
+    /// asks for a single row first, and downloads nothing when already current.
+    /// Silent on every failure — an unreachable server means the user keeps the
+    /// catalog they already have, which is a complete and working one.
+    static func refreshIfNeeded() async {
+        guard let client = SupabaseCatalogClient() else { return }
+        do {
+            // `!=`, not `>`. A version that moves backwards is a real scenario —
+            // reseeding a fresh project restarts at 1, as does restoring a
+            // backup — and under `>` every client holding a higher number would
+            // silently never update again. There's one server, so "different"
+            // is the right test for "not what I have".
+            guard let remoteVersion = try await client.catalogVersion(),
+                  remoteVersion != installedVersion else { return }
+            let document = try await client.fetchCatalog(version: remoteVersion)
+            // Reject anything that isn't a complete, fully-identified catalog.
+            // A verse with no `cardUid` has no identity to file progress under,
+            // and caching one would shadow the bundled JSON — which does have
+            // them — with a strictly worse copy. Keeping what we have is always
+            // the safer failure.
+            //
+            // A pack with no verses is the tell-tale of a half-written catalog:
+            // seeding deletes everything and re-inserts in several statements,
+            // each of which publishes, so a refresh landing mid-run can see
+            // packs that exist but aren't populated yet. Such a fetch is
+            // discarded; the seed's final publish moves the version again, so
+            // the next launch picks up the complete one.
+            guard !document.editions.isEmpty,
+                  document.editions.values.allSatisfy({ packs in
+                      !packs.isEmpty && packs.allSatisfy { pack in
+                          !pack.verses.isEmpty
+                              && pack.verses.allSatisfy { $0.cardUid?.isEmpty == false }
+                      }
+                  })
+            else { return }
+            guard let url = cacheURL else { return }
+            try JSONEncoder().encode(document).write(to: url, options: .atomic)
+            downloadedVersion = remoteVersion
+        } catch {
+            return
+        }
+    }
+}
+
+// MARK: - Supabase
+
+/// Minimal PostgREST client — two GETs, no dependency.
+///
+/// Reads its configuration from the app's Info.plist; absent or blank
+/// configuration means there is no remote catalog and the initialiser fails, so
+/// every remote path in the app becomes a no-op rather than a network error.
+struct SupabaseCatalogClient {
+
+    private let baseURL: URL
+    private let anonKey: String
+
+    init?() {
+        let info = Bundle.main.infoDictionary
+        guard let urlString = (info?["SupabaseURL"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              let key = (info?["SupabaseAnonKey"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !urlString.isEmpty, !key.isEmpty,
+              let url = URL(string: urlString)
+        else { return nil }
+        self.baseURL = url
+        self.anonKey = key
+    }
+
+    /// The one row of `catalog_meta`. Cheap enough to ask for on every launch.
+    func catalogVersion() async throws -> Int? {
+        struct Row: Decodable { let version: Int }
+        let rows: [Row] = try await get("catalog_meta", query: [
+            URLQueryItem(name: "select", value: "version"),
+            URLQueryItem(name: "limit", value: "1"),
+        ])
+        return rows.first?.version
+    }
+
+    /// Every pack with its verses, nested by PostgREST's embedded-resource
+    /// syntax so the whole catalog arrives in one request.
+    func fetchCatalog(version: Int) async throws -> VerseCatalog.Document {
+        let rows: [PackRow] = try await get("packs", query: [
+            URLQueryItem(name: "select",
+                         value: "edition,name,color,accent_text,sort_index,"
+                              + "verses(verse_id,card_uid,sort_index,title,verse,book,reference,subpack,version)"),
+            URLQueryItem(name: "order", value: "sort_index.asc"),
+        ])
+
+        var editions: [String: [Pack]] = [:]
+        for row in rows.sorted(by: { $0.sort_index < $1.sort_index }) {
+            let verses = row.verses
+                .sorted { $0.sort_index < $1.sort_index }
+                .map { Verse(id: $0.verse_id, title: $0.title, verse: $0.verse,
+                             book: $0.book, reference: $0.reference,
+                             subpack: $0.subpack, version: $0.version,
+                             cardUid: $0.card_uid) }
+            editions[row.edition, default: []].append(
+                Pack(name: row.name, color: row.color,
+                     accentText: row.accent_text, verses: verses))
+        }
+        return VerseCatalog.Document(schema: VerseCatalog.currentSchema,
+                                     catalogVersion: version, editions: editions)
+    }
+
+    // MARK: Transport
+
+    private struct PackRow: Decodable {
+        let edition: String
+        let name: String
+        let color: String
+        let accent_text: String
+        let sort_index: Int
+        let verses: [VerseRow]
+    }
+
+    private struct VerseRow: Decodable {
+        let verse_id: Int
+        let card_uid: String?
+        let sort_index: Int
+        let title: String
+        let verse: String
+        let book: String
+        let reference: String
+        let subpack: String
+        let version: String?
+    }
+
+    private func get<T: Decodable>(_ table: String, query: [URLQueryItem]) async throws -> T {
+        guard var components = URLComponents(
+            url: baseURL.appendingPathComponent("rest/v1/\(table)"),
+            resolvingAgainstBaseURL: false) else { throw URLError(.badURL) }
+        components.queryItems = query
+        guard let url = components.url else { throw URLError(.badURL) }
+
+        var request = URLRequest(url: url)
+        request.setValue(anonKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 20
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/scripture memory/Model/VerseNumbering.swift
+++ b/scripture memory/Model/VerseNumbering.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Where a verse sits in its printed pack, and the short code that names it.
+///
+/// The published material numbers every card — TMS 60 by lettered section
+/// (`C-7`), the DEP booklets and the 180 series as one straight run per pack.
+/// That number is how people actually refer to a verse to each other and how
+/// they find it in the booklet, so any list of verses needs to show it.
+///
+/// Numbering comes from each pack's published order, never from the list on
+/// screen: shuffle reorders the session and a quiz uses a subset, and neither
+/// may renumber a card whose number is fixed in print.
+enum VerseNumbering {
+
+    /// 1-based position of a verse within its section, keyed by `srsKey` so the
+    /// number survives a translation switch.
+    private static let positions: [String: Int] = {
+        var map: [String: Int] = [:]
+        for packs in [packsNIV84, packsNIV11] {
+            for pack in packs {
+                var countsBySection: [String: Int] = [:]
+                for verse in pack.verses {
+                    let position = (countsBySection[verse.subpack] ?? 0) + 1
+                    countsBySection[verse.subpack] = position
+                    map[verse.srsKey] = position
+                }
+            }
+        }
+        return map
+    }()
+
+    /// Short label for each pack, e.g. `DEP 2: Quiet Time` → `DEP 2`. Built from
+    /// the catalogue so the five 180-series packs get their series number, which
+    /// their names carry only as a subtitle (`… · Growing in Faith`).
+    private static let packCodes: [String: String] = {
+        var map: [String: String] = [:]
+        var seriesNumber = 0
+        for pack in packsNIV84 {
+            if pack.name.hasPrefix("TMS 180") {
+                seriesNumber += 1
+                map[pack.name] = "TMS 180 S\(seriesNumber)"
+            } else if pack.name.hasPrefix("DEP "),
+                      let colon = pack.name.firstIndex(of: ":") {
+                map[pack.name] = String(pack.name[..<colon])
+            } else if pack.name == "5 Assurances" {
+                map[pack.name] = "5A"
+            } else {
+                map[pack.name] = pack.name
+            }
+        }
+        return map
+    }()
+
+    static func position(of verse: Verse) -> Int? { positions[verse.srsKey] }
+
+    /// Short pack label on its own, e.g. `"DEP 2"`.
+    static func packCode(for packName: String) -> String {
+        packCodes[packName] ?? packName
+    }
+
+    /// The card's printed number, e.g. `"DEP 1-9"`, `"TMS 60 C-7"`, `"5A-3"`.
+    /// `nil` for a verse built outside the catalogue (previews, ad-hoc
+    /// construction), which has no printed card to name.
+    static func code(for verse: Verse) -> String? {
+        guard !verse.packName.isEmpty, let position = positions[verse.srsKey] else { return nil }
+        let pack = packCode(for: verse.packName)
+        return verse.subpack.isEmpty ? "\(pack)-\(position)"
+                                     : "\(pack) \(verse.subpack)-\(position)"
+    }
+}

--- a/scripture memory/Resources/verseData.json
+++ b/scripture memory/Resources/verseData.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "5 Assurances",
-    "color": "#3A7CA5",
+    "color": "#7FA23C",
     "accentText": "5",
     "verses": [
       {
@@ -10,7 +10,8 @@
         "verse": "And this is the testimony: God has given us eternal life, and this life is in his Son. He who has the Son has life; he who does not have the Son of God does not have life.",
         "book": "1 John",
         "reference": "5:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fb7aabf3e66b755f"
       },
       {
         "id": 2,
@@ -18,7 +19,8 @@
         "verse": "\"Until now you have not asked for anything in my name. Ask and you will receive, and your joy will be complete.\"",
         "book": "John",
         "reference": "16:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "01fc8d676ac96c6c"
       },
       {
         "id": 3,
@@ -26,7 +28,8 @@
         "verse": "No temptation has seized you except what is common to man. And God is faithful; he will not let you be tempted beyond what you can bear. But when you are tempted, he will also provide a way out so that you can stand up under it.",
         "book": "1 Corinthians",
         "reference": "10:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c91123b93df2df7e"
       },
       {
         "id": 4,
@@ -34,7 +37,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b8e7f6a946673b5c"
       },
       {
         "id": 5,
@@ -42,7 +46,8 @@
         "verse": "Trust in the Lord with all your heart and lean not on your own understanding; in all your ways acknowledge him, and he will make your paths straight.",
         "book": "Proverbs",
         "reference": "3:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c32b24cdb10f31d"
       }
     ]
   },
@@ -57,7 +62,8 @@
         "verse": "Therefore, if anyone is in Christ, he is a new creation; the old has gone, the new has come!",
         "book": "2 Corinthians",
         "reference": "5:17",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "53b7f282e8db4d0d"
       },
       {
         "id": 7,
@@ -65,7 +71,8 @@
         "verse": "I have been crucified with Christ and I no longer live, but Christ lives in me. The life I live in the body, I live by faith in the Son of God, who loved me and gave Himself for me.",
         "book": "Galatians",
         "reference": "2:20",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "abc5fccfb66e8c14"
       },
       {
         "id": 8,
@@ -73,7 +80,8 @@
         "verse": "Therefore, I urge you, brothers, in view of God's mercy to offer your bodies as living sacrifices, holy and pleasing to God - this is your spiritual act of worship.",
         "book": "Romans",
         "reference": "12:1",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "5887cf7e17ef94b3"
       },
       {
         "id": 9,
@@ -81,7 +89,8 @@
         "verse": "Whoever has My commands and obeys them, he is the one who loves Me. He who loves Me will be loved by My Father, and I too will love him and show Myself to him.",
         "book": "John",
         "reference": "14:21",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "838b46c6d3fe8b41"
       },
       {
         "id": 10,
@@ -89,7 +98,8 @@
         "verse": "All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness.",
         "book": "2 Timothy",
         "reference": "3:16",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "47991ecef8531919"
       },
       {
         "id": 11,
@@ -97,15 +107,8 @@
         "verse": "Do not let this Book of the Law depart from your mouth; meditate on it day and night, so that you may be careful to do everything written in it. Then you will be prosperous and successful.",
         "book": "Joshua",
         "reference": "1:8",
-        "subpack": "A"
-      },
-      {
-        "id": 12,
-        "title": "Prayer",
-        "verse": "Do not be anxious about anything, but in everything, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
-        "book": "Philippians",
-        "reference": "4:6-7",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "d30f59c977460049"
       },
       {
         "id": 13,
@@ -113,7 +116,17 @@
         "verse": "If you remain in Me and My words remain in you, ask whatever you wish, and it will be given you.",
         "book": "John",
         "reference": "15:7",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "85dea192cd6d36f4"
+      },
+      {
+        "id": 12,
+        "title": "Prayer",
+        "verse": "Do not be anxious about anything, but in everything, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
+        "book": "Philippians",
+        "reference": "4:6-7",
+        "subpack": "A",
+        "cardUid": "562305394528284f"
       },
       {
         "id": 14,
@@ -121,7 +134,8 @@
         "verse": "For where two or three come together in My name, there am I with them.",
         "book": "Matthew",
         "reference": "18:20",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "46608870776328c5"
       },
       {
         "id": 15,
@@ -129,7 +143,8 @@
         "verse": "And let us consider how we may spur one another on toward love and good deeds. Let us not give up meeting together, as some are in the habit of doing, but let us encourage one another - and all the more as you see the Day approaching.",
         "book": "Hebrews",
         "reference": "10:24-25",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "eb451a402d0e4159"
       },
       {
         "id": 16,
@@ -137,7 +152,8 @@
         "verse": "\"Come, follow Me,\" Jesus said, \"and I will make you fishers of men.\"",
         "book": "Matthew",
         "reference": "4:19",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "8af4b22a031ac015"
       },
       {
         "id": 17,
@@ -145,7 +161,8 @@
         "verse": "I am not ashamed of the gospel, because it is the power of God for the salvation of everyone who believes: first for the Jew, then for the Gentile.",
         "book": "Romans",
         "reference": "1:16",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "30dcd7c855eb750e"
       },
       {
         "id": 18,
@@ -153,7 +170,8 @@
         "verse": "For all have sinned and fall short of the glory of God.",
         "book": "Romans",
         "reference": "3:23",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "231c64df0c7f4a01"
       },
       {
         "id": 19,
@@ -161,7 +179,8 @@
         "verse": "We all, like sheep, have gone astray, each of us has turned to his own way; and the Lord has laid on Him the iniquity of us all.",
         "book": "Isaiah",
         "reference": "53:6",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "0dc817b15fe06097"
       },
       {
         "id": 20,
@@ -169,7 +188,8 @@
         "verse": "For the wages of sin is death, but the gift of God is eternal life in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "6:23",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "7265b7d0775f29a9"
       },
       {
         "id": 21,
@@ -177,7 +197,8 @@
         "verse": "Just as man is destined to die once, and after that to face judgment.",
         "book": "Hebrews",
         "reference": "9:27",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "e0988cac53b19e29"
       },
       {
         "id": 22,
@@ -185,7 +206,8 @@
         "verse": "But God demonstrates his own love for us in this: While we were still sinners, Christ died for us.",
         "book": "Romans",
         "reference": "5:8",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "35bc616433dc90ff"
       },
       {
         "id": 23,
@@ -193,7 +215,8 @@
         "verse": "For Christ died for sins once for all, the righteous for the unrighteous, to bring you to God. He was put to death in the body but made alive by the Spirit.",
         "book": "1 Peter",
         "reference": "3:18",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "6e971140dffdb60a"
       },
       {
         "id": 24,
@@ -201,7 +224,8 @@
         "verse": "For it is by grace you have been saved, through faith- and this not from yourselves, it is the gift of God- not by works, so that no one can boast.",
         "book": "Ephesians",
         "reference": "2:8-9",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "8b983188fd0b6aa4"
       },
       {
         "id": 25,
@@ -209,7 +233,8 @@
         "verse": "He saved us, not because of righteous things we had done, but because of His mercy. He saved us through the washing of rebirth and renewal by the Holy Spirit.",
         "book": "Titus",
         "reference": "3:5",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "bdd9f73f2124968e"
       },
       {
         "id": 26,
@@ -217,7 +242,8 @@
         "verse": "Yet to all who received Him, to those who believed in His name, He gave the right to become children of God.",
         "book": "John",
         "reference": "1:12",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "9eddec605ec52aa7"
       },
       {
         "id": 27,
@@ -225,7 +251,8 @@
         "verse": "Here I am! I stand at the door and knock. If anyone hears My voice and opens the door, I will come in and eat with him, and he with Me.",
         "book": "Revelation",
         "reference": "3:20",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "34d348cd32d990a1"
       },
       {
         "id": 28,
@@ -233,7 +260,8 @@
         "verse": "I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.",
         "book": "1 John",
         "reference": "5:13",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "bf74e67d86182c89"
       },
       {
         "id": 29,
@@ -241,7 +269,8 @@
         "verse": "I tell you the truth, whoever hears My word and believes Him who sent Me has eternal life and will not be condemned; he has crossed over from death to life.",
         "book": "John",
         "reference": "5:24",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "c87a17e2d505bde8"
       },
       {
         "id": 30,
@@ -249,7 +278,8 @@
         "verse": "Don't you know that you yourselves are God's temple and that God's Spirit lives in you?",
         "book": "1 Corinthians",
         "reference": "3:16",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "7f8dd7d587baa579"
       },
       {
         "id": 31,
@@ -257,7 +287,8 @@
         "verse": "We have not received the spirit of the world but the Spirit who is from God, that we may understand what God has freely given us.",
         "book": "1 Corinthians",
         "reference": "2:12",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "5bf5dd6b94a7fb33"
       },
       {
         "id": 32,
@@ -265,7 +296,8 @@
         "verse": "So do not fear, for I am with you; do not be dismayed, for I am your God. I will strengthen you and help you; I will uphold you with My righteous right hand.",
         "book": "Isaiah",
         "reference": "41:10",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "eb6a7e3bf0a647d7"
       },
       {
         "id": 33,
@@ -273,7 +305,8 @@
         "verse": "I can do everything through Him who gives me strength.",
         "book": "Philippians",
         "reference": "4:13",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "37608aa5debc6a44"
       },
       {
         "id": 34,
@@ -281,7 +314,8 @@
         "verse": "Because of the Lord's great love we are not consumed, for His compassions never fail. They are new every morning; great is Your faithfulness.",
         "book": "Lamentations",
         "reference": "3:22-23",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "eeaed8f34fa04572"
       },
       {
         "id": 35,
@@ -289,7 +323,8 @@
         "verse": "God is not a man, that He should lie, nor a son of man, that He should change His mind. Does He speak and then not act? Does he promise and not fulfill?",
         "book": "Numbers",
         "reference": "23:19",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "2bc7e82bd320dea4"
       },
       {
         "id": 36,
@@ -297,7 +332,8 @@
         "verse": "You will keep in perfect peace him whose mind is steadfast, because he trusts in You.",
         "book": "Isaiah",
         "reference": "26:3",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "61d5a30a41db651b"
       },
       {
         "id": 37,
@@ -305,7 +341,8 @@
         "verse": "Cast all your anxiety on Him because He cares for you.",
         "book": "1 Peter",
         "reference": "5:7",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "c9991056657dbe0d"
       },
       {
         "id": 38,
@@ -313,7 +350,8 @@
         "verse": "He who did not spare His own Son, but gave Him up for us all- how will He not also, along with Him, graciously give us all things?",
         "book": "Romans",
         "reference": "8:32",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "02e10c5e7b88b61b"
       },
       {
         "id": 39,
@@ -321,7 +359,8 @@
         "verse": "And my God will meet all your needs according to His glorious riches in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:19",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "6a148ad77d80b512"
       },
       {
         "id": 40,
@@ -329,7 +368,8 @@
         "verse": "Because he Himself suffered when He was tempted. He is able to help those who are being tempted.",
         "book": "Hebrews",
         "reference": "2:18",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "8ffaf0c764684e46"
       },
       {
         "id": 41,
@@ -337,7 +377,8 @@
         "verse": "How can a young man keep his way pure? By living according to Your word. I have hidden Your word in my heart that I might not sin against you.",
         "book": "Psalm",
         "reference": "119:9,11",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "6d79dd06e97ed827"
       },
       {
         "id": 42,
@@ -345,7 +386,8 @@
         "verse": "But seek first His kingdom and His righteousness, and all these things will be given to you as well.",
         "book": "Matthew",
         "reference": "6:33",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8e04f9616557a02d"
       },
       {
         "id": 43,
@@ -353,7 +395,8 @@
         "verse": "Then He said to them all: \"If anyone would come after Me, he must deny himself and take up his cross daily and follow Me.\"",
         "book": "Luke",
         "reference": "9:23",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "2f0870229caa1861"
       },
       {
         "id": 44,
@@ -361,7 +404,8 @@
         "verse": "Do not love the world or anything in the world. If anyone loves the world, the love of the Father is not in him. For everything in the world- the cravings of sinful man, the lust of his eyes and the boasting of what he has and does- comes not from the Father but from the world.",
         "book": "1 John",
         "reference": "2:15-16",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8c133f82ddf2c9a3"
       },
       {
         "id": 45,
@@ -369,7 +413,8 @@
         "verse": "Do not conform any longer to the pattern of this world, but be transformed by the renewing of your mind. Then you will be able to test and approve what God's will is- His good, pleasing and perfect will.",
         "book": "Romans",
         "reference": "12:2",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "5ccf3f464bc71678"
       },
       {
         "id": 46,
@@ -377,7 +422,8 @@
         "verse": "Therefore, my dear brothers, stand firm. Let nothing move you. Always give yourselves fully to the work of the Lord, because you know that your labor in the Lord is not in vain.",
         "book": "1 Corinthians",
         "reference": "15:58",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "38809a8ee4625c35"
       },
       {
         "id": 47,
@@ -385,7 +431,8 @@
         "verse": "Consider Him who endured such opposition from sinful men, so that you will not grow weary and lose heart.",
         "book": "Hebrews",
         "reference": "12:3",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "0ba0e96ab20782ec"
       },
       {
         "id": 48,
@@ -393,7 +440,8 @@
         "verse": "For even the Son of Man did not come to be served, but to serve and to give His life as a ransom for many.",
         "book": "Mark",
         "reference": "10:45",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "ed03829732f65aaa"
       },
       {
         "id": 49,
@@ -401,7 +449,8 @@
         "verse": "For we do not preach ourselves, but Jesus Christ as Lord, and ourselves as your servants for Jesus' sake.",
         "book": "2 Corinthians",
         "reference": "4:5",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8d92ff0adf25db9f"
       },
       {
         "id": 50,
@@ -409,7 +458,8 @@
         "verse": "Honor the Lord with your wealth, with the firstfruits of all your crops; then your barns will be filled to overflowing, and your vats will brim over with new wine.",
         "book": "Proverbs",
         "reference": "3:9-10",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "81bab1223673735b"
       },
       {
         "id": 51,
@@ -417,7 +467,8 @@
         "verse": "Remember this: Whoever sows sparingly will also reap sparingly, and whoever sows generously will also reap generously. Each man should give what he has decided in his heart to give, not reluctantly or under compulsion, for God loves a cheerful giver.",
         "book": "2 Corinthians",
         "reference": "9:6-7",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "1d99e5849dd8a561"
       },
       {
         "id": 52,
@@ -425,7 +476,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be My witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "966a7aedcdf41bf4"
       },
       {
         "id": 53,
@@ -433,7 +485,8 @@
         "verse": "Therefore go and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, and teaching them to obey everything I have commanded you. And surely I am with you always, to the very end of the age.",
         "book": "Matthew",
         "reference": "28:19-20",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "90d9a3fdf0884281"
       },
       {
         "id": 54,
@@ -441,7 +494,8 @@
         "verse": "A new command I give you: Love one another. As I have loved you so you must love one another. By this all men will know that you are my disciples if you love one another.",
         "book": "John",
         "reference": "13:34-35",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "9174078704200578"
       },
       {
         "id": 55,
@@ -449,7 +503,8 @@
         "verse": "Dear children, let us not love with words or tongue but with actions and in truth.",
         "book": "1 John",
         "reference": "3:18",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "19dc4033735f46e6"
       },
       {
         "id": 56,
@@ -457,7 +512,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit, but in humility consider others better than yourselves. Each of you should look not only to your own interests, but also to the interests of others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "6a408d83f2fd0458"
       },
       {
         "id": 57,
@@ -465,7 +521,8 @@
         "verse": "Young men, in the same way be submissive to those who are older. All of you, clothe yourselves with humility toward one another, because, \"God opposes the proud but gives grace to the humble.\" Humble yourselves, therefore, under God's mighty hand, that He may lift you up in due time.",
         "book": "1 Peter",
         "reference": "5:5-6",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "389b7246404883b7"
       },
       {
         "id": 58,
@@ -473,7 +530,8 @@
         "verse": "But among you there must not be even a hint of sexual immorality, or of any kind of impurity, or of greed, because these are improper for God's holy people.",
         "book": "Ephesians",
         "reference": "5:3",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "d73ed31c598b149d"
       },
       {
         "id": 59,
@@ -481,7 +539,8 @@
         "verse": "Dear friends, I urge you, as aliens and strangers in the world, to abstain from sinful desires, which war against your soul.",
         "book": "1 Peter",
         "reference": "2:11",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "ae32bc994c08d3da"
       },
       {
         "id": 60,
@@ -489,7 +548,8 @@
         "verse": "Do not steal. Do not lie. Do not deceive one another.",
         "book": "Leviticus",
         "reference": "19:11",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "bd9061d90bf42f4d"
       },
       {
         "id": 61,
@@ -497,7 +557,8 @@
         "verse": "So I strive always to keep my conscience clear before God and man.",
         "book": "Acts",
         "reference": "24:16",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "4ad12cf7a062aa2e"
       },
       {
         "id": 62,
@@ -505,7 +566,8 @@
         "verse": "And without faith, it is impossible to please God, because anyone who comes to Him must believe that He exists and that He rewards those who earnestly seek Him.",
         "book": "Hebrews",
         "reference": "11:6",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "3f703d666890bed4"
       },
       {
         "id": 63,
@@ -513,7 +575,8 @@
         "verse": "Yet he did not waver through unbelief regarding the promise of God, but was strengthened in his faith and gave glory to God, being fully persuaded that God had power to do what he had promised.",
         "book": "Romans",
         "reference": "4:20-21",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "7bae649880268eb2"
       },
       {
         "id": 64,
@@ -521,7 +584,8 @@
         "verse": "Let us not become weary in doing good, for at the proper time we will reap a harvest if we do not give up. Therefore, as we have opportunity, let us do good to all people, especially to those who belong to the family of believers.",
         "book": "Galatians",
         "reference": "6:9-10",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "051e68aa7a21d9d2"
       },
       {
         "id": 65,
@@ -529,13 +593,14 @@
         "verse": "In the same way, let your light shine before men, that they may see your good deeds and praise your Father in heaven.",
         "book": "Matthew",
         "reference": "5:16",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "08094b02b5ae4429"
       }
     ]
   },
   {
     "name": "DEP 1: Assurance of Salvation",
-    "color": "#0a1fbe",
+    "color": "#F4F2ED",
     "accentText": "1",
     "verses": [
       {
@@ -544,7 +609,8 @@
         "verse": "Examine yourselves to see whether you are in the faith; test yourselves. Do you not realize that Christ Jesus is in you--unless, of course, you fail the test?",
         "book": "2 Corinthians",
         "reference": "13:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0e2bab06044065ed"
       },
       {
         "id": 67,
@@ -552,7 +618,8 @@
         "verse": "And this is the testimony: God has given us eternal life, and this life is in his Son. He who has the Son has life; he who does not have the Son of God does not have life.",
         "book": "1 John",
         "reference": "5:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "155e176802031f30"
       },
       {
         "id": 68,
@@ -560,7 +627,8 @@
         "verse": "I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.",
         "book": "1 John",
         "reference": "5:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "24f285489498cf08"
       },
       {
         "id": 69,
@@ -568,7 +636,8 @@
         "verse": "I tell you the truth, he who believes has everlasting life.",
         "book": "John",
         "reference": "6:47",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce4dae5f20085e0e"
       },
       {
         "id": 70,
@@ -576,7 +645,8 @@
         "verse": "In him we have redemption through his blood, the forgiveness of sins, in accordance with the riches of God's grace",
         "book": "Ephesians",
         "reference": "1:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "356bf23affe195dc"
       },
       {
         "id": 71,
@@ -584,7 +654,8 @@
         "verse": "Therefore, there is now no condemnation for those who are in Christ Jesus,",
         "book": "Romans",
         "reference": "8:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "124dcae76ec1de3c"
       },
       {
         "id": 72,
@@ -592,7 +663,8 @@
         "verse": "and are justified freely by his grace through the redemption that came by Christ Jesus.",
         "book": "Romans",
         "reference": "3:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d19a3af57928844f"
       },
       {
         "id": 73,
@@ -600,7 +672,8 @@
         "verse": "Therefore, since we have been justified through faith, we have peace with God through our Lord Jesus Christ,",
         "book": "Romans",
         "reference": "5:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "177610a779cfe686"
       },
       {
         "id": 74,
@@ -608,7 +681,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ! In his great mercy he has given us new birth into a living hope through the resurrection of Jesus Christ from the dead,",
         "book": "1 Peter",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4affcbadc906794e"
       },
       {
         "id": 75,
@@ -616,7 +690,8 @@
         "verse": "he saved us, not because of righteous things we had done, but because of his mercy. He saved us through the washing of rebirth and renewal by the Holy Spirit,",
         "book": "Titus",
         "reference": "3:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0b9ab87550629a32"
       },
       {
         "id": 76,
@@ -624,7 +699,8 @@
         "verse": "You are all sons of God through faith in Christ Jesus,",
         "book": "Galatians",
         "reference": "3:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f24f86d449d5956a"
       },
       {
         "id": 77,
@@ -632,7 +708,8 @@
         "verse": "because those who are led by the Spirit of God are sons of God.",
         "book": "Romans",
         "reference": "8:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2653c8e785a182ff"
       },
       {
         "id": 78,
@@ -640,7 +717,8 @@
         "verse": "You, however, are controlled not by the sinful nature but by the Spirit, if the Spirit of God lives in you. And if anyone does not have the Spirit of Christ, he does not belong to Christ.",
         "book": "Romans",
         "reference": "8:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1279a17374989e96"
       },
       {
         "id": 79,
@@ -648,7 +726,8 @@
         "verse": "And I will ask the Father, and he will give you another Counselor to be with you forever--the Spirit of truth. The world cannot accept him, because it neither sees him nor knows him. But you know him, for he lives with you and will be in you.",
         "book": "John",
         "reference": "14:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "faff1c45e55487a4"
       },
       {
         "id": 80,
@@ -656,7 +735,8 @@
         "verse": "I give them eternal life, and they shall never perish; no one can snatch them out of my hand. My Father, who has given them to me, is greater than all; no one can snatch them out of my Father's hand.",
         "book": "John",
         "reference": "10:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e555e2f95c975096"
       },
       {
         "id": 81,
@@ -664,7 +744,8 @@
         "verse": "neither height nor depth, nor anything else in all creation, will be able to separate us from the love of God that is in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "8:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "588208e5b2268765"
       },
       {
         "id": 82,
@@ -672,7 +753,8 @@
         "verse": "For you have been born again, not of perishable seed, but of imperishable, through the living and enduring word of God.",
         "book": "1 Peter",
         "reference": "1:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89110f6e275ec935"
       },
       {
         "id": 83,
@@ -680,13 +762,14 @@
         "verse": "And you also were included in Christ when you heard the word of truth, the gospel of your salvation. Having believed, you were marked in him with a seal, the promised Holy Spirit,",
         "book": "Ephesians",
         "reference": "1:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "260a2c48298b927b"
       }
     ]
   },
   {
     "name": "DEP 2: Quiet Time",
-    "color": "#07c387",
+    "color": "#E14C30",
     "accentText": "2",
     "verses": [
       {
@@ -695,7 +778,8 @@
         "verse": "God, who has called you into fellowship with his Son Jesus Christ our Lord, is faithful.",
         "book": "1 Corinthians",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8a38fe982d5b7f6"
       },
       {
         "id": 85,
@@ -703,7 +787,8 @@
         "verse": "Yet the Lord longs to be gracious to you; he rises to show you compassion. For the Lord is a God of justice. Blessed are all who wait for him!",
         "book": "Isaiah",
         "reference": "30:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "610ea4478365ac01"
       },
       {
         "id": 86,
@@ -711,15 +796,18 @@
         "verse": "Seek the LORD while he may be found; call on him while he is near.",
         "book": "Isaiah",
         "reference": "55:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f64edcbb29649141"
       },
       {
         "id": 87,
         "title": "God's command",
-        "verse": "My heart says of you, \"Seek his face!\" Your face, LORD, I will seek.",
+        "verse": "When thou saidst, Seek ye my face; my heart said unto thee, Thy face, LORD, will I seek.",
         "book": "Psalm",
         "reference": "27:8",
-        "subpack": ""
+        "subpack": "",
+        "version": "KJV",
+        "cardUid": "7d381e53a1f7c058"
       },
       {
         "id": 88,
@@ -727,7 +815,8 @@
         "verse": "\"I am the vine; you are the branches. If a man remains in me and I in him, he will bear much fruit; apart from me you can do nothing.",
         "book": "John",
         "reference": "15:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9387bd5b5bf89779"
       },
       {
         "id": 89,
@@ -735,7 +824,8 @@
         "verse": "The lions may grow weak and hungry, but those who seek the LORD lack no good thing.",
         "book": "Psalm",
         "reference": "34:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0ad16d0c4a6153d3"
       },
       {
         "id": 90,
@@ -743,7 +833,8 @@
         "verse": "I will stand at my watch and station myself on the ramparts; I will look to see what he will say to me, and what answer I am to give to this complaint.",
         "book": "Habakkuk",
         "reference": "2:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6eb300883f979db5"
       },
       {
         "id": 91,
@@ -751,7 +842,8 @@
         "verse": "Let the morning bring me word of your unfailing love, for I have put my trust in you. Show me the way I should go, for to you I lift up my soul. Teach me to do your will, for you are my God; may your good Spirit lead me on level ground.",
         "book": "Psalm",
         "reference": "143:8, 10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2f6336d23a165bf8"
       },
       {
         "id": 92,
@@ -759,7 +851,8 @@
         "verse": "Let us fix our eyes on Jesus, the author and perfecter of our faith, who for the joy set before him endured the cross, scorning its shame, and sat down at the right hand of the throne of God.",
         "book": "Hebrews",
         "reference": "12:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e1b2445ad26a4e7a"
       },
       {
         "id": 93,
@@ -767,7 +860,8 @@
         "verse": "Why are you downcast, O my soul? Why so disturbed within me? Put your hope in God, for I will yet praise him, my Savior and my God.",
         "book": "Psalm",
         "reference": "42:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "74fa1b0dd4703efd"
       },
       {
         "id": 94,
@@ -775,7 +869,8 @@
         "verse": "As the deer pants for streams of water, so my soul pants for you, O God.",
         "book": "Psalm",
         "reference": "42:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ea2d78cf67dade2f"
       },
       {
         "id": 95,
@@ -783,7 +878,8 @@
         "verse": "I wait for the Lord, my soul waits, and in his word I put my hope. My soul waits for the Lord more than watchmen wait for the morning, more than watchmen wait for the morning.",
         "book": "Psalm",
         "reference": "130:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "db5c5dc7b06313ec"
       },
       {
         "id": 96,
@@ -791,7 +887,8 @@
         "verse": "Cast your cares on the LORD and he will sustain you; he will never let the righteous fall.",
         "book": "Psalm",
         "reference": "55:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6309e2059c55f512"
       },
       {
         "id": 97,
@@ -799,7 +896,8 @@
         "verse": "Praise be to the Lord, to God our Savior, who daily bears our burdens. Selah",
         "book": "Psalm",
         "reference": "68:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "83daff7c5f11a20a"
       },
       {
         "id": 98,
@@ -807,7 +905,8 @@
         "verse": "If you make the Most High your dwelling--even the LORD, who is my refuge--then no harm will befall you, no disaster will come near your tent.",
         "book": "Psalm",
         "reference": "91:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2afe3a6f7a6946c6"
       },
       {
         "id": 99,
@@ -815,7 +914,8 @@
         "verse": "\"Come to me, all you who are weary and burdened, and I will give you rest. Take my yoke upon you and learn from me, for I am gentle and humble in heart, and you will find rest for your souls.",
         "book": "Matthew",
         "reference": "11:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "58030c53fe7edc27"
       },
       {
         "id": 100,
@@ -823,7 +923,8 @@
         "verse": "I rise before dawn and cry for help; I have put my hope in your word. My eyes stay open through the watches of the night, that I may meditate on your promises.",
         "book": "Psalm",
         "reference": "119:147-148",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0537398623c0c329"
       },
       {
         "id": 101,
@@ -831,7 +932,8 @@
         "verse": "In the morning, O LORD, you hear my voice; in the morning I lay my requests before you and wait in expectation.",
         "book": "Psalm",
         "reference": "5:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dbd6f710d18f9e6a"
       },
       {
         "id": 102,
@@ -839,7 +941,8 @@
         "verse": "Come, let us bow down in worship, let us kneel before the LORD our Maker;",
         "book": "Psalm",
         "reference": "95:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c868d7c0a301bf1f"
       },
       {
         "id": 103,
@@ -847,7 +950,8 @@
         "verse": "Through Jesus, therefore, let us continually offer to God a sacrifice of praise--the fruit of lips that confess his name.",
         "book": "Hebrews",
         "reference": "13:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "88773a5d3f90c574"
       },
       {
         "id": 104,
@@ -855,7 +959,8 @@
         "verse": "Satisfy us in the morning with your unfailing love, that we may sing for joy and be glad all our days.",
         "book": "Psalm",
         "reference": "90:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fa793c2e682161ba"
       },
       {
         "id": 105,
@@ -863,7 +968,8 @@
         "verse": "for he satisfies the thirsty and fills the hungry with good things.",
         "book": "Psalm",
         "reference": "107:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e0ae746c2031d91d"
       },
       {
         "id": 106,
@@ -871,15 +977,17 @@
         "verse": "Very early in the morning, while it was still dark, Jesus got up, left the house and went off to a solitary place, where he prayed.",
         "book": "Mark",
         "reference": "1:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6938e6832d16b354"
       },
       {
         "id": 107,
-        "title": "Moses - personal fellowship wtih the Lord",
+        "title": "Moses - personal fellowship with the Lord",
         "verse": "The Lord would speak to Moses face to face, as a man speaks with his friend. Then Moses would return to the camp, but his young aide Joshua son of Nun did not leave the tent.",
         "book": "Exodus",
         "reference": "33:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4c2ee4ef34127f9a"
       },
       {
         "id": 108,
@@ -887,7 +995,8 @@
         "verse": "Now when Daniel learned that the decree had been published, he went home to his upstairs room where the windows opened toward Jerusalem. Three times a day he got down on his knees and prayed, giving thanks to his God, just as he had done before.",
         "book": "Daniel",
         "reference": "6:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "928c8ef407266ab9"
       },
       {
         "id": 109,
@@ -895,13 +1004,14 @@
         "verse": "He did not say anything to them without using a parable. But when he was alone with his own disciples, he explained everything.",
         "book": "Mark",
         "reference": "4:34",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "536aa72dc5ba8b27"
       }
     ]
   },
   {
     "name": "DEP 3: The Word",
-    "color": "#ce4611",
+    "color": "#EA8A2E",
     "accentText": "3",
     "verses": [
       {
@@ -910,7 +1020,8 @@
         "verse": "All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness,",
         "book": "2 Timothy",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "41e9f49d662c3fb0"
       },
       {
         "id": 111,
@@ -918,7 +1029,8 @@
         "verse": "For prophecy never had its origin in the will of man, but men spoke from God as they were carried along by the Holy Spirit.",
         "book": "2 Peter",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bcc053f14eb3ca2a"
       },
       {
         "id": 112,
@@ -926,7 +1038,8 @@
         "verse": "Heaven and earth will pass away, but my words will never pass away.",
         "book": "Matthew",
         "reference": "24:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ff0d767910589063"
       },
       {
         "id": 113,
@@ -934,7 +1047,8 @@
         "verse": "For, \"All men are like grass, and all their glory is like the flowers of the field; the grass withers and the flowers fall, but the word of the Lord stands forever.\" And this is the word that was preached to you.",
         "book": "1 Peter",
         "reference": "1:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b37c299901343771"
       },
       {
         "id": 114,
@@ -942,7 +1056,8 @@
         "verse": "Sanctify them by the truth; your word is truth.",
         "book": "John",
         "reference": "17:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c09456b627a90939"
       },
       {
         "id": 115,
@@ -950,7 +1065,8 @@
         "verse": "O Sovereign Lord, you are God! Your words are trustworthy, and you have promised these good things to your servant.",
         "book": "2 Samuel",
         "reference": "7:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "863a2df833973eb4"
       },
       {
         "id": 116,
@@ -958,7 +1074,8 @@
         "verse": "\"Is not my word like fire,\" declares the LORD, \"and like a hammer that breaks a rock in pieces?",
         "book": "Jeremiah",
         "reference": "23:29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2a4be0be16ab5e3b"
       },
       {
         "id": 117,
@@ -966,7 +1083,8 @@
         "verse": "for which I am suffering even to the point of being chained like a criminal. But God's word is not chained.",
         "book": "2 Timothy",
         "reference": "2:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4281202ad18ef4cd"
       },
       {
         "id": 118,
@@ -974,7 +1092,8 @@
         "verse": "Jesus answered, \"It is written: 'Man does not live on bread alone, but on every word that comes from the mouth of God.' \"",
         "book": "Matthew",
         "reference": "4:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "00ea10323a7baa38"
       },
       {
         "id": 119,
@@ -982,7 +1101,8 @@
         "verse": "And beginning with Moses and all the Prophets, he explained to them what was said in all the Scriptures concerning himself.",
         "book": "Luke",
         "reference": "24:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "05513ffc4f3c1009"
       },
       {
         "id": 120,
@@ -990,7 +1110,8 @@
         "verse": "For you have been born again, not of perishable seed, but of imperishable, through the living and enduring word of God.",
         "book": "1 Peter",
         "reference": "1:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "77619ffd87cc4ba2"
       },
       {
         "id": 121,
@@ -998,7 +1119,8 @@
         "verse": "He chose to give us birth through the word of truth, that we might be a kind of firstfruits of all he created.",
         "book": "James",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b32ba9135981a05b"
       },
       {
         "id": 122,
@@ -1006,7 +1128,8 @@
         "verse": "Like newborn babies, crave pure spiritual milk, so that by it you may grow up in your salvation,",
         "book": "1 Peter",
         "reference": "2:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "77bf3666b3c2f7cf"
       },
       {
         "id": 123,
@@ -1014,7 +1137,8 @@
         "verse": "\"Now I commit you to God and to the word of his grace, which can build you up and give you an inheritance among all those who are sanctified.",
         "book": "Acts",
         "reference": "20:32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9834b498706d7ca5"
       },
       {
         "id": 124,
@@ -1022,7 +1146,8 @@
         "verse": "Your word is a lamp to my feet and a light for my path.",
         "book": "Psalm",
         "reference": "119:105",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1fb56d8174ecee4e"
       },
       {
         "id": 125,
@@ -1030,7 +1155,8 @@
         "verse": "When you walk, they will guide you; when you sleep, they will watch over you; when you awake, they will speak to you. For these commands are a lamp, this teaching is a light, and the corrections of discipline are the way to life,",
         "book": "Proverbs",
         "reference": "6:22-23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8c88e1af380bf5c9"
       },
       {
         "id": 126,
@@ -1038,7 +1164,8 @@
         "verse": "He sent forth his word and healed them; he rescued them from the grave.",
         "book": "Psalm",
         "reference": "107:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a6aeabdf3d7070df"
       },
       {
         "id": 127,
@@ -1046,7 +1173,8 @@
         "verse": "The centurion replied, \"Lord, I do not deserve to have you come under my roof. But just say the word, and my servant will be healed.",
         "book": "Matthew",
         "reference": "8:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7394e849e15310dc"
       },
       {
         "id": 128,
@@ -1054,7 +1182,8 @@
         "verse": "When your words came, I ate them; they were my joy and my heart's delight, for I bear your name, O LORD God Almighty.",
         "book": "Jeremiah",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7cba35edad20071c"
       },
       {
         "id": 129,
@@ -1062,7 +1191,8 @@
         "verse": "Your statutes are my heritage forever; they are the joy of my heart.",
         "book": "Psalm",
         "reference": "119:111",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d14dada176dda455"
       },
       {
         "id": 130,
@@ -1070,7 +1200,8 @@
         "verse": "Take the helmet of salvation and the sword of the Spirit, which is the word of God.",
         "book": "Ephesians",
         "reference": "6:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "585e176d3ef39175"
       },
       {
         "id": 131,
@@ -1078,7 +1209,8 @@
         "verse": "For the word of God is living and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "96fff2a526f1f9dd"
       },
       {
         "id": 132,
@@ -1086,7 +1218,8 @@
         "verse": "Now the Bereans were of more noble character than the Thessalonians, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89872cec45a5b4a9"
       },
       {
         "id": 133,
@@ -1094,7 +1227,8 @@
         "verse": "Oh, how I love your law! I meditate on it all day long.",
         "book": "Psalm",
         "reference": "119:97",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "358efb055edf013e"
       },
       {
         "id": 134,
@@ -1102,7 +1236,8 @@
         "verse": "For Ezra had devoted himself to the study and observance of the Law of the LORD, and to teaching its decrees and laws in Israel.",
         "book": "Ezra",
         "reference": "7:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "199cf40b89ae47ce"
       },
       {
         "id": 135,
@@ -1110,7 +1245,8 @@
         "verse": "I have not departed from the commands of his lips; I have treasured the words of his mouth more than my daily bread.",
         "book": "Job",
         "reference": "23:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c02acd6cdc6e4810"
       },
       {
         "id": 136,
@@ -1118,7 +1254,8 @@
         "verse": "Simon answered, \"Master, we've worked hard all night and haven't caught anything. But because you say so, I will let down the nets.\" When they had done so, they caught such a large number of fish that their nets began to break.",
         "book": "Luke",
         "reference": "5:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba0832ae172f6218"
       },
       {
         "id": 137,
@@ -1126,7 +1263,8 @@
         "verse": "Consequently, faith comes from hearing the message, and the message is heard through the word of Christ.",
         "book": "Romans",
         "reference": "10:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6ebeaffe80b2478b"
       },
       {
         "id": 138,
@@ -1134,7 +1272,8 @@
         "verse": "He replied, \"Blessed rather are those who hear the word of God and obey it.\"",
         "book": "Luke",
         "reference": "11:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da74bd2494677d7a"
       },
       {
         "id": 139,
@@ -1142,7 +1281,8 @@
         "verse": "Blessed is the one who reads the words of this prophecy, and blessed are those who hear it and take to heart what is written in it, because the time is near.",
         "book": "Revelation",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "083b6b056ab901f5"
       },
       {
         "id": 140,
@@ -1150,7 +1290,8 @@
         "verse": "It is to be with him, and he is to read it all the days of his life so that he may learn to revere the LORD his God and follow carefully all the words of this law and these decrees",
         "book": "Deuteronomy",
         "reference": "17:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "14127cfdb253b4f7"
       },
       {
         "id": 141,
@@ -1158,7 +1299,8 @@
         "verse": "Now the Bereans were of more noble character than the Thessalonians, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b79e8bb18c430fa3"
       },
       {
         "id": 142,
@@ -1166,7 +1308,8 @@
         "verse": "Do your best to present yourself to God as one approved, a workman who does not need to be ashamed and who correctly handles the word of truth.",
         "book": "2 Timothy",
         "reference": "2:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "80b138b461ac5d8e"
       },
       {
         "id": 143,
@@ -1174,7 +1317,8 @@
         "verse": "These commandments that I give you today are to be upon your hearts.",
         "book": "Deuteronomy",
         "reference": "6:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5430702f3c837b7a"
       },
       {
         "id": 144,
@@ -1182,7 +1326,8 @@
         "verse": "My son, keep my words and store up my commands within you. Keep my commands and you will live; guard my teachings as the apple of your eye. Bind them on your fingers; write them on the tablet of your heart.",
         "book": "Proverbs",
         "reference": "7:1-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03c1d4d9f4304548"
       },
       {
         "id": 145,
@@ -1190,7 +1335,8 @@
         "verse": "Blessed is the man who does not walk in the counsel of the wicked or stand in the way of sinners or sit in the seat of mockers. But his delight is in the law of the LORD, and on his law he meditates day and night.",
         "book": "Psalm",
         "reference": "1:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "66373c8376855260"
       },
       {
         "id": 146,
@@ -1198,22 +1344,25 @@
         "verse": "Do not let this Book of the Law depart from your mouth; meditate on it day and night, so that you may be careful to do everything written in it. Then you will be prosperous and successful.",
         "book": "Joshua",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d38f615ecae4a277"
       }
     ]
   },
   {
     "name": "DEP 4: Prayer",
-    "color": "#f3a937",
+    "color": "#E7AF21",
     "accentText": "",
     "verses": [
       {
         "id": 276,
         "title": "Cease not to pray",
-        "verse": "pray continually;",
+        "verse": "Pray without ceasing.",
         "book": "1 Thessalonians",
         "reference": "5:17",
-        "subpack": ""
+        "subpack": "",
+        "version": "KJV",
+        "cardUid": "9d12f07eadc1c641"
       },
       {
         "id": 277,
@@ -1221,7 +1370,8 @@
         "verse": "Devote yourselves to prayer, being watchful and thankful.",
         "book": "Colossians",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cd28506d2f6db7b1"
       },
       {
         "id": 278,
@@ -1229,7 +1379,8 @@
         "verse": "The end of all things is near. Therefore be clear minded and self-controlled so that you can pray.",
         "book": "1 Peter",
         "reference": "4:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bf1ea21825142f90"
       },
       {
         "id": 279,
@@ -1237,7 +1388,8 @@
         "verse": "I urge, then, first of all, that requests, prayers, intercession and thanksgiving be made for everyone--for kings and all those in authority, that we may live peaceful and quiet lives in all godliness and holiness.",
         "book": "1 Timothy",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "85397800fdfa7915"
       },
       {
         "id": 280,
@@ -1245,7 +1397,8 @@
         "verse": "And I will do whatever you ask in my name, so that the Son may bring glory to the Father. You may ask me for anything in my name, and I will do it.",
         "book": "John",
         "reference": "14:13-14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8861483a5122975"
       },
       {
         "id": 281,
@@ -1253,7 +1406,8 @@
         "verse": "Now to him who is able to do immeasurably more than all we ask or imagine, according to his power that is at work within us,",
         "book": "Ephesians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba010795e70ab8bd"
       },
       {
         "id": 282,
@@ -1261,7 +1415,8 @@
         "verse": "'Call to me and I will answer you and tell you great and unsearchable things you do not know.'",
         "book": "Jeremiah",
         "reference": "33:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f1d8fed3a717d4a7"
       },
       {
         "id": 283,
@@ -1269,7 +1424,8 @@
         "verse": "If any of you lacks wisdom, he should ask God, who gives generously to all without finding fault, and it will be given to him.",
         "book": "James",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "98a7e1ed66c68ffd"
       },
       {
         "id": 284,
@@ -1277,7 +1433,8 @@
         "verse": "I sought the Lord, and he answered me; he delivered me from all my fears.",
         "book": "Psalm",
         "reference": "34:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c16a62eba9399c81"
       },
       {
         "id": 285,
@@ -1285,7 +1442,8 @@
         "verse": "and call upon me in the day of trouble; I will deliver you, and you will honor me.",
         "book": "Psalm",
         "reference": "50:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "617d4239d9bd6d98"
       },
       {
         "id": 286,
@@ -1293,7 +1451,8 @@
         "verse": "After they prayed, the place where they were meeting was shaken. And they were all filled with the Holy Spirit and spoke the word of God boldly.",
         "book": "Acts",
         "reference": "4:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "422163800b78aebd"
       },
       {
         "id": 287,
@@ -1301,7 +1460,8 @@
         "verse": "And pray for us, too, that God may open a door for our message, so that we may proclaim the mystery of Christ, for which I am in chains.",
         "book": "Colossians",
         "reference": "4:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "56cdbfa495a7f20a"
       },
       {
         "id": 288,
@@ -1309,7 +1469,8 @@
         "verse": "Until now you have not asked for anything in my name. Ask and you will receive, and your joy will be complete.",
         "book": "John",
         "reference": "16:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef7995099e124a44"
       },
       {
         "id": 289,
@@ -1317,7 +1478,8 @@
         "verse": "If you believe, you will receive whatever you ask for in prayer.",
         "book": "Matthew",
         "reference": "21:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "eb1b4a517bffe747"
       },
       {
         "id": 290,
@@ -1325,7 +1487,8 @@
         "verse": "And pray in the Spirit on all occasions with all kinds of prayers and requests. With this in mind, be alert and always keep on praying for all the saints.",
         "book": "Ephesians",
         "reference": "6:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "783a0516c2505f17"
       },
       {
         "id": 291,
@@ -1333,7 +1496,8 @@
         "verse": "This is the confidence we have in approaching God: that if we ask anything according to his will, he hears us. And if we know that he hears us-whatever we ask--we know that we have what we asked of him.",
         "book": "1 John",
         "reference": "5:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da5ce14426f3e06f"
       },
       {
         "id": 292,
@@ -1341,7 +1505,8 @@
         "verse": "If I had cherished sin in my heart, the Lord would not have listened;",
         "book": "Psalm",
         "reference": "66:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dd51dc12ad9f6509"
       },
       {
         "id": 293,
@@ -1349,7 +1514,8 @@
         "verse": "and receive from him anything we ask, because we obey his commands and do what pleases him.",
         "book": "1 John",
         "reference": "3:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5e4d596248082e94"
       },
       {
         "id": 294,
@@ -1357,7 +1523,8 @@
         "verse": "Again, I tell you that if two of you on earth agree about anything you ask for, it will be done for you by my Father in heaven.",
         "book": "Matthew",
         "reference": "18:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1b094edea388136c"
       },
       {
         "id": 295,
@@ -1365,7 +1532,8 @@
         "verse": "Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; he who seeks finds; and to him who knocks, the door will be opened.",
         "book": "Matthew",
         "reference": "7:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a6ad9f702b683a16"
       },
       {
         "id": 296,
@@ -1373,7 +1541,8 @@
         "verse": "Then you will call upon me and come and pray to me, and I will listen to you. You will seek me and find me when you seek me with all your heart.",
         "book": "Jeremiah",
         "reference": "29:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "35b18764f19d2183"
       },
       {
         "id": 297,
@@ -1381,7 +1550,8 @@
         "verse": "Remember the instruction you gave your servant Moses, saying, 'If you are unfaithful, I will scatter you among the nations, but if you return to me and obey my commands, then even if your exiled people are at the farthest horizon, I will gather them from there and bring them to the place I have chosen as a dwelling for my Name.'",
         "book": "Nehemiah",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c6142208318970d4"
       },
       {
         "id": 298,
@@ -1389,7 +1559,8 @@
         "verse": "Now when Daniel learned that the decree had been published, he went home to his upstairs room where the windows opened toward Jerusalem. Three times a day he got down on his knees and prayed, giving thanks to his God, just as he had done before.",
         "book": "Daniel",
         "reference": "6:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8f7c17711adcc2db"
       },
       {
         "id": 299,
@@ -1397,7 +1568,8 @@
         "verse": "Yet the news about him spread all the more, so that crowds of people came to hear him and to be healed of their sicknesses. But Jesus often withdrew to lonely places and prayed.",
         "book": "Luke",
         "reference": "5:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "de1a6f417466abe3"
       },
       {
         "id": 300,
@@ -1405,7 +1577,8 @@
         "verse": "One of those days Jesus went out to a mountainside to pray, and spent the night praying to God.",
         "book": "Luke",
         "reference": "6:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5874d64db44ec733"
       },
       {
         "id": 301,
@@ -1413,7 +1586,8 @@
         "verse": "Elijah was a man just like us. He prayed earnestly that it would not rain, and it did not rain on the land for three and a half years. Again he prayed, and the heavens gave rain, and the earth produced its crops.",
         "book": "James",
         "reference": "5:17-18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4f3c8571456577ef"
       },
       {
         "id": 302,
@@ -1421,7 +1595,8 @@
         "verse": "About midnight Paul and Silas were praying and singing hymns to God, and the other prisoners were listening to them.",
         "book": "Acts",
         "reference": "16:25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89e735c0e94ee1b1"
       },
       {
         "id": 303,
@@ -1429,7 +1604,8 @@
         "verse": "Yours, O LORD, is the greatness and the power and the glory and the majesty and the splendor, for everything in heaven and earth is yours. Yours, O LORD, is the kingdom; you are exalted as head over all. Wealth and honor come from you; you are the ruler of all things. In your hands are strength and power to exalt and give strength to all. Now, our God, we give you thanks, and praise your glorious name.",
         "book": "1 Chronicles",
         "reference": "29:11-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "325f2fbdd4b36141"
       },
       {
         "id": 304,
@@ -1437,7 +1613,8 @@
         "verse": "I urge, then, first of all, that requests, prayers, intercession and thanksgiving be made for everyone--for kings and all those in authority, that we may live peaceful and quiet lives in all godliness and holiness.",
         "book": "1 Timothy",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc1d5b9ae92bf91f"
       },
       {
         "id": 305,
@@ -1445,7 +1622,8 @@
         "verse": "give thanks in all circumstances, for this is God's will for you in Christ Jesus.",
         "book": "1 Thessalonians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce2211af189d824c"
       },
       {
         "id": 306,
@@ -1453,7 +1631,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e8f42f860d2fdcd1"
       },
       {
         "id": 307,
@@ -1461,13 +1640,14 @@
         "verse": "Do not be anxious about anything, but in everything, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6eac8319747cf265"
       }
     ]
   },
   {
     "name": "DEP 5: Fellowship",
-    "color": "#00ff07",
+    "color": "#019A4E",
     "accentText": "5",
     "verses": [
       {
@@ -1476,7 +1656,8 @@
         "verse": "But now in Christ Jesus you who once were far away have been brought near through the blood of Christ.",
         "book": "Ephesians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "851be69006bec95c"
       },
       {
         "id": 148,
@@ -1484,7 +1665,8 @@
         "verse": "and through him to reconcile to himself all things, whether things on earth or things in heaven, by making peace through his blood, shed on the cross.",
         "book": "Colossians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e37fc1d869cd48c3"
       },
       {
         "id": 149,
@@ -1492,7 +1674,8 @@
         "verse": "We proclaim to you what we have seen and heard, so that you also may have fellowship with us. And our fellowship is with the Father and with his Son, Jesus Christ.",
         "book": "1 John",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "82c58b4a3869dc98"
       },
       {
         "id": 150,
@@ -1500,7 +1683,8 @@
         "verse": "May the grace of the Lord Jesus Christ, and the love of God, and the fellowship of the Holy Spirit be with you all.",
         "book": "2 Corinthians",
         "reference": "13:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "364a4ecdcce4d565"
       },
       {
         "id": 151,
@@ -1508,7 +1692,8 @@
         "verse": "For where two or three come together in my name, there am I with them.\"",
         "book": "Matthew",
         "reference": "18:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9a03ddf552b9aca7"
       },
       {
         "id": 152,
@@ -1516,7 +1701,8 @@
         "verse": "How good and pleasant it is when brothers live together in unity! It is like precious oil poured on the head, running down on the beard, running down on Aaron's beard, down upon the collar of his robes. It is as if the dew of Hermon were falling on Mount Zion. For there the Lord bestows his blessing, even life forevermore.",
         "book": "Psalm",
         "reference": "133:1-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57f2966ff215d17a"
       },
       {
         "id": 153,
@@ -1524,7 +1710,8 @@
         "verse": "But encourage one another daily, as long as it is called Today, so that none of you may be hardened by sin's deceitfulness.",
         "book": "Hebrews",
         "reference": "3:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d2b7ae572091d2e7"
       },
       {
         "id": 154,
@@ -1532,7 +1719,8 @@
         "verse": "Two are better than one, because they have a good return for their work: If one falls down, his friend can help him up. But pity the man who falls and has no one to help him up!",
         "book": "Ecclesiastes",
         "reference": "4:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cfab94960a4230be"
       },
       {
         "id": 155,
@@ -1540,7 +1728,8 @@
         "verse": "Flee the evil desires of youth, and pursue righteousness, faith, love and peace, along with those who call on the Lord out of a pure heart.",
         "book": "2 Timothy",
         "reference": "2:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cbf94210a8eb820a"
       },
       {
         "id": 156,
@@ -1548,7 +1737,8 @@
         "verse": "As iron sharpens iron, so one man sharpens another. As water reflects a face, so a man's heart reflects the man.",
         "book": "Proverbs",
         "reference": "27:17,19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1c0a9bb6e909d064"
       },
       {
         "id": 157,
@@ -1556,7 +1746,8 @@
         "verse": "He who walks with the wise grows wise, but a companion of fools suffers harm.",
         "book": "Proverbs",
         "reference": "13:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "91b229f53594fb7d"
       },
       {
         "id": 158,
@@ -1564,7 +1755,8 @@
         "verse": "until we all reach unity in the faith and in the knowledge of the Son of God and become mature, attaining to the whole measure of the fullness of Christ.",
         "book": "Ephesians",
         "reference": "4:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "255248f46b9ff9a4"
       },
       {
         "id": 159,
@@ -1572,7 +1764,8 @@
         "verse": "They devoted themselves to the apostles' teaching and to the fellowship, to the breaking of bread and to prayer. praising God and enjoying the favor of all the people. And the Lord added to their number daily those who were being saved.",
         "book": "Acts",
         "reference": "2:42,47",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "391a5138580066f7"
       },
       {
         "id": 160,
@@ -1580,7 +1773,8 @@
         "verse": "because of your partnership in the gospel from the first day until now, Whatever happens, conduct yourselves in a manner worthy of the gospel of Christ. Then, whether I come and see you or only hear about you in my absence, I will know that you stand firm in one spirit, contending as one man for the faith of the gospel",
         "book": "Philippians",
         "reference": "1:5,27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0c9b1f24e70a1d22"
       },
       {
         "id": 161,
@@ -1588,7 +1782,8 @@
         "verse": "And let us consider how we may spur one another on toward love and good deeds. Let us not give up meeting together, as some are in the habit of doing, but let us encourage one another--and all the more as you see the Day approaching.",
         "book": "Hebrews",
         "reference": "10:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "efb9cea35522b581"
       },
       {
         "id": 162,
@@ -1596,7 +1791,8 @@
         "verse": "For I testify that they gave as much as they were able, and even beyond their ability. Entirely on their own, they urgently pleaded with us for the privilege of sharing in this service to the saints.",
         "book": "2 Corinthians",
         "reference": "8:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e62106982323de23"
       },
       {
         "id": 163,
@@ -1604,7 +1800,8 @@
         "verse": "But rejoice that you participate in the sufferings of Christ, so that you may be overjoyed when his glory is revealed.",
         "book": "1 Peter",
         "reference": "4:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2ec3dead68c10958"
       },
       {
         "id": 164,
@@ -1612,7 +1809,8 @@
         "verse": "Carry each other's burdens, and in this way you will fulfill the law of Christ.",
         "book": "Galatians",
         "reference": "6:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8f6124a735424219"
       },
       {
         "id": 165,
@@ -1620,7 +1818,8 @@
         "verse": "If you have any encouragement from being united with Christ, if any comfort from his love, if any fellowship with the Spirit, if any tenderness and compassion, then make my joy complete by being like-minded, having the same love, being one in spirit and purpose.",
         "book": "Philippians",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "05ffe60782e4a962"
       },
       {
         "id": 166,
@@ -1628,7 +1827,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit, but in humility consider others better than yourselves. Each of you should look not only to your own interests, but also to the interests of others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "003eb8b4dd2d5b93"
       },
       {
         "id": 167,
@@ -1636,7 +1836,8 @@
         "verse": "We are not withholding our affection from you, but you are withholding yours from us. As a fair exchange--I speak as to my children--open wide your hearts also.",
         "book": "2 Corinthians",
         "reference": "6:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b234bfdf8e881b59"
       },
       {
         "id": 168,
@@ -1644,7 +1845,8 @@
         "verse": "Submit to one another out of reverence for Christ.",
         "book": "Ephesians",
         "reference": "5:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3b1332a9c553db15"
       },
       {
         "id": 169,
@@ -1652,7 +1854,8 @@
         "verse": "But they kept quiet because on the way they had argued about who was the greatest. Sitting down, Jesus called the Twelve and said, \"If anyone wants to be first, he must be the very last, and the servant of all.\"",
         "book": "Mark",
         "reference": "9:34-35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c0cd2d9fe5522d18"
       },
       {
         "id": 170,
@@ -1660,7 +1863,8 @@
         "verse": "See to it that no one misses the grace of God and that no bitter root grows up to cause trouble and defile many.",
         "book": "Hebrews",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f3c6d9738b6fdd41"
       },
       {
         "id": 171,
@@ -1668,7 +1872,8 @@
         "verse": "Have nothing to do with the fruitless deeds of darkness, but rather expose them.",
         "book": "Ephesians",
         "reference": "5:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d1687f3357b758c2"
       },
       {
         "id": 172,
@@ -1676,7 +1881,8 @@
         "verse": "No one serving as a soldier gets involved in civilian affairs--he wants to please his commanding officer.",
         "book": "2 Timothy",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "82cfaf89158bfaa5"
       },
       {
         "id": 173,
@@ -1684,7 +1890,8 @@
         "verse": "\"Therefore, if you are offering your gift at the altar and there remember that your brother has something against you, leave your gift there in front of the altar. First go and be reconciled to your brother; then come and offer your gift.",
         "book": "Matthew",
         "reference": "5:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70766a8c061484a1"
       },
       {
         "id": 174,
@@ -1692,7 +1899,8 @@
         "verse": "\"If your brother sins against you, go and show him his fault, just between the two of you. If he listens to you, you have won your brother over.",
         "book": "Matthew",
         "reference": "18:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f98e381dfc5609ee"
       },
       {
         "id": 175,
@@ -1700,7 +1908,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ecbc539fcd01bb79"
       },
       {
         "id": 176,
@@ -1708,13 +1917,14 @@
         "verse": "He who conceals his sins does not prosper, but whoever confesses and renounces them finds mercy.",
         "book": "Proverbs",
         "reference": "28:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2c71d56fa3d0e05b"
       }
     ]
   },
   {
     "name": "DEP 6: Witnessing",
-    "color": "#14f7ff",
+    "color": "#0090D0",
     "accentText": "6",
     "verses": [
       {
@@ -1723,7 +1933,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\"",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "42d32896a4d2dbc4"
       },
       {
         "id": 178,
@@ -1731,7 +1942,8 @@
         "verse": "All this is from God, who reconciled us to himself through Christ and gave us the ministry of reconciliation: that God was reconciling the world to himself in Christ, not counting men's sins against them. And he has committed to us the message of reconciliation.",
         "book": "2 Corinthians",
         "reference": "5:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "18fd8b95b8493fe0"
       },
       {
         "id": 179,
@@ -1739,7 +1951,8 @@
         "verse": "In the presence of God and of Christ Jesus, who will judge the living and the dead, and in view of his appearing and his kingdom, I give you this charge: Preach the Word; be prepared in season and out of season; correct, rebuke and encourage--with great patience and careful instruction.",
         "book": "2 Timothy",
         "reference": "4:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8450d0c69ccff067"
       },
       {
         "id": 180,
@@ -1747,7 +1960,8 @@
         "verse": "For the Son of Man came to seek and to save what was lost.\"",
         "book": "Luke",
         "reference": "19:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a3c641f0768b66f6"
       },
       {
         "id": 181,
@@ -1755,7 +1969,8 @@
         "verse": "On the contrary, we speak as men approved by God to be entrusted with the gospel. We are not trying to please men but God, who tests our hearts.",
         "book": "1 Thessalonians",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "796de829c27a8b0f"
       },
       {
         "id": 182,
@@ -1763,7 +1978,8 @@
         "verse": "Yet when I preach the gospel, I cannot boast, for I am compelled to preach. Woe to me if I do not preach the gospel!",
         "book": "1 Corinthians",
         "reference": "9:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "47f50bd3719f9dd9"
       },
       {
         "id": 183,
@@ -1771,7 +1987,8 @@
         "verse": "How, then, can they call on the one they have not believed in? And how can they believe in the one of whom they have not heard? And how can they hear without someone preaching to them?",
         "book": "Romans",
         "reference": "10:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87b64570af3a0ecc"
       },
       {
         "id": 184,
@@ -1779,15 +1996,17 @@
         "verse": "This is good, and pleases God our Savior, who wants all men to be saved and to come to a knowledge of the truth.",
         "book": "1 Timothy",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03c1259b89eb0d13"
       },
       {
         "id": 185,
         "title": "God's great concern for men",
-        "verse": "But the LORD said, \"You have been concerned about this vine, though you did not tend it or make it grow. It sprang up overnight and died overnight. But Nineveh has more than a hundred and twenty thousand people who cannot tell their right hand from their left, and many cattle as well. Should I not be concerned about that great city?\" \u001a",
+        "verse": "But the LORD said, \"You have been concerned about this vine, though you did not tend it or make it grow. It sprang up overnight and died overnight. But Nineveh has more than a hundred and twenty thousand people who cannot tell their right hand from their left, and many cattle as well. Should I not be concerned about that great city?\"",
         "book": "Jonah",
         "reference": "4:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "14ca94f31b70f845"
       },
       {
         "id": 186,
@@ -1795,7 +2014,8 @@
         "verse": "I tell you that in the same way there will be more rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent.",
         "book": "Luke",
         "reference": "15:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f4b72ea2ac2df154"
       },
       {
         "id": 187,
@@ -1803,7 +2023,8 @@
         "verse": "We proclaim to you what we have seen and heard, so that you also may have fellowship with us. And our fellowship is with the Father and with his Son, Jesus Christ.",
         "book": "1 John",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1b4e207919ef5a98"
       },
       {
         "id": 188,
@@ -1811,7 +2032,8 @@
         "verse": "Those who are wise will shine like the brightness of the heavens, and those who lead many to righteousness, like the stars for ever and ever.",
         "book": "Daniel",
         "reference": "12:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "471a02f6807cfe9b"
       },
       {
         "id": 189,
@@ -1819,7 +2041,8 @@
         "verse": "\"Come, follow me,\" Jesus said, \"and I will make you fishers of men.\"",
         "book": "Matthew",
         "reference": "4:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a562c26b910f45c"
       },
       {
         "id": 190,
@@ -1827,7 +2050,8 @@
         "verse": "so that you may become blameless and pure, children of God without fault in a crooked and depraved generation, in which you shine like stars in the universe as you hold out the word of life--in order that I may boast on the day of Christ that I did not run or labor for nothing.",
         "book": "Philippians",
         "reference": "2:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6caa572ca7098f83"
       },
       {
         "id": 191,
@@ -1835,7 +2059,8 @@
         "verse": "Pray also for me, that whenever I open my mouth, words may be given me so that I will fearlessly make known the mystery of the gospel,",
         "book": "Ephesians",
         "reference": "6:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a726b675872941c8"
       },
       {
         "id": 192,
@@ -1843,7 +2068,8 @@
         "verse": "But in your hearts set apart Christ as Lord. Always be prepared to give an answer to everyone who asks you to give the reason for the hope that you have. But do this with gentleness and respect,",
         "book": "1 Peter",
         "reference": "3:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fdd0269c8535ec8f"
       },
       {
         "id": 193,
@@ -1851,7 +2077,8 @@
         "verse": "Many of the Samaritans from that town believed in him because of the woman's testimony, \"He told me everything I ever did.\"",
         "book": "John",
         "reference": "4:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5e6de217dbf7f892"
       },
       {
         "id": 194,
@@ -1859,7 +2086,8 @@
         "verse": "For the word of God is living and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7100d4f006d43f0b"
       },
       {
         "id": 195,
@@ -1867,7 +2095,8 @@
         "verse": "so is my word that goes out from my mouth: It will not return to me empty, but will accomplish what I desire and achieve the purpose for which I sent it.",
         "book": "Isaiah",
         "reference": "55:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e71ee053bb84e1f2"
       },
       {
         "id": 196,
@@ -1875,7 +2104,8 @@
         "verse": "but we preach Christ crucified: a stumbling block to Jews and foolishness to Gentiles, but to those whom God has called, both Jews and Greeks, Christ the power of God and the wisdom of God.",
         "book": "1 Corinthians",
         "reference": "1:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "90b0ff12647b90ca"
       },
       {
         "id": 197,
@@ -1883,7 +2113,8 @@
         "verse": "because our gospel came to you not simply with words, but also with power, with the Holy Spirit and with deep conviction. You know how we lived among you for your sake.",
         "book": "1 Thessalonians",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bfb5bd8e3ae7ad5e"
       },
       {
         "id": 198,
@@ -1891,7 +2122,8 @@
         "verse": "That if you confess with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you confess and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d84c71c21053f92c"
       },
       {
         "id": 199,
@@ -1899,7 +2131,8 @@
         "verse": "For he says, \"In the time of my favor I heard you, and in the day of salvation I helped you.\" I tell you, now is the time of God's favor, now is the day of salvation.",
         "book": "2 Corinthians",
         "reference": "6:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ed585ba601cbbd9b"
       },
       {
         "id": 200,
@@ -1907,7 +2140,8 @@
         "verse": "Examine yourselves to see whether you are in the faith; test yourselves. Do you not realize that Christ Jesus is in you--unless, of course, you fail the test?",
         "book": "2 Corinthians",
         "reference": "13:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "27843920558c8d5f"
       },
       {
         "id": 201,
@@ -1915,7 +2149,8 @@
         "verse": "As his custom was, Paul went into the synagogue, and on three Sabbath days he reasoned with them from the Scriptures, explaining and proving that the Christ had to suffer and rise from the dead. \"This Jesus I am proclaiming to you is the Christ,\" he said.",
         "book": "Acts",
         "reference": "17:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9622580e7c6b1191"
       },
       {
         "id": 202,
@@ -1923,7 +2158,8 @@
         "verse": "However, I consider my life worth nothing to me, if only I may finish the race and complete the task the Lord Jesus has given me--the task of testifying to the gospel of God's grace.",
         "book": "Acts",
         "reference": "20:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a68b0cf6a363059c"
       },
       {
         "id": 203,
@@ -1931,7 +2167,8 @@
         "verse": "The Spirit told Philip, \"Go to that chariot and stay near it.\" Then Philip ran up to the chariot and heard the man reading Isaiah the prophet. \"Do you understand what you are reading?\" Philip asked.",
         "book": "Acts",
         "reference": "8:29-30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba5726b0240962b4"
       },
       {
         "id": 204,
@@ -1939,7 +2176,8 @@
         "verse": "For we cannot help speaking about what we have seen and heard.\"",
         "book": "Acts",
         "reference": "4:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef7c5e1ce7b05012"
       },
       {
         "id": 205,
@@ -1947,7 +2185,8 @@
         "verse": "So God created man in his own image, in the image of God he created him; male and female he created them.",
         "book": "Genesis",
         "reference": "1:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "74ad102a507ac9de"
       },
       {
         "id": 206,
@@ -1955,7 +2194,8 @@
         "verse": "Surely the arm of the LORD is not too short to save, nor his ear too dull to hear. But your iniquities have separated you from your God; your sins have hidden his face from you, so that he will not hear.",
         "book": "Isaiah",
         "reference": "59:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d92ff2297902730a"
       },
       {
         "id": 207,
@@ -1963,7 +2203,8 @@
         "verse": "Therefore, just as sin entered the world through one man, and death through sin, and in this way death came to all men, because all sinned--",
         "book": "Romans",
         "reference": "5:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "df6c5ddf2a846315"
       },
       {
         "id": 208,
@@ -1971,7 +2212,8 @@
         "verse": "for all have sinned and fall short of the glory of God,",
         "book": "Romans",
         "reference": "3:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6fc02e7f3d5a1a92"
       },
       {
         "id": 209,
@@ -1979,7 +2221,8 @@
         "verse": "Just as man is destined to die once, and after that to face judgment,",
         "book": "Hebrews",
         "reference": "9:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b15fc4f39cc45bb4"
       },
       {
         "id": 210,
@@ -1987,7 +2230,8 @@
         "verse": "He will punish those who do not know God and do not obey the gospel of our Lord Jesus. They will be punished with everlasting destruction and shut out from the presence of the Lord and from the majesty of his power",
         "book": "2 Thessalonians",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a91aa9bf635fee8"
       },
       {
         "id": 211,
@@ -1995,7 +2239,8 @@
         "verse": "For the wages of sin is death, but the gift of God is eternal life in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "6:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "46f486793eff08bc"
       },
       {
         "id": 212,
@@ -2003,7 +2248,8 @@
         "verse": "But the cowardly, the unbelieving, the vile, the murderers, the sexually immoral, those who practice magic arts, the idolaters and all liars--their place will be in the fiery lake of burning sulfur. This is the second death.\"",
         "book": "Revelation",
         "reference": "21:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "16d56d1c1c607084"
       },
       {
         "id": 213,
@@ -2011,7 +2257,8 @@
         "verse": "For it is by grace you have been saved, through faith--and this not from yourselves, it is the gift of God--not by works, so that no one can boast.",
         "book": "Ephesians",
         "reference": "2:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f7cd4531c1748fa5"
       },
       {
         "id": 214,
@@ -2019,7 +2266,8 @@
         "verse": "I do not set aside the grace of God, for if righteousness could be gained through the law, Christ died for nothing!\"",
         "book": "Galatians",
         "reference": "2:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4042588b4b1ae2a2"
       },
       {
         "id": 215,
@@ -2027,7 +2275,8 @@
         "verse": "Salvation is found in no one else, for there is no other name under heaven given to men by which we must be saved.\"",
         "book": "Acts",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cdfb48caaad46ba7"
       },
       {
         "id": 216,
@@ -2035,7 +2284,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your forefathers,",
         "book": "1 Peter",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9e407216615ea0ac"
       },
       {
         "id": 217,
@@ -2043,7 +2293,8 @@
         "verse": "Jews demand miraculous signs and Greeks look for wisdom, but we preach Christ crucified: a stumbling block to Jews and foolishness to Gentiles,",
         "book": "1 Corinthians",
         "reference": "1:22-23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "25ec47827abd1293"
       },
       {
         "id": 218,
@@ -2051,7 +2302,8 @@
         "verse": "For since in the wisdom of God the world through its wisdom did not know him, God was pleased through the foolishness of what was preached to save those who believe.",
         "book": "1 Corinthians",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b6176d2da12b6302"
       },
       {
         "id": 219,
@@ -2059,7 +2311,8 @@
         "verse": "See to it that no one takes you captive through hollow and deceptive philosophy, which depends on human tradition and the basic principles of this world rather than on Christ.",
         "book": "Colossians",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "655f8c5a96949696"
       },
       {
         "id": 220,
@@ -2067,7 +2320,8 @@
         "verse": "children born not of natural descent, nor of human decision or a husband's will, but born of God.",
         "book": "John",
         "reference": "1:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2e9f0b24bb32ca91"
       },
       {
         "id": 221,
@@ -2075,7 +2329,8 @@
         "verse": "Flesh gives birth to flesh, but the Spirit gives birth to spirit. You should not be surprised at my saying, 'You must be born again.'",
         "book": "John",
         "reference": "3:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bc4301af4d3bc643"
       },
       {
         "id": 222,
@@ -2083,7 +2338,8 @@
         "verse": "The Spirit gives life; the flesh counts for nothing. The words I have spoken to you are spirit and they are life.",
         "book": "John",
         "reference": "6:63",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b4007135935d86d9"
       },
       {
         "id": 223,
@@ -2091,7 +2347,8 @@
         "verse": "For Christ died for sins once for all, the righteous for the unrighteous, to bring you to God. He was put to death in the body but made alive by the Spirit,",
         "book": "1 Peter",
         "reference": "3:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9cd43164e840fbf8"
       },
       {
         "id": 224,
@@ -2099,7 +2356,8 @@
         "verse": "\"For God so loved the world that he gave his one and only Son, that whoever believes in him shall not perish but have eternal life.",
         "book": "John",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61cb35edc10396cf"
       },
       {
         "id": 225,
@@ -2107,7 +2365,8 @@
         "verse": "But God demonstrates his own love for us in this: While we were still sinners, Christ died for us.",
         "book": "Romans",
         "reference": "5:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a90ad23df1b8716c"
       },
       {
         "id": 226,
@@ -2115,7 +2374,8 @@
         "verse": "For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day according to the Scriptures,",
         "book": "1 Corinthians",
         "reference": "15:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e9a225100315dfa4"
       },
       {
         "id": 227,
@@ -2123,7 +2383,8 @@
         "verse": "When you were dead in your sins and in the uncircumcision of your sinful nature, God made you alive with Christ. He forgave us all our sins,",
         "book": "Colossians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f5ec7373c98e59aa"
       },
       {
         "id": 228,
@@ -2131,7 +2392,8 @@
         "verse": "\"I tell you the truth, whoever hears my word and believes him who sent me has eternal life and will not be condemned; he has crossed over from death to life.",
         "book": "John",
         "reference": "5:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f3fb749fb62914c5"
       },
       {
         "id": 229,
@@ -2139,7 +2401,8 @@
         "verse": "Yet to all who received him, to those who believed in his name, he gave the right to become children of God--",
         "book": "John",
         "reference": "1:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b0423d531d0ff503"
       },
       {
         "id": 230,
@@ -2147,7 +2410,8 @@
         "verse": "Here I am! I stand at the door and knock. If anyone hears my voice and opens the door, I will come in and eat with him, and he with me.",
         "book": "Revelation",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bf12ed32e00a4544"
       },
       {
         "id": 231,
@@ -2155,13 +2419,14 @@
         "verse": "That if you confess with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you confess and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57bb2d28e2cb658d"
       }
     ]
   },
   {
     "name": "DEP 7: The Lordship of Christ",
-    "color": "#0032ff",
+    "color": "#01409E",
     "accentText": "7",
     "verses": [
       {
@@ -2170,7 +2435,8 @@
         "verse": "He was with God in the beginning. Through him all things were made; without him nothing was made that has been made.",
         "book": "John",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e3826d02963fa08f"
       },
       {
         "id": 233,
@@ -2178,7 +2444,8 @@
         "verse": "For by him all things were created: things in heaven and on earth, visible and invisible, whether thrones or powers or rulers or authorities; all things were created by him and for him. He is before all things, and in him all things hold together.",
         "book": "Colossians",
         "reference": "1:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f68a939769d759fb"
       },
       {
         "id": 234,
@@ -2186,7 +2453,8 @@
         "verse": "And he is the head of the body, the church; he is the beginning and the firstborn from among the dead, so that in everything he might have the supremacy.",
         "book": "Colossians",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "678639d1f4e8c15c"
       },
       {
         "id": 235,
@@ -2194,7 +2462,8 @@
         "verse": "far above all rule and authority, power and dominion, and every title that can be given, not only in the present age but also in the one to come.",
         "book": "Ephesians",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "680faf2e6e7e691a"
       },
       {
         "id": 236,
@@ -2202,7 +2471,8 @@
         "verse": "that at the name of Jesus every knee should bow, in heaven and on earth and under the earth, and every tongue confess that Jesus Christ is Lord, to the glory of God the Father.",
         "book": "Philippians",
         "reference": "2:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dff34281e8231c62"
       },
       {
         "id": 237,
@@ -2210,7 +2480,8 @@
         "verse": "For this very reason, Christ died and returned to life so that he might be the Lord of both the dead and the living.",
         "book": "Romans",
         "reference": "14:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f971219321809d88"
       },
       {
         "id": 238,
@@ -2218,7 +2489,8 @@
         "verse": "Do you not know that your body is a temple of the Holy Spirit, who is in you, whom you have received from God? You are not your own; you were bought at a price. Therefore honor God with your body.",
         "book": "1 Corinthians",
         "reference": "6:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb77cab02059d213"
       },
       {
         "id": 239,
@@ -2226,7 +2498,8 @@
         "verse": "And he died for all, that those who live should no longer live for themselves but for him who died for them and was raised again.",
         "book": "2 Corinthians",
         "reference": "5:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b5ceb1d868294633"
       },
       {
         "id": 240,
@@ -2234,7 +2507,8 @@
         "verse": "But seek first his kingdom and his righteousness, and all these things will be given to you as well.",
         "book": "Matthew",
         "reference": "6:33",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5fea29f2b0512d37"
       },
       {
         "id": 241,
@@ -2242,7 +2516,8 @@
         "verse": "\"I tell you the truth,\" Jesus replied, \"no one who has left home or brothers or sisters or mother or father or children or fields for me and the gospel will fail to receive a hundred times as much in this present age (homes, brothers, sisters, mothers, children and fields--and with them, persecutions) and in the age to come, eternal life.",
         "book": "Mark",
         "reference": "10:29-30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "30072efb63ad246d"
       },
       {
         "id": 242,
@@ -2250,7 +2525,8 @@
         "verse": "and said, \"I swear by myself, declares the LORD, that because you have done this and have not withheld your son, your only son, I will surely bless you and make your descendants as numerous as the stars in the sky and as the sand on the seashore. Your descendants will take possession of the cities of their enemies,",
         "book": "Genesis",
         "reference": "22:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "60b184454c2177e2"
       },
       {
         "id": 243,
@@ -2258,7 +2534,8 @@
         "verse": "\"And you, my son Solomon, acknowledge the God of your father, and serve him with wholehearted devotion and with a willing mind, for the LORD searches every heart and understands every motive behind the thoughts. If you seek him, he will be found by you; but if you forsake him, he will reject you forever.",
         "book": "1 Chronicles",
         "reference": "28:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c00a83066f8068a4"
       },
       {
         "id": 244,
@@ -2266,7 +2543,8 @@
         "verse": "For the eyes of the LORD range throughout the earth to strengthen those whose hearts are fully committed to him. You have done a foolish thing, and from now on you will be at war.\"",
         "book": "2 Chronicles",
         "reference": "16:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2192a04982adea91"
       },
       {
         "id": 245,
@@ -2274,7 +2552,8 @@
         "verse": "\"Because he loves me,\" says the LORD, \"I will rescue him; I will protect him, for he acknowledges my name.",
         "book": "Psalm",
         "reference": "91:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb292fec34bc3108"
       },
       {
         "id": 246,
@@ -2282,7 +2561,8 @@
         "verse": "\"Therefore the LORD, the God of Israel, declares: 'I promised that your house and your father's house would minister before me forever.' But now the LORD declares: 'Far be it from me! Those who honor me I will honor, but those who despise me will be disdained.",
         "book": "1 Samuel",
         "reference": "2:30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e704bcbdab78a580"
       },
       {
         "id": 247,
@@ -2290,7 +2570,8 @@
         "verse": "Then he said to them all: \"If anyone would come after me, he must deny himself and take up his cross daily and follow me.",
         "book": "Luke",
         "reference": "9:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0871aa32bb0314d1"
       },
       {
         "id": 248,
@@ -2298,7 +2579,8 @@
         "verse": "When a man's ways are pleasing to the LORD, he makes even his enemies live at peace with him.",
         "book": "Proverbs",
         "reference": "16:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5d7456b07d13bad5"
       },
       {
         "id": 249,
@@ -2306,7 +2588,8 @@
         "verse": "Trust in the LORD with all your heart and lean not on your own understanding; in all your ways acknowledge him, and he will make your paths straight.",
         "book": "Proverbs",
         "reference": "3:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d981c28f08240492"
       },
       {
         "id": 250,
@@ -2314,7 +2597,8 @@
         "verse": "You were taught, with regard to your former way of life, to put off your old self, which is being corrupted by its deceitful desires; to be made new in the attitude of your minds; and to put on the new self, created to be like God in true righteousness and holiness.",
         "book": "Ephesians",
         "reference": "4:22-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "136a02728eed50c4"
       },
       {
         "id": 251,
@@ -2322,7 +2606,8 @@
         "verse": "Flee the evil desires of youth, and pursue righteousness, faith, love and peace, along with those who call on the Lord out of a pure heart.",
         "book": "2 Timothy",
         "reference": "2:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3c64366969cc14f9"
       },
       {
         "id": 252,
@@ -2330,7 +2615,8 @@
         "verse": "For we brought nothing into the world, and we can take nothing out of it. But if we have food and clothing, we will be content with that. People who want to get rich fall into temptation and a trap and into many foolish and harmful desires that plunge men into ruin and destruction.",
         "book": "1 Timothy",
         "reference": "6:7-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b7ec843291b0f424"
       },
       {
         "id": 253,
@@ -2338,7 +2624,8 @@
         "verse": "Be very careful, then, how you live--not as unwise but as wise, making the most of every opportunity, because the days are evil.",
         "book": "Ephesians",
         "reference": "5:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc7985a0e5111596"
       },
       {
         "id": 254,
@@ -2346,7 +2633,8 @@
         "verse": "Without delay he called them, and they left their father Zebedee in the boat with the hired men and followed him.",
         "book": "Mark",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a5458d5f99fc5526"
       },
       {
         "id": 255,
@@ -2354,7 +2642,8 @@
         "verse": "I eagerly expect and hope that I will in no way be ashamed, but will have sufficient courage so that now as always Christ will be exalted in my body, whether by life or by death.",
         "book": "Philippians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4910b66021ad4396"
       },
       {
         "id": 256,
@@ -2362,7 +2651,8 @@
         "verse": "For everyone looks out for his own interests, not those of Jesus Christ. But you know that Timothy has proved himself, because as a son with his father he has served with me in the work of the gospel.",
         "book": "Philippians",
         "reference": "2:21-22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "845ecb9a20404bf1"
       },
       {
         "id": 257,
@@ -2370,13 +2660,14 @@
         "verse": "Some faced jeers and flogging, while still others were chained and put in prison. They were stoned; they were sawed in two; they were put to death by the sword. They went about in sheepskins and goatskins, destitute, persecuted and mistreated--the world was not worthy of them. They wandered in deserts and mountains, and in caves and holes in the ground.",
         "book": "Hebrews",
         "reference": "11:36-38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "81acad9ea2995c82"
       }
     ]
   },
   {
     "name": "DEP 8: World Vision",
-    "color": "#8900ff",
+    "color": "#362B8A",
     "accentText": "8",
     "verses": [
       {
@@ -2385,7 +2676,8 @@
         "verse": "\"I will make you into a great nation and I will bless you; I will make your name great, and you will be a blessing. I will bless those who bless you, and whoever curses you I will curse; and all peoples on earth will be blessed through you.\"",
         "book": "Genesis",
         "reference": "12:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e23696a3eda4308c"
       },
       {
         "id": 259,
@@ -2393,7 +2685,8 @@
         "verse": "he says: \"It is too small a thing for you to be my servant to restore the tribes of Jacob and bring back those of Israel I have kept. I will also make you a light for the Gentiles, that you may bring my salvation to the ends of the earth.\"",
         "book": "Isaiah",
         "reference": "49:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "250ae3d6a5c53191"
       },
       {
         "id": 260,
@@ -2401,7 +2694,8 @@
         "verse": "Therefore go and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, and teaching them to obey everything I have commanded you. And surely I am with you always, to the very end of the age.\"",
         "book": "Matthew",
         "reference": "28:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f50834c9f82a1676"
       },
       {
         "id": 261,
@@ -2409,7 +2703,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\"",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f9754a40a89ec8ba"
       },
       {
         "id": 262,
@@ -2417,7 +2712,8 @@
         "verse": "Then I heard the voice of the Lord saying, \"Whom shall I send? And who will go for us?\" And I said, \"Here am I. Send me!\"",
         "book": "Isaiah",
         "reference": "6:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ada587118a33373a"
       },
       {
         "id": 263,
@@ -2425,7 +2721,8 @@
         "verse": "to be a minister of Christ Jesus to the Gentiles with the priestly duty of proclaiming the gospel of God, so that the Gentiles might become an offering acceptable to God, sanctified by the Holy Spirit.",
         "book": "Romans",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e10b720b0f11e070"
       },
       {
         "id": 264,
@@ -2433,7 +2730,8 @@
         "verse": "Ask of me, and I will make the nations your inheritance, the ends of the earth your possession.",
         "book": "Psalm",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bde180e4c954cd94"
       },
       {
         "id": 265,
@@ -2441,7 +2739,8 @@
         "verse": "Be exalted, O God, above the heavens; let your glory be over all the earth.",
         "book": "Psalm",
         "reference": "57:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "72e8ed68e7724c16"
       },
       {
         "id": 266,
@@ -2449,7 +2748,8 @@
         "verse": "a faith and knowledge resting on the hope of eternal life, which God, who does not lie, promised before the beginning of time, and at his appointed season he brought his word to light through the preaching entrusted to me by the command of God our Savior,",
         "book": "Titus",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7d1f3d4844590cb7"
       },
       {
         "id": 267,
@@ -2457,7 +2757,8 @@
         "verse": "But the Lord stood at my side and gave me strength, so that through me the message might be fully proclaimed and all the Gentiles might hear it. And I was delivered from the lion's mouth.",
         "book": "2 Timothy",
         "reference": "4:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b54223f0569d385b"
       },
       {
         "id": 268,
@@ -2465,7 +2766,8 @@
         "verse": "We proclaim him, admonishing and teaching everyone with all wisdom, so that we may present everyone perfect in Christ. To this end I labor, struggling with all his energy, which so powerfully works in me.",
         "book": "Colossians",
         "reference": "1:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6717dd3397b469ca"
       },
       {
         "id": 269,
@@ -2473,7 +2775,8 @@
         "verse": "And this is my prayer: that your love may abound more and more in knowledge and depth of insight, so that you may be able to discern what is best and may be pure and blameless until the day of Christ, filled with the fruit of righteousness that comes through Jesus Christ--to the glory and praise of God.",
         "book": "Philippians",
         "reference": "1:9-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "91188675a80c177d"
       },
       {
         "id": 270,
@@ -2481,7 +2784,8 @@
         "verse": "And the things you have heard me say in the presence of many witnesses entrust to reliable men who will also be qualified to teach others.",
         "book": "2 Timothy",
         "reference": "2:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da0386c36c4a831c"
       },
       {
         "id": 271,
@@ -2489,7 +2793,8 @@
         "verse": "The least of you will become a thousand, the smallest a mighty nation. I am the LORD; in its time I will do this swiftly.\"",
         "book": "Isaiah",
         "reference": "60:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0fb59b1a61e73bf6"
       },
       {
         "id": 272,
@@ -2497,7 +2802,8 @@
         "verse": "Therefore, since we are surrounded by such a great cloud of witnesses, let us throw off everything that hinders and the sin that so easily entangles, and let us run with perseverance the race marked out for us.",
         "book": "Hebrews",
         "reference": "12:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "672305c21d39dbc4"
       },
       {
         "id": 273,
@@ -2505,7 +2811,8 @@
         "verse": "For the eyes of the LORD range throughout the earth to strengthen those whose hearts are fully committed to him. You have done a foolish thing, and from now on you will be at war.\"",
         "book": "2 Chronicles",
         "reference": "16:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6e316c176c8737d8"
       },
       {
         "id": 274,
@@ -2513,7 +2820,8 @@
         "verse": "For the earth will be filled with the knowledge of the glory of the LORD, as the waters cover the sea.",
         "book": "Habakkuk",
         "reference": "2:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d1b556de7966dae4"
       },
       {
         "id": 275,
@@ -2521,13 +2829,14 @@
         "verse": "My name will be great among the nations, from the rising to the setting of the sun. In every place incense and pure offerings will be brought to my name, because my name will be great among the nations,\" says the Lord Almighty.",
         "book": "Malachi",
         "reference": "1:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "16c71d811b477a8b"
       }
     ]
   },
   {
     "name": "TMS 180 · Getting to Know God",
-    "color": "#6A4C93",
+    "color": "#5E3A87",
     "accentText": "1",
     "verses": [
       {
@@ -2536,7 +2845,8 @@
         "verse": "In the beginning was the Word, and the Word was with God, and the Word was God. The Word became flesh and made his dwelling among us. We have seen his glory, the glory of the One and Only, who came from the Father, full of grace and truth.",
         "book": "John",
         "reference": "1:1,14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ad0fd6a5607c6206"
       },
       {
         "id": 10002,
@@ -2544,7 +2854,8 @@
         "verse": "But about the Son he says, \"Your throne, O God, will last for ever and ever, and righteousness will be the scepter of your kingdom.",
         "book": "Hebrews",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6acde3c43628147f"
       },
       {
         "id": 10003,
@@ -2552,7 +2863,8 @@
         "verse": "For we do not have a high priest who is unable to sympathize with our weaknesses, but we have one who has been tempted in every way, just as we are—yet was without sin.",
         "book": "Hebrews",
         "reference": "4:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7d9b9e7292cd2201"
       },
       {
         "id": 10004,
@@ -2560,7 +2872,8 @@
         "verse": "And Jesus grew in wisdom and stature, and in favor with God and men.",
         "book": "Luke",
         "reference": "2:52",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2888e1e2bd72d8c8"
       },
       {
         "id": 10005,
@@ -2568,7 +2881,8 @@
         "verse": "For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day according to the Scriptures,",
         "book": "1 Corinthians",
         "reference": "15:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e01fa1abc4c824dc"
       },
       {
         "id": 10006,
@@ -2576,7 +2890,8 @@
         "verse": "But Christ has indeed been raised from the dead, the firstfruits of those who have fallen asleep.",
         "book": "1 Corinthians",
         "reference": "15:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "088c7dbc0517e935"
       },
       {
         "id": 10007,
@@ -2584,7 +2899,8 @@
         "verse": "No one has ever seen God, but God the One and Only, who is at the Father's side, has made him known.",
         "book": "John",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce14c2ec2ccf422b"
       },
       {
         "id": 10008,
@@ -2592,7 +2908,8 @@
         "verse": "The Son is the radiance of God's glory and the exact representation of his being, sustaining all things by his powerful word. After he had provided purification for sins, he sat down at the right hand of the Majesty in heaven.",
         "book": "Hebrews",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ca24432e0ba3341a"
       },
       {
         "id": 10009,
@@ -2600,7 +2917,8 @@
         "verse": "For the Son of Man came to seek and to save what was lost.\"",
         "book": "Luke",
         "reference": "19:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ab2695c0099c3ddf"
       },
       {
         "id": 10010,
@@ -2608,7 +2926,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your forefathers, but with the precious blood of Christ, a lamb without blemish or defect.",
         "book": "1 Peter",
         "reference": "1:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c084bca16a5249b1"
       },
       {
         "id": 10011,
@@ -2616,7 +2935,8 @@
         "verse": "For the Lord himself will come down from heaven, with a loud command, with the voice of the archangel and with the trumpet call of God, and the dead in Christ will rise first. After that, we who are still alive and are left will be caught up together with them in the clouds to meet the Lord in the air. And so we will be with the Lord forever.",
         "book": "1 Thessalonians",
         "reference": "4:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e40a5387c97e290c"
       },
       {
         "id": 10012,
@@ -2624,7 +2944,8 @@
         "verse": "Dear friends, now we are children of God, and what we will be has not yet been made known. But we know that when he appears, we shall be like him, for we shall see him as he is. Everyone who has this hope in him purifies himself, just as he is pure.",
         "book": "1 John",
         "reference": "3:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cb877f495a4fe3d5"
       },
       {
         "id": 10013,
@@ -2632,7 +2953,8 @@
         "verse": "But when he, the Spirit of truth, comes, he will guide you into all truth. He will not speak on his own; he will speak only what he hears, and he will tell you what is yet to come. He will bring glory to me by taking from what is mine and making it known to you.",
         "book": "John",
         "reference": "16:13-14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6c11e294ab00721e"
       },
       {
         "id": 10014,
@@ -2640,7 +2962,8 @@
         "verse": "Therefore I tell you that no one who is speaking by the Spirit of God says, \"Jesus be cursed,\" and no one can say, \"Jesus is Lord,\" except by the Holy Spirit.",
         "book": "1 Corinthians",
         "reference": "12:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "94590e66b55fbf56"
       },
       {
         "id": 10015,
@@ -2648,7 +2971,8 @@
         "verse": "You, however, are controlled not by the sinful nature but by the Spirit, if the Spirit of God lives in you. And if anyone does not have the Spirit of Christ, he does not belong to Christ.",
         "book": "Romans",
         "reference": "8:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f84e56d9698659ed"
       },
       {
         "id": 10016,
@@ -2656,7 +2980,8 @@
         "verse": "Because you are sons, God sent the Spirit of his Son into our hearts, the Spirit who calls out, \"Abba, Father.\"",
         "book": "Galatians",
         "reference": "4:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2d0c0113984c1c62"
       },
       {
         "id": 10017,
@@ -2664,7 +2989,8 @@
         "verse": "Do not get drunk on wine, which leads to debauchery. Instead, be filled with the Spirit.",
         "book": "Ephesians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "934cf5ee6c5e0793"
       },
       {
         "id": 10018,
@@ -2672,7 +2998,8 @@
         "verse": "So I say, live by the Spirit, and you will not gratify the desires of the sinful nature.",
         "book": "Galatians",
         "reference": "5:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a9a55158fafd358d"
       },
       {
         "id": 10019,
@@ -2680,7 +3007,8 @@
         "verse": "However, as it is written: \"No eye has seen, no ear has heard, no mind has conceived what God has prepared for those who love him\"—but God has revealed it to us by his Spirit. The Spirit searches all things, even the deep things of God.",
         "book": "1 Corinthians",
         "reference": "2:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fb52c890d7c702fe"
       },
       {
         "id": 10020,
@@ -2688,7 +3016,8 @@
         "verse": "But the Counselor, the Holy Spirit, whom the Father will send in my name, will teach you all things and will remind you of everything I have said to you.",
         "book": "John",
         "reference": "14:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7e5b8f2a9ce2f2ec"
       },
       {
         "id": 10021,
@@ -2696,7 +3025,8 @@
         "verse": "My message and my preaching were not with wise and persuasive words, but with a demonstration of the Spirit's power, so that your faith might not rest on men's wisdom, but on God's power.",
         "book": "1 Corinthians",
         "reference": "2:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c94d71e4e1be5f02"
       },
       {
         "id": 10022,
@@ -2704,7 +3034,8 @@
         "verse": "because our gospel came to you not simply with words, but also with power, with the Holy Spirit and with deep conviction. You know how we lived among you for your sake.",
         "book": "1 Thessalonians",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "346c64a29af2dffa"
       },
       {
         "id": 10023,
@@ -2712,7 +3043,8 @@
         "verse": "All these are the work of one and the same Spirit, and he gives them to each one, just as he determines.",
         "book": "1 Corinthians",
         "reference": "12:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8e9590712ff9022e"
       },
       {
         "id": 10024,
@@ -2720,7 +3052,8 @@
         "verse": "There are different kinds of gifts, but the same Spirit. There are different kinds of service, but the same Lord. There are different kinds of working, but the same God works all of them in all men.",
         "book": "1 Corinthians",
         "reference": "12:4-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d0a67cdcb1ca8032"
       },
       {
         "id": 10025,
@@ -2728,7 +3061,8 @@
         "verse": "\"Ah, Sovereign LORD, you have made the heavens and the earth by your great power and outstretched arm. Nothing is too hard for you.",
         "book": "Jeremiah",
         "reference": "32:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "63af1504260b6d44"
       },
       {
         "id": 10026,
@@ -2736,7 +3070,8 @@
         "verse": "Oh, the depth of the riches of the wisdom and knowledge of God! How unsearchable his judgments, and his paths beyond tracing out!",
         "book": "Romans",
         "reference": "11:33",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9a1d29c7f5d1cba9"
       },
       {
         "id": 10027,
@@ -2744,7 +3079,8 @@
         "verse": "Can anyone hide in secret places so that I cannot see him?\" declares the LORD. \"Do not I fill heaven and earth?\" declares the LORD.",
         "book": "Jeremiah",
         "reference": "23:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ffec9be019bc9028"
       },
       {
         "id": 10028,
@@ -2752,7 +3088,8 @@
         "verse": "And God is able to make all grace abound to you, so that in all things at all times, having all that you need, you will abound in every good work.",
         "book": "2 Corinthians",
         "reference": "9:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a2f3f455fd612c0a"
       },
       {
         "id": 10029,
@@ -2760,7 +3097,8 @@
         "verse": "Yours, O LORD, is the greatness and the power and the glory and the majesty and the splendor, for everything in heaven and earth is yours. Yours, O LORD, is the kingdom; you are exalted as head over all. Wealth and honor come from you; you are the ruler of all things. In your hands are strength and power to exalt and give strength to all. Now, our God, we give you thanks, and praise your glorious name.",
         "book": "1 Chronicles",
         "reference": "29:11-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b458144f068a002c"
       },
       {
         "id": 10030,
@@ -2768,7 +3106,8 @@
         "verse": "But the Lord is faithful, and he will strengthen and protect you from the evil one.",
         "book": "2 Thessalonians",
         "reference": "3:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d3623bbdfbd7a5e6"
       },
       {
         "id": 10031,
@@ -2776,7 +3115,8 @@
         "verse": "God is spirit, and his worshipers must worship in spirit and in truth.\"",
         "book": "John",
         "reference": "4:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0c1e0ff9f5051499"
       },
       {
         "id": 10032,
@@ -2784,7 +3124,8 @@
         "verse": "But just as he who called you is holy, so be holy in all you do; for it is written: \"Be holy, because I am holy.\"",
         "book": "1 Peter",
         "reference": "1:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87c3b0c2b4922da5"
       },
       {
         "id": 10033,
@@ -2792,7 +3133,8 @@
         "verse": "Great is the LORD and most worthy of praise; his greatness no one can fathom.",
         "book": "Psalm",
         "reference": "145:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "414d0b41aca470cd"
       },
       {
         "id": 10034,
@@ -2800,7 +3142,8 @@
         "verse": "This is love: not that we loved God, but that he loved us and sent his Son as an atoning sacrifice for our sins.",
         "book": "1 John",
         "reference": "4:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e005d0657d7a7677"
       },
       {
         "id": 10035,
@@ -2808,7 +3151,8 @@
         "verse": "But you, O Lord, are a compassionate and gracious God, slow to anger, abounding in love and faithfulness.",
         "book": "Psalm",
         "reference": "86:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "37af79e3a159dfce"
       },
       {
         "id": 10036,
@@ -2816,13 +3160,14 @@
         "verse": "And we know that in all things God works for the good of those who love him, who have been called according to his purpose.",
         "book": "Romans",
         "reference": "8:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "21a48c3904b01d89"
       }
     ]
   },
   {
     "name": "TMS 180 · Growing in Love",
-    "color": "#C9184A",
+    "color": "#8E3339",
     "accentText": "2",
     "verses": [
       {
@@ -2831,7 +3176,8 @@
         "verse": "Instead, speaking the truth in love, we will in all things grow up into him who is the Head, that is, Christ.",
         "book": "Ephesians",
         "reference": "4:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "11e78ee8c60ce5c3"
       },
       {
         "id": 10038,
@@ -2839,7 +3185,8 @@
         "verse": "Do not lie to each other, since you have taken off your old self with its practices",
         "book": "Colossians",
         "reference": "3:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "872a33c8833cb8c0"
       },
       {
         "id": 10039,
@@ -2847,7 +3194,8 @@
         "verse": "He who covers over an offense promotes love, but whoever repeats the matter separates close friends.",
         "book": "Proverbs",
         "reference": "17:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d75462755ef041c9"
       },
       {
         "id": 10040,
@@ -2855,7 +3203,8 @@
         "verse": "A gossip betrays a confidence, but a trustworthy man keeps a secret.",
         "book": "Proverbs",
         "reference": "11:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "efa987c982d29584"
       },
       {
         "id": 10041,
@@ -2863,7 +3212,8 @@
         "verse": "Pray that I may proclaim it clearly, as I should. Be wise in the way you act toward outsiders; make the most of every opportunity. Let your conversation be always full of grace, seasoned with salt, so that you may know how to answer everyone.",
         "book": "Colossians",
         "reference": "4:4-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8722804ef75a7d5e"
       },
       {
         "id": 10042,
@@ -2871,7 +3221,8 @@
         "verse": "A gentle answer turns away wrath, but a harsh word stirs up anger.",
         "book": "Proverbs",
         "reference": "15:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5c132d4b09302f09"
       },
       {
         "id": 10043,
@@ -2879,7 +3230,8 @@
         "verse": "Therefore confess your sins to each other and pray for each other so that you may be healed. The prayer of a righteous man is powerful and effective.",
         "book": "James",
         "reference": "5:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "813c49277fd475c3"
       },
       {
         "id": 10044,
@@ -2887,7 +3239,8 @@
         "verse": "\"Therefore, if you are offering your gift at the altar and there remember that your brother has something against you, leave your gift there in front of the altar. First go and be reconciled to your brother; then come and offer your gift.",
         "book": "Matthew",
         "reference": "5:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c9ecfd87bb0a09ca"
       },
       {
         "id": 10045,
@@ -2895,7 +3248,8 @@
         "verse": "My dear brothers, take note of this: Everyone should be quick to listen, slow to speak and slow to become angry,",
         "book": "James",
         "reference": "1:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "85649b891714205e"
       },
       {
         "id": 10046,
@@ -2903,7 +3257,8 @@
         "verse": "He who answers before listening—that is his folly and his shame.",
         "book": "Proverbs",
         "reference": "18:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "18089a507336ab09"
       },
       {
         "id": 10047,
@@ -2911,7 +3266,8 @@
         "verse": "Do not rebuke a mocker or he will hate you; rebuke a wise man and he will love you. Instruct a wise man and he will be wiser still; teach a righteous man and he will add to his learning.",
         "book": "Proverbs",
         "reference": "9:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "048db2ee06b91498"
       },
       {
         "id": 10048,
@@ -2919,7 +3275,8 @@
         "verse": "\"If your brother sins against you, go and show him his fault, just between the two of you. If he listens to you, you have won your brother over.",
         "book": "Matthew",
         "reference": "18:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ccba60cd59c75916"
       },
       {
         "id": 10049,
@@ -2927,7 +3284,8 @@
         "verse": "Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you.",
         "book": "Ephesians",
         "reference": "4:32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "53a7b4e11dacac07"
       },
       {
         "id": 10050,
@@ -2935,7 +3293,8 @@
         "verse": "Bear with each other and forgive whatever grievances you may have against one another. Forgive as the Lord forgave you.",
         "book": "Colossians",
         "reference": "3:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8decb3b7b3a54386"
       },
       {
         "id": 10051,
@@ -2943,7 +3302,8 @@
         "verse": "Be completely humble and gentle; be patient, bearing with one another in love.",
         "book": "Ephesians",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a43d9a576dbbca87"
       },
       {
         "id": 10052,
@@ -2951,7 +3311,8 @@
         "verse": "And the Lord's servant must not quarrel; instead, he must be kind to everyone, able to teach, not resentful. Those who oppose him he must gently instruct, in the hope that God will grant them repentance leading them to a knowledge of the truth,",
         "book": "2 Timothy",
         "reference": "2:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "75e6c58cbc58e778"
       },
       {
         "id": 10053,
@@ -2959,7 +3320,8 @@
         "verse": "\"In your anger do not sin\": Do not let the sun go down while you are still angry,",
         "book": "Ephesians",
         "reference": "4:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4ac16250f278b4d1"
       },
       {
         "id": 10054,
@@ -2967,7 +3329,8 @@
         "verse": "But now you must rid yourselves of all such things as these: anger, rage, malice, slander, and filthy language from your lips.",
         "book": "Colossians",
         "reference": "3:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a438dd5a60ce77f4"
       },
       {
         "id": 10055,
@@ -2975,7 +3338,8 @@
         "verse": "See to it that no one misses the grace of God and that no bitter root grows up to cause trouble and defile many.",
         "book": "Hebrews",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5fc9ab7e18196f69"
       },
       {
         "id": 10056,
@@ -2983,7 +3347,8 @@
         "verse": "Get rid of all bitterness, rage and anger, brawling and slander, along with every form of malice.",
         "book": "Ephesians",
         "reference": "4:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "26023181f40150cb"
       },
       {
         "id": 10057,
@@ -2991,7 +3356,17 @@
         "verse": "But how is it to your credit if you receive a beating for doing wrong and endure it? But if you suffer for doing good and you endure it, this is commendable before God. To this you were called, because Christ suffered for you, leaving you an example, that you should follow in his steps.",
         "book": "1 Peter",
         "reference": "2:20-21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2536ca7cdf835907"
+      },
+      {
+        "id": 20001,
+        "title": "Endure Injustice",
+        "verse": "Do not take revenge, my friends, but leave room for God's wrath, for it is written: \"It is mine to avenge; I will repay,\" says the Lord.",
+        "book": "Romans",
+        "reference": "12:19",
+        "subpack": "",
+        "cardUid": "2f0b947e5be05ec1"
       },
       {
         "id": 10058,
@@ -2999,7 +3374,8 @@
         "verse": "Anger is cruel and fury overwhelming, but who can stand before jealousy?",
         "book": "Proverbs",
         "reference": "27:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6e481bccd76cb08e"
       },
       {
         "id": 10059,
@@ -3007,7 +3383,8 @@
         "verse": "For where you have envy and selfish ambition, there you find disorder and every evil practice.",
         "book": "James",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4e0aa82a4f2980dd"
       },
       {
         "id": 10060,
@@ -3015,7 +3392,8 @@
         "verse": "May the God who gives endurance and encouragement give you a spirit of unity among yourselves as you follow Christ Jesus, so that with one heart and mouth you may glorify the God and Father of our Lord Jesus Christ.",
         "book": "Romans",
         "reference": "15:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc3a406c36c50e6e"
       },
       {
         "id": 10061,
@@ -3023,7 +3401,8 @@
         "verse": "I appeal to you, brothers, in the name of our Lord Jesus Christ, that all of you agree with one another so that there may be no divisions among you and that you may be perfectly united in mind and thought.",
         "book": "1 Corinthians",
         "reference": "1:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "36846201f0e81be8"
       },
       {
         "id": 10062,
@@ -3031,7 +3410,8 @@
         "verse": "Not so with you. Instead, whoever wants to become great among you must be your servant, and whoever wants to be first must be your slave—",
         "book": "Matthew",
         "reference": "20:26-27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7f072ea7763a22c8"
       },
       {
         "id": 10063,
@@ -3039,7 +3419,8 @@
         "verse": "You, my brothers, were called to be free. But do not use your freedom to indulge the sinful nature; rather, serve one another in love.",
         "book": "Galatians",
         "reference": "5:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9b82340a369679d6"
       },
       {
         "id": 10064,
@@ -3047,7 +3428,8 @@
         "verse": "Each of us should please his neighbor for his good, to build him up.",
         "book": "Romans",
         "reference": "15:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "41aa402b865a4118"
       },
       {
         "id": 10065,
@@ -3055,7 +3437,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit, but in humility consider others better than yourselves. Each of you should look not only to your own interests, but also to the interests of others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03667fb75c855075"
       },
       {
         "id": 10066,
@@ -3063,7 +3446,8 @@
         "verse": "Therefore encourage one another and build each other up, just as in fact you are doing.",
         "book": "1 Thessalonians",
         "reference": "5:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "78201e7718866680"
       },
       {
         "id": 10067,
@@ -3071,7 +3455,8 @@
         "verse": "Two are better than one, because they have a good return for their work: If one falls down, his friend can help him up. But pity the man who falls and has no one to help him up!",
         "book": "Ecclesiastes",
         "reference": "4:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3336f4844b76863d"
       },
       {
         "id": 10068,
@@ -3079,7 +3464,8 @@
         "verse": "When he saw the crowds, he had compassion on them, because they were harassed and helpless, like sheep without a shepherd.",
         "book": "Matthew",
         "reference": "9:36",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "835f9cba837bbe84"
       },
       {
         "id": 10069,
@@ -3087,7 +3473,8 @@
         "verse": "Rejoice with those who rejoice; mourn with those who mourn.",
         "book": "Romans",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "06b7b9c92c05840d"
       },
       {
         "id": 10070,
@@ -3095,7 +3482,8 @@
         "verse": "But the wisdom that comes from heaven is first of all pure; then peace-loving, considerate, submissive, full of mercy and good fruit, impartial and sincere.",
         "book": "James",
         "reference": "3:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "890ba6720c15bbdb"
       },
       {
         "id": 10071,
@@ -3103,13 +3491,14 @@
         "verse": "Brothers, if someone is caught in a sin, you who are spiritual should restore him gently. But watch yourself, or you also may be tempted.",
         "book": "Galatians",
         "reference": "6:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "71db06fd0bdcf929"
       }
     ]
   },
   {
     "name": "TMS 180 · Growing in Faith",
-    "color": "#1B998B",
+    "color": "#2E86B8",
     "accentText": "3",
     "verses": [
       {
@@ -3118,7 +3507,8 @@
         "verse": "His divine power has given us everything we need for life and godliness through our knowledge of him who called us by his own glory and goodness. Through these he has given us his very great and precious promises, so that through them you may participate in the divine nature and escape the corruption in the world caused by evil desires.",
         "book": "2 Peter",
         "reference": "1:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef02d3aee1d50539"
       },
       {
         "id": 10073,
@@ -3126,7 +3516,8 @@
         "verse": "For no matter how many promises God has made, they are \"Yes\" in Christ. And so through him the \"Amen\" is spoken by us to the glory of God.",
         "book": "2 Corinthians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "774e855fbdabfd6e"
       },
       {
         "id": 10074,
@@ -3134,7 +3525,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ, the Father of compassion and the God of all comfort, who comforts us in all our troubles, so that we can comfort those in any trouble with the comfort we ourselves have received from God.",
         "book": "2 Corinthians",
         "reference": "1:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d08a657e650c3eda"
       },
       {
         "id": 10075,
@@ -3142,7 +3534,8 @@
         "verse": "So neither he who plants nor he who waters is anything, but only God, who makes things grow. The man who plants and the man who waters have one purpose, and each will be rewarded according to his own labor.",
         "book": "1 Corinthians",
         "reference": "3:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "56a51c22bcb41dcf"
       },
       {
         "id": 10076,
@@ -3150,7 +3543,8 @@
         "verse": "But his delight is in the law of the LORD, and on his law he meditates day and night. He is like a tree planted by streams of water, which yields its fruit in season and whose leaf does not wither. Whatever he does prospers.",
         "book": "Psalm",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "591b37ed6ad03f6c"
       },
       {
         "id": 10077,
@@ -3158,7 +3552,8 @@
         "verse": "For if you possess these qualities in increasing measure, they will keep you from being ineffective and unproductive in your knowledge of our Lord Jesus Christ.",
         "book": "2 Peter",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a5bf10ed89a6439"
       },
       {
         "id": 10078,
@@ -3166,7 +3561,17 @@
         "verse": "And the God of all grace, who called you to his eternal glory in Christ, after you have suffered a little while, will himself restore you and make you strong, firm and steadfast.",
         "book": "1 Peter",
         "reference": "5:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce5bf5d8dc8629ae"
+      },
+      {
+        "id": 20002,
+        "title": "Promises for Help in Trouble",
+        "verse": "But he said to me, \"My grace is sufficient for you, for my power is made perfect in weakness.\" Therefore I will boast all the more gladly about my weaknesses, so that Christ's power may rest on me.",
+        "book": "2 Corinthians",
+        "reference": "12:9",
+        "subpack": "",
+        "cardUid": "79ef8e7360ce5484"
       },
       {
         "id": 10079,
@@ -3174,7 +3579,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ, who has blessed us in the heavenly realms with every spiritual blessing in Christ.",
         "book": "Ephesians",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "25cd3f2672c6a6ed"
       },
       {
         "id": 10080,
@@ -3182,7 +3588,8 @@
         "verse": "Delight yourself in the LORD and he will give you the desires of your heart. Commit your way to the LORD; trust in him and he will do this:",
         "book": "Psalm",
         "reference": "37:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5f19e5534fa2f7ea"
       },
       {
         "id": 10081,
@@ -3190,7 +3597,8 @@
         "verse": "My dear children, I write this to you so that you will not sin. But if anybody does sin, we have one who speaks to the Father in our defense—Jesus Christ, the Righteous One. He is the atoning sacrifice for our sins, and not only for ours but also for the sins of the whole world.",
         "book": "1 John",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "692cffe3a091d7f5"
       },
       {
         "id": 10082,
@@ -3198,7 +3606,8 @@
         "verse": "as far as the east is from the west, so far has he removed our transgressions from us.",
         "book": "Psalm",
         "reference": "103:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5b91eda5d730a0b4"
       },
       {
         "id": 10083,
@@ -3206,7 +3615,8 @@
         "verse": "For the word of God is living and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1abaf7aa796fed7a"
       },
       {
         "id": 10084,
@@ -3214,7 +3624,8 @@
         "verse": "As the rain and the snow come down from heaven, and do not return to it without watering the earth and making it bud and flourish, so that it yields seed for the sower and bread for the eater, so is my word that goes out from my mouth: It will not return to me empty, but will accomplish what I desire and achieve the purpose for which I sent it.",
         "book": "Isaiah",
         "reference": "55:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d7cbbf0256f7201f"
       },
       {
         "id": 10085,
@@ -3222,7 +3633,8 @@
         "verse": "Above all, you must understand that no prophecy of Scripture came about by the prophet's own interpretation. For prophecy never had its origin in the will of man, but men spoke from God as they were carried along by the Holy Spirit.",
         "book": "2 Peter",
         "reference": "1:20-21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "20350effdd439fc0"
       },
       {
         "id": 10086,
@@ -3230,7 +3642,8 @@
         "verse": "And we also thank God continually because, when you received the word of God, which you heard from us, you accepted it not as the word of men, but as it actually is, the word of God, which is at work in you who believe.",
         "book": "1 Thessalonians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6dbe34129bc8feed"
       },
       {
         "id": 10087,
@@ -3238,7 +3651,8 @@
         "verse": "When your words came, I ate them; they were my joy and my heart's delight, for I bear your name, O LORD God Almighty.",
         "book": "Jeremiah",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "76da5408958980a0"
       },
       {
         "id": 10088,
@@ -3246,7 +3660,8 @@
         "verse": "I have not departed from the commands of his lips; I have treasured the words of his mouth more than my daily bread.",
         "book": "Job",
         "reference": "23:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "96115d4dcdaf863d"
       },
       {
         "id": 10089,
@@ -3254,7 +3669,8 @@
         "verse": "Now the Bereans were of more noble character than the Thessalonians, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "86e6550aa5bf9704"
       },
       {
         "id": 10090,
@@ -3262,7 +3678,8 @@
         "verse": "You diligently study the Scriptures because you think that by them you possess eternal life. These are the Scriptures that testify about me, yet you refuse to come to me to have life.",
         "book": "John",
         "reference": "5:39-40",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87370dc5ed549d87"
       },
       {
         "id": 10091,
@@ -3270,7 +3687,17 @@
         "verse": "To the Jews who had believed him, Jesus said, \"If you hold to my teaching, you are really my disciples. Then you will know the truth, and the truth will set you free.\"",
         "book": "John",
         "reference": "8:31-32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c5d3591e1fce395"
+      },
+      {
+        "id": 20003,
+        "title": "Obey",
+        "verse": "Jesus answered, \"It is written: 'Man does not live on bread alone, but on every word that comes from the mouth of God.' \"",
+        "book": "Matthew",
+        "reference": "4:4",
+        "subpack": "",
+        "cardUid": "4668ba1f5984f1be"
       },
       {
         "id": 10092,
@@ -3278,7 +3705,8 @@
         "verse": "Heaven and earth will pass away, but my words will never pass away.",
         "book": "Matthew",
         "reference": "24:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "280e3df0637ff130"
       },
       {
         "id": 10093,
@@ -3286,7 +3714,8 @@
         "verse": "Sanctify them by the truth; your word is truth.",
         "book": "John",
         "reference": "17:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b908bbcdb8145961"
       },
       {
         "id": 10094,
@@ -3294,7 +3723,8 @@
         "verse": "In this you greatly rejoice, though now for a little while you may have had to suffer grief in all kinds of trials. These have come so that your faith—of greater worth than gold, which perishes even though refined by fire—may be proved genuine and may result in praise, glory and honor when Jesus Christ is revealed.",
         "book": "1 Peter",
         "reference": "1:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c371f333631da31e"
       },
       {
         "id": 10095,
@@ -3302,7 +3732,8 @@
         "verse": "Consider it pure joy, my brothers, whenever you face trials of many kinds, because you know that the testing of your faith develops perseverance. Perseverance must finish its work so that you may be mature and complete, not lacking anything.",
         "book": "James",
         "reference": "1:2-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "83e832f8a88050d3"
       },
       {
         "id": 10096,
@@ -3310,7 +3741,8 @@
         "verse": "For we also have had the gospel preached to us, just as they did; but the message they heard was of no value to them, because those who heard did not combine it with faith.",
         "book": "Hebrews",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57b01b90544057f4"
       },
       {
         "id": 10097,
@@ -3318,7 +3750,8 @@
         "verse": "But my righteous one will live by faith. And if he shrinks back, I will not be pleased with him.\"",
         "book": "Hebrews",
         "reference": "10:38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "948aa9d522b1120e"
       },
       {
         "id": 10098,
@@ -3326,7 +3759,8 @@
         "verse": "In addition to all this, take up the shield of faith, with which you can extinguish all the flaming arrows of the evil one.",
         "book": "Ephesians",
         "reference": "6:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "db33ab280862de77"
       },
       {
         "id": 10099,
@@ -3334,7 +3768,8 @@
         "verse": "But you, man of God, flee from all this, and pursue righteousness, godliness, faith, love, endurance and gentleness. Fight the good fight of the faith. Take hold of the eternal life to which you were called when you made your good confession in the presence of many witnesses.",
         "book": "1 Timothy",
         "reference": "6:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "868850efc43ddab2"
       },
       {
         "id": 10100,
@@ -3342,7 +3777,8 @@
         "verse": "Now faith is being sure of what we hope for and certain of what we do not see.",
         "book": "Hebrews",
         "reference": "11:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9d1b38928487cc90"
       },
       {
         "id": 10101,
@@ -3350,7 +3786,8 @@
         "verse": "Consequently, faith comes from hearing the message, and the message is heard through the word of Christ.",
         "book": "Romans",
         "reference": "10:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9bc115188c1202e5"
       },
       {
         "id": 10102,
@@ -3358,7 +3795,8 @@
         "verse": "We do not want you to become lazy, but to imitate those who through faith and patience inherit what has been promised.",
         "book": "Hebrews",
         "reference": "6:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e1f5cbc358126d5d"
       },
       {
         "id": 10103,
@@ -3366,7 +3804,8 @@
         "verse": "In the same way, faith by itself, if it is not accompanied by action, is dead.",
         "book": "James",
         "reference": "2:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "10911412e968ced8"
       },
       {
         "id": 10104,
@@ -3374,7 +3813,8 @@
         "verse": "know that a man is not justified by observing the law, but by faith in Jesus Christ. So we, too, have put our faith in Christ Jesus that we may be justified by faith in Christ and not by observing the law, because by observing the law no one will be justified.",
         "book": "Galatians",
         "reference": "2:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6f3150a9d0bc3da4"
       },
       {
         "id": 10105,
@@ -3382,13 +3822,14 @@
         "verse": "Therefore, since we have been justified through faith, we have peace with God through our Lord Jesus Christ,",
         "book": "Romans",
         "reference": "5:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5ae61635c33dbfc0"
       }
     ]
   },
   {
     "name": "TMS 180 · Walking in Victory",
-    "color": "#BC6C25",
+    "color": "#8E9A3C",
     "accentText": "4",
     "verses": [
       {
@@ -3397,7 +3838,8 @@
         "verse": "But thanks be to God! He gives us the victory through our Lord Jesus Christ.",
         "book": "1 Corinthians",
         "reference": "15:57",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef6c99115ef786a8"
       },
       {
         "id": 10107,
@@ -3405,7 +3847,8 @@
         "verse": "But thanks be to God, who always leads us in triumphal procession in Christ and through us spreads everywhere the fragrance of the knowledge of him.",
         "book": "2 Corinthians",
         "reference": "2:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8d6ce4c3d4eb0f37"
       },
       {
         "id": 10108,
@@ -3413,7 +3856,8 @@
         "verse": "The weapons we fight with are not the weapons of the world. On the contrary, they have divine power to demolish strongholds. We demolish arguments and every pretension that sets itself up against the knowledge of God, and we take captive every thought to make it obedient to Christ.",
         "book": "2 Corinthians",
         "reference": "10:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ab11c93d756bb064"
       },
       {
         "id": 10109,
@@ -3421,7 +3865,8 @@
         "verse": "Finally, be strong in the Lord and in his mighty power. Put on the full armor of God so that you can take your stand against the devil's schemes.",
         "book": "Ephesians",
         "reference": "6:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3f13bfde408474b3"
       },
       {
         "id": 10110,
@@ -3429,7 +3874,8 @@
         "verse": "They overcame him by the blood of the Lamb and by the word of their testimony; they did not love their lives so much as to shrink from death.",
         "book": "Revelation",
         "reference": "12:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d10c20d806e12f0c"
       },
       {
         "id": 10111,
@@ -3437,7 +3883,8 @@
         "verse": "Submit yourselves, then, to God. Resist the devil, and he will flee from you. Come near to God and he will come near to you. Wash your hands, you sinners, and purify your hearts, you double-minded.",
         "book": "James",
         "reference": "4:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b6d5b270920d8bc0"
       },
       {
         "id": 10112,
@@ -3445,7 +3892,8 @@
         "verse": "Those who live according to the sinful nature have their minds set on what that nature desires; but those who live in accordance with the Spirit have their minds set on what the Spirit desires. The mind of sinful man is death, but the mind controlled by the Spirit is life and peace;",
         "book": "Romans",
         "reference": "8:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8c18bfc3c5f8ed00"
       },
       {
         "id": 10113,
@@ -3453,7 +3901,8 @@
         "verse": "Rather, clothe yourselves with the Lord Jesus Christ, and do not think about how to gratify the desires of the sinful nature.",
         "book": "Romans",
         "reference": "13:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "af95e96ed1bd7d3e"
       },
       {
         "id": 10114,
@@ -3461,7 +3910,8 @@
         "verse": "You, dear children, are from God and have overcome them, because the one who is in you is greater than the one who is in the world.",
         "book": "1 John",
         "reference": "4:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61714393f371382a"
       },
       {
         "id": 10115,
@@ -3469,7 +3919,8 @@
         "verse": "for everyone born of God overcomes the world. This is the victory that has overcome the world, even our faith. Who is it that overcomes the world? Only he who believes that Jesus is the Son of God.",
         "book": "1 John",
         "reference": "5:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7de51f8bb243f450"
       },
       {
         "id": 10116,
@@ -3477,7 +3928,8 @@
         "verse": "The law of his God is in his heart; his feet do not slip.",
         "book": "Psalm",
         "reference": "37:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6427e7a6ce996c44"
       },
       {
         "id": 10117,
@@ -3485,7 +3937,8 @@
         "verse": "Therefore do not let sin reign in your mortal body so that you obey its evil desires. Do not offer the parts of your body to sin, as instruments of wickedness, but rather offer yourselves to God, as those who have been brought from death to life; and offer the parts of your body to him as instruments of righteousness.",
         "book": "Romans",
         "reference": "6:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f4e8bf8bcbd51cd1"
       },
       {
         "id": 10118,
@@ -3493,7 +3946,8 @@
         "verse": "Finally, brothers, whatever is true, whatever is noble, whatever is right, whatever is pure, whatever is lovely, whatever is admirable—if anything is excellent or praiseworthy—think about such things.",
         "book": "Philippians",
         "reference": "4:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6c813d6dbaa848c7"
       },
       {
         "id": 10119,
@@ -3501,7 +3955,8 @@
         "verse": "To the pure, all things are pure, but to those who are corrupted and do not believe, nothing is pure. In fact, both their minds and consciences are corrupted.",
         "book": "Titus",
         "reference": "1:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8dffcfa2f90c604a"
       },
       {
         "id": 10120,
@@ -3509,7 +3964,8 @@
         "verse": "The good man brings good things out of the good stored up in his heart, and the evil man brings evil things out of the evil stored up in his heart. For out of the overflow of his heart his mouth speaks.",
         "book": "Luke",
         "reference": "6:45",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "69f78182e31c7a2d"
       },
       {
         "id": 10121,
@@ -3517,7 +3973,8 @@
         "verse": "Above all else, guard your heart, for it is the wellspring of life.",
         "book": "Proverbs",
         "reference": "4:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "490592c80f9eefb9"
       },
       {
         "id": 10122,
@@ -3525,7 +3982,8 @@
         "verse": "\"The eye is the lamp of the body. If your eyes are good, your whole body will be full of light.",
         "book": "Matthew",
         "reference": "6:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb88344e7ad33eca"
       },
       {
         "id": 10123,
@@ -3533,7 +3991,8 @@
         "verse": "But I tell you that anyone who looks at a woman lustfully has already committed adultery with her in his heart.",
         "book": "Matthew",
         "reference": "5:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9e6f2af10e2c4a16"
       },
       {
         "id": 10124,
@@ -3541,7 +4000,8 @@
         "verse": "It is God's will that you should be sanctified: that you should avoid sexual immorality;",
         "book": "1 Thessalonians",
         "reference": "4:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3ce1baf4bc851270"
       },
       {
         "id": 10125,
@@ -3549,7 +4009,8 @@
         "verse": "\"Food for the stomach and the stomach for food\"—but God will destroy them both. The body is not meant for sexual immorality, but for the Lord, and the Lord for the body.",
         "book": "1 Corinthians",
         "reference": "6:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8fe292821bd17612"
       },
       {
         "id": 10126,
@@ -3557,7 +4018,8 @@
         "verse": "Do not let any unwholesome talk come out of your mouths, but only what is helpful for building others up according to their needs, that it may benefit those who listen.",
         "book": "Ephesians",
         "reference": "4:29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d7921a27159b212e"
       },
       {
         "id": 10127,
@@ -3565,7 +4027,8 @@
         "verse": "But I tell you that men will have to give account on the day of judgment for every careless word they have spoken. For by your words you will be acquitted, and by your words you will be condemned.\"",
         "book": "Matthew",
         "reference": "12:36-37",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8a2f67d1c9858cf9"
       },
       {
         "id": 10128,
@@ -3573,7 +4036,8 @@
         "verse": "Avoid every kind of evil.",
         "book": "1 Thessalonians",
         "reference": "5:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0ac40c30429e4bbe"
       },
       {
         "id": 10129,
@@ -3581,7 +4045,8 @@
         "verse": "Do not rebuke an older man harshly, but exhort him as if he were your father. Treat younger men as brothers, older women as mothers, and younger women as sisters, with absolute purity.",
         "book": "1 Timothy",
         "reference": "5:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3622acb13fa16041"
       },
       {
         "id": 10130,
@@ -3589,7 +4054,8 @@
         "verse": "If you believe, you will receive whatever you ask for in prayer.\"",
         "book": "Matthew",
         "reference": "21:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d8e4fa462c36c12c"
       },
       {
         "id": 10131,
@@ -3597,7 +4063,8 @@
         "verse": "\"Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; he who seeks finds; and to him who knocks, the door will be opened.",
         "book": "Matthew",
         "reference": "7:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dbfd98060dcce681"
       },
       {
         "id": 10132,
@@ -3605,7 +4072,8 @@
         "verse": "But when you pray, go into your room, close the door and pray to your Father, who is unseen. Then your Father, who sees what is done in secret, will reward you.",
         "book": "Matthew",
         "reference": "6:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fe37a295cf9d21d4"
       },
       {
         "id": 10133,
@@ -3613,7 +4081,8 @@
         "verse": "Very early in the morning, while it was still dark, Jesus got up, left the house and went off to a solitary place, where he prayed.",
         "book": "Mark",
         "reference": "1:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "17903a9c2ecb61d8"
       },
       {
         "id": 10134,
@@ -3621,7 +4090,8 @@
         "verse": "'Call to me and I will answer you and tell you great and unsearchable things you do not know.'",
         "book": "Jeremiah",
         "reference": "33:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "72db4a4990f5a4d3"
       },
       {
         "id": 10135,
@@ -3629,7 +4099,8 @@
         "verse": "Now to him who is able to do immeasurably more than all we ask or imagine, according to his power that is at work within us,",
         "book": "Ephesians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a1910f617cadeb45"
       },
       {
         "id": 10136,
@@ -3637,7 +4108,8 @@
         "verse": "This is the confidence we have in approaching God: that if we ask anything according to his will, he hears us. And if we know that he hears us—whatever we ask—we know that we have what we asked of him.",
         "book": "1 John",
         "reference": "5:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0e1c038620d70bcb"
       },
       {
         "id": 10137,
@@ -3645,7 +4117,8 @@
         "verse": "pray continually; give thanks in all circumstances, for this is God's will for you in Christ Jesus.",
         "book": "1 Thessalonians",
         "reference": "5:17-18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b7b2f14446f05d48"
       },
       {
         "id": 10138,
@@ -3653,7 +4126,8 @@
         "verse": "As for me, far be it from me that I should sin against the LORD by failing to pray for you. And I will teach you the way that is good and right.",
         "book": "1 Samuel",
         "reference": "12:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fa5b4c14979333b6"
       },
       {
         "id": 10139,
@@ -3661,7 +4135,8 @@
         "verse": "Then he said to his disciples, \"The harvest is plentiful but the workers are few. Ask the Lord of the harvest, therefore, to send out workers into his harvest field.\"",
         "book": "Matthew",
         "reference": "9:37-38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7cee46d467f5d565"
       },
       {
         "id": 10140,
@@ -3669,7 +4144,8 @@
         "verse": "Through Jesus, therefore, let us continually offer to God a sacrifice of praise—the fruit of lips that confess his name.",
         "book": "Hebrews",
         "reference": "13:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "396c741fc9c6e29c"
       },
       {
         "id": 10141,
@@ -3677,13 +4153,14 @@
         "verse": "Praise the LORD. Praise the LORD, O my soul. I will praise the LORD all my life; I will sing praise to my God as long as I live.",
         "book": "Psalm",
         "reference": "146:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d47cb34c1082651e"
       }
     ]
   },
   {
     "name": "TMS 180 · Sharing Christ with Others",
-    "color": "#277DA1",
+    "color": "#D9925C",
     "accentText": "5",
     "verses": [
       {
@@ -3692,7 +4169,8 @@
         "verse": "To them God has chosen to make known among the Gentiles the glorious riches of this mystery, which is Christ in you, the hope of glory. We proclaim him, admonishing and teaching everyone with all wisdom, so that we may present everyone perfect in Christ.",
         "book": "Colossians",
         "reference": "1:27-28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2d8f6a42022b4fac"
       },
       {
         "id": 10143,
@@ -3700,7 +4178,8 @@
         "verse": "that God was reconciling the world to himself in Christ, not counting men's sins against them. And he has committed to us the message of reconciliation. We are therefore Christ's ambassadors, as though God were making his appeal through us. We implore you on Christ's behalf: Be reconciled to God.",
         "book": "2 Corinthians",
         "reference": "5:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "79bc265815fe3cf9"
       },
       {
         "id": 10144,
@@ -3708,7 +4187,8 @@
         "verse": "On the contrary, we speak as men approved by God to be entrusted with the gospel. We are not trying to please men but God, who tests our hearts.",
         "book": "1 Thessalonians",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "29658bfc39ef6394"
       },
       {
         "id": 10145,
@@ -3716,7 +4196,8 @@
         "verse": "Though I am free and belong to no man, I make myself a slave to everyone, to win as many as possible.",
         "book": "1 Corinthians",
         "reference": "9:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7b857eb429d1d40e"
       },
       {
         "id": 10146,
@@ -3724,7 +4205,8 @@
         "verse": "Do you not say, 'Four months more and then the harvest'? I tell you, open your eyes and look at the fields! They are ripe for harvest.",
         "book": "John",
         "reference": "4:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7a0695f18c11f66c"
       },
       {
         "id": 10147,
@@ -3732,7 +4214,8 @@
         "verse": "We loved you so much that we were delighted to share with you not only the gospel of God but our lives as well, because you had become so dear to us.",
         "book": "1 Thessalonians",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "11d5b9f231cbc1d7"
       },
       {
         "id": 10148,
@@ -3740,7 +4223,8 @@
         "verse": "As it is written: \"There is no one righteous, not even one; there is no one who understands, no one who seeks God. All have turned away, they have together become worthless; there is no one who does good, not even one.\"",
         "book": "Romans",
         "reference": "3:10-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "02796341ce14ceb2"
       },
       {
         "id": 10149,
@@ -3748,7 +4232,8 @@
         "verse": "He will punish those who do not know God and do not obey the gospel of our Lord Jesus. They will be punished with everlasting destruction and shut out from the presence of the Lord and from the majesty of his power",
         "book": "2 Thessalonians",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cadae55e55fb7885"
       },
       {
         "id": 10150,
@@ -3756,7 +4241,8 @@
         "verse": "He himself bore our sins in his body on the tree, so that we might die to sins and live for righteousness; by his wounds you have been healed.",
         "book": "1 Peter",
         "reference": "2:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4dfdaa57ba457f40"
       },
       {
         "id": 10151,
@@ -3764,7 +4250,8 @@
         "verse": "who has saved us and called us to a holy life—not because of anything we have done but because of his own purpose and grace. This grace was given us in Christ Jesus before the beginning of time,",
         "book": "2 Timothy",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c15a1d646552214e"
       },
       {
         "id": 10152,
@@ -3772,7 +4259,8 @@
         "verse": "That if you confess with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you confess and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d4c353e0a264a83e"
       },
       {
         "id": 10153,
@@ -3780,7 +4268,8 @@
         "verse": "I give them eternal life, and they shall never perish; no one can snatch them out of my hand. My Father, who has given them to me, is greater than all; no one can snatch them out of my Father's hand.",
         "book": "John",
         "reference": "10:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "09068f9544a53662"
       },
       {
         "id": 10154,
@@ -3788,7 +4277,8 @@
         "verse": "All a man's ways seem right to him, but the LORD weighs the heart.",
         "book": "Proverbs",
         "reference": "21:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1af4487bab249a9c"
       },
       {
         "id": 10155,
@@ -3796,7 +4286,8 @@
         "verse": "What good is it for a man to gain the whole world, yet forfeit his soul?",
         "book": "Mark",
         "reference": "8:36",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f876bef822c59b06"
       },
       {
         "id": 10156,
@@ -3804,7 +4295,8 @@
         "verse": "If anyone chooses to do God's will, he will find out whether my teaching comes from God or whether I speak on my own.",
         "book": "John",
         "reference": "7:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "418086039ff57dc3"
       },
       {
         "id": 10157,
@@ -3812,7 +4304,8 @@
         "verse": "Jesus answered them, \"It is not the healthy who need a doctor, but the sick. I have not come to call the righteous, but sinners to repentance.\"",
         "book": "Luke",
         "reference": "5:31-32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70040b779965a43c"
       },
       {
         "id": 10158,
@@ -3820,7 +4313,8 @@
         "verse": "How can you believe if you accept praise from one another, yet make no effort to obtain the praise that comes from the only God?",
         "book": "John",
         "reference": "5:44",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f730075719c00814"
       },
       {
         "id": 10159,
@@ -3828,7 +4322,8 @@
         "verse": "Therefore he is able to save completely those who come to God through him, because he always lives to intercede for them.",
         "book": "Hebrews",
         "reference": "7:25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4d949afb30fea4b3"
       },
       {
         "id": 10160,
@@ -3836,7 +4331,8 @@
         "verse": "Do not boast about tomorrow, for you do not know what a day may bring forth.",
         "book": "Proverbs",
         "reference": "27:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ed25837ecf494348"
       },
       {
         "id": 10161,
@@ -3844,7 +4340,8 @@
         "verse": "So then, each of us will give an account of himself to God.",
         "book": "Romans",
         "reference": "14:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "553bb10cea9b3131"
       },
       {
         "id": 10162,
@@ -3852,7 +4349,8 @@
         "verse": "You diligently study the Scriptures because you think that by them you possess eternal life. These are the Scriptures that testify about me,",
         "book": "John",
         "reference": "5:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "aa4048b283e6efe8"
       },
       {
         "id": 10163,
@@ -3860,7 +4358,17 @@
         "verse": "There is a way that seems right to a man, but in the end it leads to death.",
         "book": "Proverbs",
         "reference": "14:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dcd1353504785dec"
+      },
+      {
+        "id": 20004,
+        "title": "God Won't Send Anyone to Hell",
+        "verse": "\"Then he will say to those on his left, 'Depart from me, you who are cursed, into the eternal fire prepared for the devil and his angels.",
+        "book": "Matthew",
+        "reference": "25:41",
+        "subpack": "",
+        "cardUid": "fa49520b7758dc6f"
       },
       {
         "id": 10164,
@@ -3868,7 +4376,8 @@
         "verse": "For since the creation of the world God's invisible qualities—his eternal power and divine nature—have been clearly seen, being understood from what has been made, so that men are without excuse.",
         "book": "Romans",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3ebb7a5a67e9f8cb"
       },
       {
         "id": 10165,
@@ -3876,7 +4385,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your forefathers, but with the precious blood of Christ, a lamb without blemish or defect.",
         "book": "1 Peter",
         "reference": "1:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "485db829f2e09ccc"
       },
       {
         "id": 10166,
@@ -3884,7 +4394,8 @@
         "verse": "All this is from God, who reconciled us to himself through Christ and gave us the ministry of reconciliation:",
         "book": "2 Corinthians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8e7d2b351b78ec2"
       },
       {
         "id": 10167,
@@ -3892,7 +4403,8 @@
         "verse": "In him we have redemption through his blood, the forgiveness of sins, in accordance with the riches of God's grace",
         "book": "Ephesians",
         "reference": "1:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c87d19b4c2a8d0f4"
       },
       {
         "id": 10168,
@@ -3900,7 +4412,8 @@
         "verse": "For sin shall not be your master, because you are not under law, but under grace. What then? Shall we sin because we are not under law but under grace? By no means!",
         "book": "Romans",
         "reference": "6:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61526805bbcdd38e"
       },
       {
         "id": 10169,
@@ -3908,7 +4421,8 @@
         "verse": "You are all sons of God through faith in Christ Jesus,",
         "book": "Galatians",
         "reference": "3:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f894c2e7cb721d7d"
       },
       {
         "id": 10170,
@@ -3916,7 +4430,8 @@
         "verse": "But you are a chosen people, a royal priesthood, a holy nation, a people belonging to God, that you may declare the praises of him who called you out of darkness into his wonderful light.",
         "book": "1 Peter",
         "reference": "2:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "716b640fd19e2c92"
       },
       {
         "id": 10171,
@@ -3924,7 +4439,8 @@
         "verse": "God made him who had no sin to be sin for us, so that in him we might become the righteousness of God.",
         "book": "2 Corinthians",
         "reference": "5:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0097805421838754"
       },
       {
         "id": 10172,
@@ -3932,7 +4448,8 @@
         "verse": "It is because of him that you are in Christ Jesus, who has become for us wisdom from God—that is, our righteousness, holiness and redemption.",
         "book": "1 Corinthians",
         "reference": "1:30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c130b394973678e"
       },
       {
         "id": 10173,
@@ -3940,7 +4457,8 @@
         "verse": "because by one sacrifice he has made perfect forever those who are being made holy.",
         "book": "Hebrews",
         "reference": "10:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "34454e430a4ecbe6"
       },
       {
         "id": 10174,
@@ -3948,7 +4466,8 @@
         "verse": "and are justified freely by his grace through the redemption that came by Christ Jesus.",
         "book": "Romans",
         "reference": "3:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "011f81407de1aca9"
       },
       {
         "id": 10175,
@@ -3956,7 +4475,8 @@
         "verse": "But our citizenship is in heaven. And we eagerly await a Savior from there, the Lord Jesus Christ,",
         "book": "Philippians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f94f3170e8b1b787"
       },
       {
         "id": 10176,
@@ -3964,7 +4484,8 @@
         "verse": "For in Christ all the fullness of the Deity lives in bodily form, and you have been given fullness in Christ, who is the head over every power and authority.",
         "book": "Colossians",
         "reference": "2:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70c389041d50c7bb"
       }
     ]
   }

--- a/scripture memory/Resources/verseDataNIV11.json
+++ b/scripture memory/Resources/verseDataNIV11.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "5 Assurances",
-    "color": "#ff7f50",
+    "color": "#7FA23C",
     "accentText": "5",
     "verses": [
       {
@@ -10,7 +10,8 @@
         "verse": "And this is the testimony: God has given us eternal life, and this life is in his Son. Whoever has the Son has life; whoever does not have the Son of God does not have life.",
         "book": "1 John",
         "reference": "5:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fb7aabf3e66b755f"
       },
       {
         "id": 2,
@@ -18,7 +19,8 @@
         "verse": "Until now you have not asked for anything in my name. Ask and you will receive, and your joy will be complete.",
         "book": "John",
         "reference": "16:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "01fc8d676ac96c6c"
       },
       {
         "id": 3,
@@ -26,7 +28,8 @@
         "verse": "No temptation has overtaken you except what is common to mankind. And God is faithful; he will not let you be tempted beyond what you can bear. But when you are tempted, he will also provide a way out so that you can endure it.",
         "book": "1 Corinthians",
         "reference": "10:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c91123b93df2df7e"
       },
       {
         "id": 4,
@@ -34,7 +37,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b8e7f6a946673b5c"
       },
       {
         "id": 5,
@@ -42,7 +46,8 @@
         "verse": "Trust in the Lord with all your heart and lean not on your own understanding; in all your ways submit to him, and he will make your paths straight.",
         "book": "Proverbs",
         "reference": "3:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c32b24cdb10f31d"
       }
     ]
   },
@@ -57,7 +62,8 @@
         "verse": "Therefore, if anyone is in Christ, the new creation has come: The old has gone, the new is here!",
         "book": "2 Corinthians",
         "reference": "5:17",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "53b7f282e8db4d0d"
       },
       {
         "id": 12,
@@ -65,7 +71,8 @@
         "verse": "I have been crucified with Christ and I no longer live, but Christ lives in me. The life I now live in the body, I live by faith in the Son of God, who loved me and gave himself for me.",
         "book": "Galatians",
         "reference": "2:20",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "abc5fccfb66e8c14"
       },
       {
         "id": 13,
@@ -73,7 +80,8 @@
         "verse": "Therefore, I urge you, brothers and sisters, in view of God's mercy, to offer your bodies as a living sacrifice, holy and pleasing to God—this is your true and proper worship.",
         "book": "Romans",
         "reference": "12:1",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "5887cf7e17ef94b3"
       },
       {
         "id": 14,
@@ -81,7 +89,8 @@
         "verse": "Whoever has my commands and keeps them is the one who loves me. The one who loves me will be loved by my Father, and I too will love them and show myself to them.",
         "book": "John",
         "reference": "14:21",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "838b46c6d3fe8b41"
       },
       {
         "id": 15,
@@ -89,7 +98,8 @@
         "verse": "All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness,",
         "book": "2 Timothy",
         "reference": "3:16",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "47991ecef8531919"
       },
       {
         "id": 16,
@@ -97,7 +107,8 @@
         "verse": "Keep this Book of the Law always on your lips; meditate on it day and night, so that you may be careful to do everything written in it. Then you will be prosperous and successful.",
         "book": "Joshua",
         "reference": "1:8",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "d30f59c977460049"
       },
       {
         "id": 17,
@@ -105,7 +116,8 @@
         "verse": "If you remain in me and my words remain in you, ask whatever you wish, and it will be done for you.",
         "book": "John",
         "reference": "15:7",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "85dea192cd6d36f4"
       },
       {
         "id": 18,
@@ -113,7 +125,8 @@
         "verse": "Do not be anxious about anything, but in every situation, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:6-7",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "562305394528284f"
       },
       {
         "id": 19,
@@ -121,7 +134,8 @@
         "verse": "For where two or three gather in my name, there am I with them.",
         "book": "Matthew",
         "reference": "18:20",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "46608870776328c5"
       },
       {
         "id": 20,
@@ -129,7 +143,8 @@
         "verse": "And let us consider how we may spur one another on toward love and good deeds, not giving up meeting together, as some are in the habit of doing, but encouraging one another—and all the more as you see the Day approaching.",
         "book": "Hebrews",
         "reference": "10:24-25",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "eb451a402d0e4159"
       },
       {
         "id": 21,
@@ -137,7 +152,8 @@
         "verse": "\"Come, follow me,\" Jesus said, \"and I will send you out to fish for people.\"",
         "book": "Matthew",
         "reference": "4:19",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "8af4b22a031ac015"
       },
       {
         "id": 22,
@@ -145,7 +161,8 @@
         "verse": "For I am not ashamed of the gospel, because it is the power of God that brings salvation to everyone who believes: first to the Jew, then to the Gentile.",
         "book": "Romans",
         "reference": "1:16",
-        "subpack": "A"
+        "subpack": "A",
+        "cardUid": "30dcd7c855eb750e"
       },
       {
         "id": 31,
@@ -153,7 +170,8 @@
         "verse": "for all have sinned and fall short of the glory of God,",
         "book": "Romans",
         "reference": "3:23",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "231c64df0c7f4a01"
       },
       {
         "id": 32,
@@ -161,7 +179,8 @@
         "verse": "We all, like sheep, have gone astray, each of us has turned to our own way; and the Lord has laid on him the iniquity of us all.",
         "book": "Isaiah",
         "reference": "53:6",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "0dc817b15fe06097"
       },
       {
         "id": 33,
@@ -169,7 +188,8 @@
         "verse": "For the wages of sin is death, but the gift of God is eternal life in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "6:23",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "7265b7d0775f29a9"
       },
       {
         "id": 34,
@@ -177,7 +197,8 @@
         "verse": "Just as people are destined to die once, and after that to face judgment,",
         "book": "Hebrews",
         "reference": "9:27",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "e0988cac53b19e29"
       },
       {
         "id": 35,
@@ -185,7 +206,8 @@
         "verse": "But God demonstrates his own love for us in this: While we were still sinners, Christ died for us.",
         "book": "Romans",
         "reference": "5:8",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "35bc616433dc90ff"
       },
       {
         "id": 36,
@@ -193,7 +215,8 @@
         "verse": "For Christ also suffered once for sins, the righteous for the unrighteous, to bring you to God. He was put to death in the body but made alive in the Spirit.",
         "book": "1 Peter",
         "reference": "3:18",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "6e971140dffdb60a"
       },
       {
         "id": 37,
@@ -201,7 +224,8 @@
         "verse": "For it is by grace you have been saved, through faith—and this is not from yourselves, it is the gift of God— not by works, so that no one can boast.",
         "book": "Ephesians",
         "reference": "2:8-9",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "8b983188fd0b6aa4"
       },
       {
         "id": 38,
@@ -209,7 +233,8 @@
         "verse": "he saved us, not because of righteous things we had done, but because of his mercy. He saved us through the washing of rebirth and renewal by the Holy Spirit,",
         "book": "Titus",
         "reference": "3:5",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "bdd9f73f2124968e"
       },
       {
         "id": 39,
@@ -217,7 +242,8 @@
         "verse": "Yet to all who did receive him, to those who believed in his name, he gave the right to become children of God—",
         "book": "John",
         "reference": "1:12",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "9eddec605ec52aa7"
       },
       {
         "id": 40,
@@ -225,7 +251,8 @@
         "verse": "Here I am! I stand at the door and knock. If anyone hears my voice and opens the door, I will come in and eat with that person, and they with me.",
         "book": "Revelation",
         "reference": "3:20",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "34d348cd32d990a1"
       },
       {
         "id": 41,
@@ -233,7 +260,8 @@
         "verse": "I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.",
         "book": "1 John",
         "reference": "5:13",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "bf74e67d86182c89"
       },
       {
         "id": 42,
@@ -241,7 +269,8 @@
         "verse": "\"Very truly I tell you, whoever hears my word and believes him who sent me has eternal life and will not be judged but has crossed over from death to life.\"",
         "book": "John",
         "reference": "5:24",
-        "subpack": "B"
+        "subpack": "B",
+        "cardUid": "c87a17e2d505bde8"
       },
       {
         "id": 51,
@@ -249,7 +278,8 @@
         "verse": "Don't you know that you yourselves are God's temple and that God's Spirit dwells in your midst?",
         "book": "1 Corinthians",
         "reference": "3:16",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "7f8dd7d587baa579"
       },
       {
         "id": 52,
@@ -257,7 +287,8 @@
         "verse": "What we have received is not the spirit of the world, but the Spirit who is from God, so that we may understand what God has freely given us.",
         "book": "1 Corinthians",
         "reference": "2:12",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "5bf5dd6b94a7fb33"
       },
       {
         "id": 53,
@@ -265,7 +296,8 @@
         "verse": "So do not fear, for I am with you; do not be dismayed, for I am your God. I will strengthen you and help you; I will uphold you with my righteous right hand.",
         "book": "Isaiah",
         "reference": "41:10",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "eb6a7e3bf0a647d7"
       },
       {
         "id": 54,
@@ -273,7 +305,8 @@
         "verse": "I can do all this through him who gives me strength.",
         "book": "Philippians",
         "reference": "4:13",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "37608aa5debc6a44"
       },
       {
         "id": 55,
@@ -281,7 +314,8 @@
         "verse": "Because of the Lord's great love we are not consumed, for his compassions never fail. They are new every morning; great is your faithfulness.",
         "book": "Lamentations",
         "reference": "3:22-23",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "eeaed8f34fa04572"
       },
       {
         "id": 56,
@@ -289,7 +323,8 @@
         "verse": "God is not human, that he should lie, not a human being, that he should change his mind. Does he speak and then not act? Does he promise and not fulfill?",
         "book": "Numbers",
         "reference": "23:19",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "2bc7e82bd320dea4"
       },
       {
         "id": 57,
@@ -297,7 +332,8 @@
         "verse": "You will keep in perfect peace those whose minds are steadfast, because they trust in you.",
         "book": "Isaiah",
         "reference": "26:3",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "61d5a30a41db651b"
       },
       {
         "id": 58,
@@ -305,7 +341,8 @@
         "verse": "Cast all your anxiety on him because he cares for you.",
         "book": "1 Peter",
         "reference": "5:7",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "c9991056657dbe0d"
       },
       {
         "id": 59,
@@ -313,7 +350,8 @@
         "verse": "He who did not spare his own Son, but gave him up for us all—how will he not also, along with him, graciously give us all things?",
         "book": "Romans",
         "reference": "8:32",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "02e10c5e7b88b61b"
       },
       {
         "id": 60,
@@ -321,7 +359,8 @@
         "verse": "And my God will meet all your needs according to the riches of his glory in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:19",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "6a148ad77d80b512"
       },
       {
         "id": 61,
@@ -329,7 +368,8 @@
         "verse": "Because he himself suffered when he was tempted, he is able to help those who are being tempted.",
         "book": "Hebrews",
         "reference": "2:18",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "8ffaf0c764684e46"
       },
       {
         "id": 62,
@@ -337,7 +377,8 @@
         "verse": "How can a young person stay on the path of purity? By living according to your word. I have hidden your word in my heart that I might not sin against you.",
         "book": "Psalm",
         "reference": "119:9, 11",
-        "subpack": "C"
+        "subpack": "C",
+        "cardUid": "6d79dd06e97ed827"
       },
       {
         "id": 71,
@@ -345,7 +386,8 @@
         "verse": "But seek first his kingdom and his righteousness, and all these things will be given to you as well.",
         "book": "Matthew",
         "reference": "6:33",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8e04f9616557a02d"
       },
       {
         "id": 72,
@@ -353,7 +395,8 @@
         "verse": "Then he said to them all: \"Whoever wants to be my disciple must deny themselves and take up their cross daily and follow me.\"",
         "book": "Luke",
         "reference": "9:23",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "2f0870229caa1861"
       },
       {
         "id": 73,
@@ -361,7 +404,8 @@
         "verse": "Do not love the world or anything in the world. If anyone loves the world, love for the Father is not in them. For everything in the world—the lust of the flesh, the lust of the eyes, and the pride of life—comes not from the Father but from the world.",
         "book": "1 John",
         "reference": "2:15-16",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8c133f82ddf2c9a3"
       },
       {
         "id": 74,
@@ -369,7 +413,8 @@
         "verse": "Do not conform to the pattern of this world, but be transformed by the renewing of your mind. Then you will be able to test and approve what God's will is—his good, pleasing and perfect will.",
         "book": "Romans",
         "reference": "12:2",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "5ccf3f464bc71678"
       },
       {
         "id": 75,
@@ -377,7 +422,8 @@
         "verse": "Therefore, my dear brothers and sisters, stand firm. Let nothing move you. Always give yourselves fully to the work of the Lord, because you know that your labor in the Lord is not in vain.",
         "book": "1 Corinthians",
         "reference": "15:58",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "38809a8ee4625c35"
       },
       {
         "id": 76,
@@ -385,7 +431,8 @@
         "verse": "Consider him who endured such opposition from sinners, so that you will not grow weary and lose heart.",
         "book": "Hebrews",
         "reference": "12:3",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "0ba0e96ab20782ec"
       },
       {
         "id": 77,
@@ -393,7 +440,8 @@
         "verse": "For even the Son of Man did not come to be served, but to serve, and to give his life as a ransom for many.",
         "book": "Mark",
         "reference": "10:45",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "ed03829732f65aaa"
       },
       {
         "id": 78,
@@ -401,7 +449,8 @@
         "verse": "For what we preach is not ourselves, but Jesus Christ as Lord, and ourselves as your servants for Jesus' sake.",
         "book": "2 Corinthians",
         "reference": "4:5",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "8d92ff0adf25db9f"
       },
       {
         "id": 79,
@@ -409,7 +458,8 @@
         "verse": "Honor the Lord with your wealth, with the firstfruits of all your crops; then your barns will be filled to overflowing, and your vats will brim over with new wine.",
         "book": "Proverbs",
         "reference": "3:9-10",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "81bab1223673735b"
       },
       {
         "id": 80,
@@ -417,7 +467,8 @@
         "verse": "Remember this: Whoever sows sparingly will also reap sparingly, and whoever sows generously will also reap generously. Each of you should give what you have decided in your heart to give, not reluctantly or under compulsion, for God loves a cheerful giver.",
         "book": "2 Corinthians",
         "reference": "9:6-7",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "1d99e5849dd8a561"
       },
       {
         "id": 81,
@@ -425,7 +476,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "966a7aedcdf41bf4"
       },
       {
         "id": 82,
@@ -433,7 +485,8 @@
         "verse": "Therefore go and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, and teaching them to obey everything I have commanded you. And surely I am with you always, to the very end of the age.",
         "book": "Matthew",
         "reference": "28:19-20",
-        "subpack": "D"
+        "subpack": "D",
+        "cardUid": "90d9a3fdf0884281"
       },
       {
         "id": 91,
@@ -441,7 +494,8 @@
         "verse": "A new command I give you: Love one another. As I have loved you, so you must love one another. By this everyone will know that you are my disciples, if you love one another.",
         "book": "John",
         "reference": "13:34-35",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "9174078704200578"
       },
       {
         "id": 92,
@@ -449,7 +503,8 @@
         "verse": "Dear children, let us not love with words or speech but with actions and in truth.",
         "book": "1 John",
         "reference": "3:18",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "19dc4033735f46e6"
       },
       {
         "id": 93,
@@ -457,7 +512,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit. Rather, in humility value others above yourselves, not looking to your own interests but each of you to the interests of the others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "6a408d83f2fd0458"
       },
       {
         "id": 94,
@@ -465,7 +521,8 @@
         "verse": "All of you, clothe yourselves with humility toward one another, because God opposes the proud but shows favor to the humble. Humble yourselves, therefore, under God's mighty hand, that he may lift you up in due time.",
         "book": "1 Peter",
         "reference": "5:5-6",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "389b7246404883b7"
       },
       {
         "id": 95,
@@ -473,7 +530,8 @@
         "verse": "But among you there must not be even a hint of sexual immorality, or of any kind of impurity, or of greed, because these are improper for God's holy people.",
         "book": "Ephesians",
         "reference": "5:3",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "d73ed31c598b149d"
       },
       {
         "id": 96,
@@ -481,7 +539,8 @@
         "verse": "Dear friends, I urge you, as foreigners and exiles, to abstain from sinful desires, which wage war against your soul.",
         "book": "1 Peter",
         "reference": "2:11",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "ae32bc994c08d3da"
       },
       {
         "id": 97,
@@ -489,7 +548,8 @@
         "verse": "Do not steal. Do not lie. Do not deceive one another.",
         "book": "Leviticus",
         "reference": "19:11",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "bd9061d90bf42f4d"
       },
       {
         "id": 98,
@@ -497,7 +557,8 @@
         "verse": "So I strive always to keep my conscience clear before God and man.",
         "book": "Acts",
         "reference": "24:16",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "4ad12cf7a062aa2e"
       },
       {
         "id": 99,
@@ -505,7 +566,8 @@
         "verse": "And without faith it is impossible to please God, because anyone who comes to him must believe that he exists and that he rewards those who earnestly seek him.",
         "book": "Hebrews",
         "reference": "11:6",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "3f703d666890bed4"
       },
       {
         "id": 100,
@@ -513,7 +575,8 @@
         "verse": "Yet he did not waver through unbelief regarding the promise of God, but was strengthened in his faith and gave glory to God, being fully persuaded that God had the power to do what he had promised.",
         "book": "Romans",
         "reference": "4:20-21",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "7bae649880268eb2"
       },
       {
         "id": 101,
@@ -521,7 +584,8 @@
         "verse": "Let us not become weary in doing good, for at the proper time we will reap a harvest if we do not give up. Therefore, as we have opportunity, let us do good to all people, especially to those who belong to the family of believers.",
         "book": "Galatians",
         "reference": "6:9-10",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "051e68aa7a21d9d2"
       },
       {
         "id": 102,
@@ -529,13 +593,14 @@
         "verse": "In the same way, let your light shine before others, that they may see your good deeds and glorify your Father in heaven.",
         "book": "Matthew",
         "reference": "5:16",
-        "subpack": "E"
+        "subpack": "E",
+        "cardUid": "08094b02b5ae4429"
       }
     ]
   },
   {
     "name": "DEP 1: Assurance of Salvation",
-    "color": "#0a1fbe",
+    "color": "#F4F2ED",
     "accentText": "1",
     "verses": [
       {
@@ -544,7 +609,8 @@
         "verse": "Examine yourselves to see whether you are in the faith; test yourselves. Do you not realize that Christ Jesus is in you—unless, of course, you fail the test?",
         "book": "2 Corinthians",
         "reference": "13:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0e2bab06044065ed"
       },
       {
         "id": 2102,
@@ -552,7 +618,8 @@
         "verse": "And this is the testimony: God has given us eternal life, and this life is in his Son. Whoever has the Son has life; whoever does not have the Son of God does not have life.",
         "book": "1 John",
         "reference": "5:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "155e176802031f30"
       },
       {
         "id": 2103,
@@ -560,7 +627,8 @@
         "verse": "I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.",
         "book": "1 John",
         "reference": "5:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "24f285489498cf08"
       },
       {
         "id": 2104,
@@ -568,7 +636,8 @@
         "verse": "Very truly I tell you, the one who believes has eternal life.",
         "book": "John",
         "reference": "6:47",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce4dae5f20085e0e"
       },
       {
         "id": 2105,
@@ -576,7 +645,8 @@
         "verse": "In him we have redemption through his blood, the forgiveness of sins, in accordance with the riches of God's grace",
         "book": "Ephesians",
         "reference": "1:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "356bf23affe195dc"
       },
       {
         "id": 2106,
@@ -584,7 +654,8 @@
         "verse": "Therefore, there is now no condemnation for those who are in Christ Jesus,",
         "book": "Romans",
         "reference": "8:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "124dcae76ec1de3c"
       },
       {
         "id": 2107,
@@ -592,7 +663,8 @@
         "verse": "and all are justified freely by his grace through the redemption that came by Christ Jesus.",
         "book": "Romans",
         "reference": "3:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d19a3af57928844f"
       },
       {
         "id": 2108,
@@ -600,7 +672,8 @@
         "verse": "Therefore, since we have been justified through faith, we have peace with God through our Lord Jesus Christ,",
         "book": "Romans",
         "reference": "5:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "177610a779cfe686"
       },
       {
         "id": 2109,
@@ -608,7 +681,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ! In his great mercy he has given us new birth into a living hope through the resurrection of Jesus Christ from the dead,",
         "book": "1 Peter",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4affcbadc906794e"
       },
       {
         "id": 2110,
@@ -616,7 +690,8 @@
         "verse": "he saved us, not because of righteous things we had done, but because of his mercy. He saved us through the washing of rebirth and renewal by the Holy Spirit,",
         "book": "Titus",
         "reference": "3:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0b9ab87550629a32"
       },
       {
         "id": 2111,
@@ -624,7 +699,8 @@
         "verse": "So in Christ Jesus you are all children of God through faith,",
         "book": "Galatians",
         "reference": "3:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f24f86d449d5956a"
       },
       {
         "id": 2112,
@@ -632,7 +708,8 @@
         "verse": "For those who are led by the Spirit of God are the children of God.",
         "book": "Romans",
         "reference": "8:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2653c8e785a182ff"
       },
       {
         "id": 2113,
@@ -640,7 +717,8 @@
         "verse": "You, however, are not in the realm of the flesh but are in the realm of the Spirit, if indeed the Spirit of God lives in you. And if anyone does not have the Spirit of Christ, they do not belong to Christ.",
         "book": "Romans",
         "reference": "8:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1279a17374989e96"
       },
       {
         "id": 2114,
@@ -648,7 +726,8 @@
         "verse": "And I will ask the Father, and he will give you another advocate to help you and be with you forever— the Spirit of truth. The world cannot accept him, because it neither sees him nor knows him. But you know him, for he lives with you and will be in you.",
         "book": "John",
         "reference": "14:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "faff1c45e55487a4"
       },
       {
         "id": 2115,
@@ -656,7 +735,8 @@
         "verse": "I give them eternal life, and they shall never perish; no one will snatch them out of my hand. My Father, who has given them to me, is greater than all; no one can snatch them out of my Father's hand.",
         "book": "John",
         "reference": "10:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e555e2f95c975096"
       },
       {
         "id": 2116,
@@ -664,7 +744,8 @@
         "verse": "neither height nor depth, nor anything else in all creation, will be able to separate us from the love of God that is in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "8:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "588208e5b2268765"
       },
       {
         "id": 2117,
@@ -672,7 +753,8 @@
         "verse": "For you have been born again, not of perishable seed, but of imperishable, through the living and enduring word of God.",
         "book": "1 Peter",
         "reference": "1:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89110f6e275ec935"
       },
       {
         "id": 2118,
@@ -680,13 +762,14 @@
         "verse": "And you also were included in Christ when you heard the message of truth, the gospel of your salvation. When you believed, you were marked in him with a seal, the promised Holy Spirit,",
         "book": "Ephesians",
         "reference": "1:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "260a2c48298b927b"
       }
     ]
   },
   {
     "name": "DEP 2: Quiet Time",
-    "color": "#07c387",
+    "color": "#E14C30",
     "accentText": "2",
     "verses": [
       {
@@ -695,7 +778,8 @@
         "verse": "God is faithful, who has called you into fellowship with his Son, Jesus Christ our Lord.",
         "book": "1 Corinthians",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8a38fe982d5b7f6"
       },
       {
         "id": 2202,
@@ -703,7 +787,8 @@
         "verse": "Yet the Lord longs to be gracious to you; therefore he will rise up to show you compassion. For the Lord is a God of justice. Blessed are all who wait for him!",
         "book": "Isaiah",
         "reference": "30:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "610ea4478365ac01"
       },
       {
         "id": 2203,
@@ -711,15 +796,18 @@
         "verse": "Seek the Lord while he may be found; call on him while he is near.",
         "book": "Isaiah",
         "reference": "55:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f64edcbb29649141"
       },
       {
         "id": 2204,
         "title": "God's command",
-        "verse": "My heart says of you, \"Seek his face!\" Your face, Lord, I will seek.",
+        "verse": "When thou saidst, Seek ye my face; my heart said unto thee, Thy face, LORD, will I seek.",
         "book": "Psalm",
         "reference": "27:8",
-        "subpack": ""
+        "subpack": "",
+        "version": "KJV",
+        "cardUid": "7d381e53a1f7c058"
       },
       {
         "id": 2205,
@@ -727,7 +815,8 @@
         "verse": "\"I am the vine; you are the branches. If you remain in me and I in you, you will bear much fruit; apart from me you can do nothing.",
         "book": "John",
         "reference": "15:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9387bd5b5bf89779"
       },
       {
         "id": 2206,
@@ -735,7 +824,8 @@
         "verse": "The lions may grow weak and hungry, but those who seek the Lord lack no good thing.",
         "book": "Psalm",
         "reference": "34:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0ad16d0c4a6153d3"
       },
       {
         "id": 2207,
@@ -743,7 +833,8 @@
         "verse": "I will stand at my watch and station myself on the ramparts; I will look to see what he will say to me, and what answer I am to give to this complaint.",
         "book": "Habakkuk",
         "reference": "2:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6eb300883f979db5"
       },
       {
         "id": 2208,
@@ -751,7 +842,8 @@
         "verse": "Let the morning bring me word of your unfailing love, for I have put my trust in you. Show me the way I should go, for to you I entrust my life. Teach me to do your will, for you are my God; may your good Spirit lead me on level ground.",
         "book": "Psalm",
         "reference": "143:8, 10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2f6336d23a165bf8"
       },
       {
         "id": 2209,
@@ -759,7 +851,8 @@
         "verse": "fixing our eyes on Jesus, the pioneer and perfecter of faith. For the joy set before him he endured the cross, scorning its shame, and sat down at the right hand of the throne of God.",
         "book": "Hebrews",
         "reference": "12:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e1b2445ad26a4e7a"
       },
       {
         "id": 2210,
@@ -767,7 +860,8 @@
         "verse": "Why, my soul, are you downcast? Why so disturbed within me? Put your hope in God, for I will yet praise him, my Savior and my God.",
         "book": "Psalm",
         "reference": "42:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "74fa1b0dd4703efd"
       },
       {
         "id": 2211,
@@ -775,7 +869,8 @@
         "verse": "As the deer pants for streams of water, so my soul pants for you, my God.",
         "book": "Psalm",
         "reference": "42:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ea2d78cf67dade2f"
       },
       {
         "id": 2212,
@@ -783,7 +878,8 @@
         "verse": "I wait for the Lord, my whole being waits, and in his word I put my hope. I wait for the Lord more than watchmen wait for the morning, more than watchmen wait for the morning.",
         "book": "Psalm",
         "reference": "130:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "db5c5dc7b06313ec"
       },
       {
         "id": 2213,
@@ -791,7 +887,8 @@
         "verse": "Cast your cares on the Lord and he will sustain you; he will never let the righteous be shaken.",
         "book": "Psalm",
         "reference": "55:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6309e2059c55f512"
       },
       {
         "id": 2214,
@@ -799,7 +896,8 @@
         "verse": "Praise be to the Lord, to God our Savior, who daily bears our burdens.",
         "book": "Psalm",
         "reference": "68:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "83daff7c5f11a20a"
       },
       {
         "id": 2215,
@@ -807,7 +905,8 @@
         "verse": "If you say, \"The Lord is my refuge,\" and you make the Most High your dwelling, no harm will overtake you, no disaster will come near your tent.",
         "book": "Psalm",
         "reference": "91:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2afe3a6f7a6946c6"
       },
       {
         "id": 2216,
@@ -815,7 +914,8 @@
         "verse": "\"Come to me, all you who are weary and burdened, and I will give you rest. Take my yoke upon you and learn from me, for I am gentle and humble in heart, and you will find rest for your souls.",
         "book": "Matthew",
         "reference": "11:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "58030c53fe7edc27"
       },
       {
         "id": 2217,
@@ -823,7 +923,8 @@
         "verse": "I rise before dawn and cry for help; I have put my hope in your word. My eyes stay open through the watches of the night, that I may meditate on your promises.",
         "book": "Psalm",
         "reference": "119:147-148",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0537398623c0c329"
       },
       {
         "id": 2218,
@@ -831,7 +932,8 @@
         "verse": "In the morning, Lord, you hear my voice; in the morning I lay my requests before you and wait expectantly.",
         "book": "Psalm",
         "reference": "5:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dbd6f710d18f9e6a"
       },
       {
         "id": 2219,
@@ -839,7 +941,8 @@
         "verse": "Come, let us bow down in worship, let us kneel before the Lord our Maker;",
         "book": "Psalm",
         "reference": "95:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c868d7c0a301bf1f"
       },
       {
         "id": 2220,
@@ -847,7 +950,8 @@
         "verse": "Through Jesus, therefore, let us continually offer to God a sacrifice of praise—the fruit of lips that openly profess his name.",
         "book": "Hebrews",
         "reference": "13:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "88773a5d3f90c574"
       },
       {
         "id": 2221,
@@ -855,7 +959,8 @@
         "verse": "Satisfy us in the morning with your unfailing love, that we may sing for joy and be glad all our days.",
         "book": "Psalm",
         "reference": "90:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fa793c2e682161ba"
       },
       {
         "id": 2222,
@@ -863,7 +968,8 @@
         "verse": "for he satisfies the thirsty and fills the hungry with good things.",
         "book": "Psalm",
         "reference": "107:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e0ae746c2031d91d"
       },
       {
         "id": 2223,
@@ -871,7 +977,8 @@
         "verse": "Very early in the morning, while it was still dark, Jesus got up, left the house and went off to a solitary place, where he prayed.",
         "book": "Mark",
         "reference": "1:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6938e6832d16b354"
       },
       {
         "id": 2224,
@@ -879,7 +986,8 @@
         "verse": "The Lord would speak to Moses face to face, as one speaks to a friend. Then Moses would return to the camp, but his young aide Joshua son of Nun did not leave the tent.",
         "book": "Exodus",
         "reference": "33:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4c2ee4ef34127f9a"
       },
       {
         "id": 2225,
@@ -887,7 +995,8 @@
         "verse": "Now when Daniel learned that the decree had been published, he went home to his upstairs room where the windows opened toward Jerusalem. Three times a day he got down on his knees and prayed, giving thanks to his God, just as he had done before.",
         "book": "Daniel",
         "reference": "6:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "928c8ef407266ab9"
       },
       {
         "id": 2226,
@@ -895,13 +1004,14 @@
         "verse": "He did not say anything to them without using a parable. But when he was alone with his own disciples, he explained everything.",
         "book": "Mark",
         "reference": "4:34",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "536aa72dc5ba8b27"
       }
     ]
   },
   {
     "name": "DEP 3: The Word",
-    "color": "#ce4611",
+    "color": "#EA8A2E",
     "accentText": "3",
     "verses": [
       {
@@ -910,7 +1020,8 @@
         "verse": "All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness,",
         "book": "2 Timothy",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "41e9f49d662c3fb0"
       },
       {
         "id": 2302,
@@ -918,7 +1029,8 @@
         "verse": "For prophecy never had its origin in the human will, but prophets, though human, spoke from God as they were carried along by the Holy Spirit.",
         "book": "2 Peter",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bcc053f14eb3ca2a"
       },
       {
         "id": 2303,
@@ -926,7 +1038,8 @@
         "verse": "Heaven and earth will pass away, but my words will never pass away.",
         "book": "Matthew",
         "reference": "24:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ff0d767910589063"
       },
       {
         "id": 2304,
@@ -934,7 +1047,8 @@
         "verse": "For, \"All people are like grass, and all their glory is like the flowers of the field; the grass withers and the flowers fall, but the word of the Lord endures forever.\" And this is the word that was preached to you.",
         "book": "1 Peter",
         "reference": "1:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b37c299901343771"
       },
       {
         "id": 2305,
@@ -942,7 +1056,8 @@
         "verse": "Sanctify them by the truth; your word is truth.",
         "book": "John",
         "reference": "17:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c09456b627a90939"
       },
       {
         "id": 2306,
@@ -950,7 +1065,8 @@
         "verse": "Sovereign Lord, you are God! Your covenant is trustworthy, and you have promised these good things to your servant.",
         "book": "2 Samuel",
         "reference": "7:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "863a2df833973eb4"
       },
       {
         "id": 2307,
@@ -958,7 +1074,8 @@
         "verse": "\"Is not my word like fire,\" declares the Lord, \"and like a hammer that breaks a rock in pieces?\"",
         "book": "Jeremiah",
         "reference": "23:29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2a4be0be16ab5e3b"
       },
       {
         "id": 2308,
@@ -966,7 +1083,8 @@
         "verse": "for which I am suffering even to the point of being chained like a criminal. But God's word is not chained.",
         "book": "2 Timothy",
         "reference": "2:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4281202ad18ef4cd"
       },
       {
         "id": 2309,
@@ -974,7 +1092,8 @@
         "verse": "Jesus answered, \"It is written: 'Man shall not live on bread alone, but on every word that comes from the mouth of God.'\"",
         "book": "Matthew",
         "reference": "4:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "00ea10323a7baa38"
       },
       {
         "id": 2310,
@@ -982,7 +1101,8 @@
         "verse": "And beginning with Moses and all the Prophets, he explained to them what was said in all the Scriptures concerning himself.",
         "book": "Luke",
         "reference": "24:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "05513ffc4f3c1009"
       },
       {
         "id": 2311,
@@ -990,7 +1110,8 @@
         "verse": "For you have been born again, not of perishable seed, but of imperishable, through the living and enduring word of God.",
         "book": "1 Peter",
         "reference": "1:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "77619ffd87cc4ba2"
       },
       {
         "id": 2312,
@@ -998,7 +1119,8 @@
         "verse": "He chose to give us birth through the word of truth, that we might be a kind of firstfruits of all he created.",
         "book": "James",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b32ba9135981a05b"
       },
       {
         "id": 2313,
@@ -1006,7 +1128,8 @@
         "verse": "Like newborn babies, crave pure spiritual milk, so that by it you may grow up in your salvation,",
         "book": "1 Peter",
         "reference": "2:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "77bf3666b3c2f7cf"
       },
       {
         "id": 2314,
@@ -1014,7 +1137,8 @@
         "verse": "\"Now I commit you to God and to the word of his grace, which can build you up and give you an inheritance among all those who are sanctified.",
         "book": "Acts",
         "reference": "20:32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9834b498706d7ca5"
       },
       {
         "id": 2315,
@@ -1022,7 +1146,8 @@
         "verse": "Your word is a lamp for my feet, a light on my path.",
         "book": "Psalm",
         "reference": "119:105",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1fb56d8174ecee4e"
       },
       {
         "id": 2316,
@@ -1030,7 +1155,8 @@
         "verse": "When you walk, they will guide you; when you sleep, they will watch over you; when you awake, they will speak to you. For this command is a lamp, this teaching is a light, and correction and instruction are the way to life,",
         "book": "Proverbs",
         "reference": "6:22-23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8c88e1af380bf5c9"
       },
       {
         "id": 2317,
@@ -1038,7 +1164,8 @@
         "verse": "He sent out his word and healed them; he rescued them from the grave.",
         "book": "Psalm",
         "reference": "107:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a6aeabdf3d7070df"
       },
       {
         "id": 2318,
@@ -1046,7 +1173,8 @@
         "verse": "The centurion replied, \"Lord, I do not deserve to have you come under my roof. But just say the word, and my servant will be healed.\"",
         "book": "Matthew",
         "reference": "8:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7394e849e15310dc"
       },
       {
         "id": 2319,
@@ -1054,7 +1182,8 @@
         "verse": "When your words came, I ate them; they were my joy and my heart's delight, for I bear your name, Lord God Almighty.",
         "book": "Jeremiah",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7cba35edad20071c"
       },
       {
         "id": 2320,
@@ -1062,7 +1191,8 @@
         "verse": "Your statutes are my heritage forever; they are the joy of my heart.",
         "book": "Psalm",
         "reference": "119:111",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d14dada176dda455"
       },
       {
         "id": 2321,
@@ -1070,7 +1200,8 @@
         "verse": "Take the helmet of salvation and the sword of the Spirit, which is the word of God.",
         "book": "Ephesians",
         "reference": "6:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "585e176d3ef39175"
       },
       {
         "id": 2322,
@@ -1078,7 +1209,8 @@
         "verse": "For the word of God is alive and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "96fff2a526f1f9dd"
       },
       {
         "id": 2323,
@@ -1086,7 +1218,8 @@
         "verse": "Now the Berean Jews were of more noble character than those in Thessalonica, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89872cec45a5b4a9"
       },
       {
         "id": 2324,
@@ -1094,7 +1227,8 @@
         "verse": "Oh, how I love your law! I meditate on it all day long.",
         "book": "Psalm",
         "reference": "119:97",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "358efb055edf013e"
       },
       {
         "id": 2325,
@@ -1102,7 +1236,8 @@
         "verse": "For Ezra had devoted himself to the study and observance of the Law of the Lord, and to teaching its decrees and laws in Israel.",
         "book": "Ezra",
         "reference": "7:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "199cf40b89ae47ce"
       },
       {
         "id": 2326,
@@ -1110,7 +1245,8 @@
         "verse": "I have not departed from the commands of his lips; I have treasured the words of his mouth more than my daily bread.",
         "book": "Job",
         "reference": "23:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c02acd6cdc6e4810"
       },
       {
         "id": 2327,
@@ -1118,7 +1254,8 @@
         "verse": "Simon answered, \"Master, we've worked hard all night and haven't caught anything. But because you say so, I will let down the nets.\" When they had done so, they caught such a large number of fish that their nets began to break.",
         "book": "Luke",
         "reference": "5:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba0832ae172f6218"
       },
       {
         "id": 2328,
@@ -1126,7 +1263,8 @@
         "verse": "Consequently, faith comes from hearing the message, and the message is heard through the word about Christ.",
         "book": "Romans",
         "reference": "10:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6ebeaffe80b2478b"
       },
       {
         "id": 2329,
@@ -1134,7 +1272,8 @@
         "verse": "He replied, \"Blessed rather are those who hear the word of God and obey it.\"",
         "book": "Luke",
         "reference": "11:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da74bd2494677d7a"
       },
       {
         "id": 2330,
@@ -1142,7 +1281,8 @@
         "verse": "Blessed is the one who reads aloud the words of this prophecy, and blessed are those who hear it and take to heart what is written in it, because the time is near.",
         "book": "Revelation",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "083b6b056ab901f5"
       },
       {
         "id": 2331,
@@ -1150,7 +1290,8 @@
         "verse": "It is to be with him, and he is to read it all the days of his life so that he may learn to revere the Lord his God and follow carefully all the words of this law and these decrees",
         "book": "Deuteronomy",
         "reference": "17:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "14127cfdb253b4f7"
       },
       {
         "id": 2332,
@@ -1158,7 +1299,8 @@
         "verse": "Now the Berean Jews were of more noble character than those in Thessalonica, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b79e8bb18c430fa3"
       },
       {
         "id": 2333,
@@ -1166,7 +1308,8 @@
         "verse": "Do your best to present yourself to God as one approved, a worker who does not need to be ashamed and who correctly handles the word of truth.",
         "book": "2 Timothy",
         "reference": "2:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "80b138b461ac5d8e"
       },
       {
         "id": 2334,
@@ -1174,7 +1317,8 @@
         "verse": "These commandments that I give you today are to be on your hearts.",
         "book": "Deuteronomy",
         "reference": "6:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5430702f3c837b7a"
       },
       {
         "id": 2335,
@@ -1182,7 +1326,8 @@
         "verse": "My son, keep my words and store up my commands within you. Keep my commands and you will live; guard my teachings as the apple of your eye. Bind them on your fingers; write them on the tablet of your heart.",
         "book": "Proverbs",
         "reference": "7:1-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03c1d4d9f4304548"
       },
       {
         "id": 2336,
@@ -1190,7 +1335,8 @@
         "verse": "Blessed is the one who does not walk in step with the wicked or stand in the way that sinners take or sit in the company of mockers, but whose delight is in the law of the Lord, and who meditates on his law day and night.",
         "book": "Psalm",
         "reference": "1:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "66373c8376855260"
       },
       {
         "id": 2337,
@@ -1198,22 +1344,25 @@
         "verse": "Keep this Book of the Law always on your lips; meditate on it day and night, so that you may be careful to do everything written in it. Then you will be prosperous and successful.",
         "book": "Joshua",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d38f615ecae4a277"
       }
     ]
   },
   {
     "name": "DEP 4: Prayer",
-    "color": "#f3a937",
+    "color": "#E7AF21",
     "accentText": "4",
     "verses": [
       {
         "id": 2801,
         "title": "Cease not to pray",
-        "verse": "pray continually,",
+        "verse": "Pray without ceasing.",
         "book": "1 Thessalonians",
         "reference": "5:17",
-        "subpack": ""
+        "subpack": "",
+        "version": "KJV",
+        "cardUid": "9d12f07eadc1c641"
       },
       {
         "id": 2802,
@@ -1221,7 +1370,8 @@
         "verse": "Devote yourselves to prayer, being watchful and thankful.",
         "book": "Colossians",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cd28506d2f6db7b1"
       },
       {
         "id": 2803,
@@ -1229,7 +1379,8 @@
         "verse": "The end of all things is near. Therefore be alert and of sober mind so that you may pray.",
         "book": "1 Peter",
         "reference": "4:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bf1ea21825142f90"
       },
       {
         "id": 2804,
@@ -1237,7 +1388,8 @@
         "verse": "I urge, then, first of all, that petitions, prayers, intercession and thanksgiving be made for all people— for kings and all those in authority, that we may live peaceful and quiet lives in all godliness and holiness.",
         "book": "1 Timothy",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "85397800fdfa7915"
       },
       {
         "id": 2805,
@@ -1245,7 +1397,8 @@
         "verse": "And I will do whatever you ask in my name, so that the Father may be glorified in the Son. You may ask me for anything in my name, and I will do it.",
         "book": "John",
         "reference": "14:13-14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8861483a5122975"
       },
       {
         "id": 2806,
@@ -1253,7 +1406,8 @@
         "verse": "Now to him who is able to do immeasurably more than all we ask or imagine, according to his power that is at work within us,",
         "book": "Ephesians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba010795e70ab8bd"
       },
       {
         "id": 2807,
@@ -1261,7 +1415,8 @@
         "verse": "'Call to me and I will answer you and tell you great and unsearchable things you do not know.'",
         "book": "Jeremiah",
         "reference": "33:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f1d8fed3a717d4a7"
       },
       {
         "id": 2808,
@@ -1269,7 +1424,8 @@
         "verse": "If any of you lacks wisdom, you should ask God, who gives generously to all without finding fault, and it will be given to you.",
         "book": "James",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "98a7e1ed66c68ffd"
       },
       {
         "id": 2809,
@@ -1277,7 +1433,8 @@
         "verse": "I sought the Lord, and he answered me; he delivered me from all my fears.",
         "book": "Psalm",
         "reference": "34:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c16a62eba9399c81"
       },
       {
         "id": 2810,
@@ -1285,7 +1442,8 @@
         "verse": "and call on me in the day of trouble; I will deliver you, and you will honor me.",
         "book": "Psalm",
         "reference": "50:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "617d4239d9bd6d98"
       },
       {
         "id": 2811,
@@ -1293,7 +1451,8 @@
         "verse": "After they prayed, the place where they were meeting was shaken. And they were all filled with the Holy Spirit and spoke the word of God boldly.",
         "book": "Acts",
         "reference": "4:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "422163800b78aebd"
       },
       {
         "id": 2812,
@@ -1301,7 +1460,8 @@
         "verse": "And pray for us, too, that God may open a door for our message, so that we may proclaim the mystery of Christ, for which I am in chains.",
         "book": "Colossians",
         "reference": "4:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "56cdbfa495a7f20a"
       },
       {
         "id": 2813,
@@ -1309,7 +1469,8 @@
         "verse": "Until now you have not asked for anything in my name. Ask and you will receive, and your joy will be complete.",
         "book": "John",
         "reference": "16:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef7995099e124a44"
       },
       {
         "id": 2814,
@@ -1317,7 +1478,8 @@
         "verse": "If you believe, you will receive whatever you ask for in prayer.",
         "book": "Matthew",
         "reference": "21:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "eb1b4a517bffe747"
       },
       {
         "id": 2815,
@@ -1325,7 +1487,8 @@
         "verse": "And pray in the Spirit on all occasions with all kinds of prayers and requests. With this in mind, be alert and always keep on praying for all the Lord's people.",
         "book": "Ephesians",
         "reference": "6:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "783a0516c2505f17"
       },
       {
         "id": 2816,
@@ -1333,7 +1496,8 @@
         "verse": "This is the confidence we have in approaching God: that if we ask anything according to his will, he hears us. And if we know that he hears us—whatever we ask—we know that we have what we asked of him.",
         "book": "1 John",
         "reference": "5:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da5ce14426f3e06f"
       },
       {
         "id": 2817,
@@ -1341,7 +1505,8 @@
         "verse": "If I had cherished sin in my heart, the Lord would not have listened;",
         "book": "Psalm",
         "reference": "66:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dd51dc12ad9f6509"
       },
       {
         "id": 2818,
@@ -1349,7 +1514,8 @@
         "verse": "and receive from him anything we ask, because we keep his commands and do what pleases him.",
         "book": "1 John",
         "reference": "3:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5e4d596248082e94"
       },
       {
         "id": 2819,
@@ -1357,7 +1523,8 @@
         "verse": "“Again, truly I tell you that if two of you on earth agree about anything they ask for, it will be done for them by my Father in heaven.",
         "book": "Matthew",
         "reference": "18:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1b094edea388136c"
       },
       {
         "id": 2820,
@@ -1365,7 +1532,8 @@
         "verse": "“Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; the one who seeks finds; and to the one who knocks, the door will be opened.",
         "book": "Matthew",
         "reference": "7:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a6ad9f702b683a16"
       },
       {
         "id": 2821,
@@ -1373,7 +1541,8 @@
         "verse": "Then you will call on me and come and pray to me, and I will listen to you. You will seek me and find me when you seek me with all your heart.",
         "book": "Jeremiah",
         "reference": "29:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "35b18764f19d2183"
       },
       {
         "id": 2822,
@@ -1381,7 +1550,8 @@
         "verse": "“Remember the instruction you gave your servant Moses, saying, 'If you are unfaithful, I will scatter you among the nations, but if you return to me and obey my commands, then even if your exiled people are at the farthest horizon, I will gather them from there and bring them to the place I have chosen as a dwelling for my Name.'",
         "book": "Nehemiah",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c6142208318970d4"
       },
       {
         "id": 2823,
@@ -1389,7 +1559,8 @@
         "verse": "Now when Daniel learned that the decree had been published, he went home to his upstairs room where the windows opened toward Jerusalem. Three times a day he got down on his knees and prayed, giving thanks to his God, just as he had done before.",
         "book": "Daniel",
         "reference": "6:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8f7c17711adcc2db"
       },
       {
         "id": 2824,
@@ -1397,7 +1568,8 @@
         "verse": "Yet the news about him spread all the more, so that crowds of people came to hear him and to be healed of their sicknesses. But Jesus often withdrew to lonely places and prayed.",
         "book": "Luke",
         "reference": "5:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "de1a6f417466abe3"
       },
       {
         "id": 2825,
@@ -1405,7 +1577,8 @@
         "verse": "One of those days Jesus went out to a mountainside to pray, and spent the night praying to God.",
         "book": "Luke",
         "reference": "6:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5874d64db44ec733"
       },
       {
         "id": 2826,
@@ -1413,7 +1586,8 @@
         "verse": "Elijah was a human being, even as we are. He prayed earnestly that it would not rain, and it did not rain on the land for three and a half years. Again he prayed, and the heavens gave rain, and the earth produced its crops.",
         "book": "James",
         "reference": "5:17-18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4f3c8571456577ef"
       },
       {
         "id": 2827,
@@ -1421,7 +1595,8 @@
         "verse": "About midnight Paul and Silas were praying and singing hymns to God, and the other prisoners were listening to them.",
         "book": "Acts",
         "reference": "16:25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "89e735c0e94ee1b1"
       },
       {
         "id": 2828,
@@ -1429,7 +1604,8 @@
         "verse": "Yours, Lord, is the greatness and the power and the glory and the majesty and the splendor, for everything in heaven and earth is yours. Yours, Lord, is the kingdom; you are exalted as head over all. Wealth and honor come from you; you are the ruler of all things. In your hands are strength and power to exalt and give strength to all. Now, our God, we give you thanks, and praise your glorious name.",
         "book": "1 Chronicles",
         "reference": "29:11-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "325f2fbdd4b36141"
       },
       {
         "id": 2829,
@@ -1437,7 +1613,8 @@
         "verse": "I urge, then, first of all, that petitions, prayers, intercession and thanksgiving be made for all people— for kings and all those in authority, that we may live peaceful and quiet lives in all godliness and holiness.",
         "book": "1 Timothy",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc1d5b9ae92bf91f"
       },
       {
         "id": 2830,
@@ -1445,7 +1622,8 @@
         "verse": "give thanks in all circumstances; for this is God's will for you in Christ Jesus.",
         "book": "1 Thessalonians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce2211af189d824c"
       },
       {
         "id": 2831,
@@ -1453,7 +1631,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e8f42f860d2fdcd1"
       },
       {
         "id": 2832,
@@ -1461,13 +1640,14 @@
         "verse": "Do not be anxious about anything, but in every situation, by prayer and petition, with thanksgiving, present your requests to God. And the peace of God, which transcends all understanding, will guard your hearts and your minds in Christ Jesus.",
         "book": "Philippians",
         "reference": "4:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6eac8319747cf265"
       }
     ]
   },
   {
     "name": "DEP 5: Fellowship",
-    "color": "#00b809",
+    "color": "#019A4E",
     "accentText": "5",
     "verses": [
       {
@@ -1476,7 +1656,8 @@
         "verse": "But now in Christ Jesus you who once were far away have been brought near by the blood of Christ.",
         "book": "Ephesians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "851be69006bec95c"
       },
       {
         "id": 2402,
@@ -1484,7 +1665,8 @@
         "verse": "and through him to reconcile to himself all things, whether things on earth or things in heaven, by making peace through his blood, shed on the cross.",
         "book": "Colossians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e37fc1d869cd48c3"
       },
       {
         "id": 2403,
@@ -1492,7 +1674,8 @@
         "verse": "We proclaim to you what we have seen and heard, so that you also may have fellowship with us. And our fellowship is with the Father and with his Son, Jesus Christ.",
         "book": "1 John",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "82c58b4a3869dc98"
       },
       {
         "id": 2404,
@@ -1500,7 +1683,8 @@
         "verse": "May the grace of the Lord Jesus Christ, and the love of God, and the fellowship of the Holy Spirit be with you all.",
         "book": "2 Corinthians",
         "reference": "13:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "364a4ecdcce4d565"
       },
       {
         "id": 2405,
@@ -1508,7 +1692,8 @@
         "verse": "For where two or three gather in my name, there am I with them.",
         "book": "Matthew",
         "reference": "18:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9a03ddf552b9aca7"
       },
       {
         "id": 2406,
@@ -1516,7 +1701,8 @@
         "verse": "How good and pleasant it is when God's people live together in unity! It is like precious oil poured on the head, running down on the beard, running down on Aaron's beard, down on the collar of his robe. It is as if the dew of Hermon were falling on Mount Zion. For there the Lord bestows his blessing, even life forevermore.",
         "book": "Psalm",
         "reference": "133:1-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57f2966ff215d17a"
       },
       {
         "id": 2407,
@@ -1524,7 +1710,8 @@
         "verse": "But encourage one another daily, as long as it is called \"Today,\" so that none of you may be hardened by sin's deceitfulness.",
         "book": "Hebrews",
         "reference": "3:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d2b7ae572091d2e7"
       },
       {
         "id": 2408,
@@ -1532,7 +1719,8 @@
         "verse": "Two are better than one, because they have a good return for their labor: If either of them falls down, one can help the other up. But pity anyone who falls and has no one to help them up.",
         "book": "Ecclesiastes",
         "reference": "4:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cfab94960a4230be"
       },
       {
         "id": 2409,
@@ -1540,7 +1728,8 @@
         "verse": "Flee the evil desires of youth and pursue righteousness, faith, love and peace, along with those who call on the Lord out of a pure heart.",
         "book": "2 Timothy",
         "reference": "2:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cbf94210a8eb820a"
       },
       {
         "id": 2410,
@@ -1548,7 +1737,8 @@
         "verse": "As iron sharpens iron, so one person sharpens another. As water reflects the face, so one's life reflects the heart.",
         "book": "Proverbs",
         "reference": "27:17, 19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1c0a9bb6e909d064"
       },
       {
         "id": 2411,
@@ -1556,7 +1746,8 @@
         "verse": "Walk with the wise and become wise, for a companion of fools suffers harm.",
         "book": "Proverbs",
         "reference": "13:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "91b229f53594fb7d"
       },
       {
         "id": 2412,
@@ -1564,7 +1755,8 @@
         "verse": "until we all reach unity in the faith and in the knowledge of the Son of God and become mature, attaining to the whole measure of the fullness of Christ.",
         "book": "Ephesians",
         "reference": "4:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "255248f46b9ff9a4"
       },
       {
         "id": 2413,
@@ -1572,7 +1764,8 @@
         "verse": "They devoted themselves to the apostles' teaching and to fellowship, to the breaking of bread and to prayer. praising God and enjoying the favor of all the people. And the Lord added to their number daily those who were being saved.",
         "book": "Acts",
         "reference": "2:42, 47",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "391a5138580066f7"
       },
       {
         "id": 2414,
@@ -1580,7 +1773,8 @@
         "verse": "because of your partnership in the gospel from the first day until now, Whatever happens, conduct yourselves in a manner worthy of the gospel of Christ. Then, whether I come and see you or only hear about you in my absence, I will know that you stand firm in the one Spirit, striving together as one for the faith of the gospel",
         "book": "Philippians",
         "reference": "1:5, 27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0c9b1f24e70a1d22"
       },
       {
         "id": 2415,
@@ -1588,7 +1782,8 @@
         "verse": "And let us consider how we may spur one another on toward love and good deeds, not giving up meeting together, as some are in the habit of doing, but encouraging one another—and all the more as you see the Day approaching.",
         "book": "Hebrews",
         "reference": "10:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "efb9cea35522b581"
       },
       {
         "id": 2416,
@@ -1596,7 +1791,8 @@
         "verse": "For I testify that they gave as much as they were able, and even beyond their ability. Entirely on their own, they urgently pleaded with us for the privilege of sharing in this service to the Lord's people.",
         "book": "2 Corinthians",
         "reference": "8:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e62106982323de23"
       },
       {
         "id": 2417,
@@ -1604,7 +1800,8 @@
         "verse": "But rejoice inasmuch as you participate in the sufferings of Christ, so that you may be overjoyed when his glory is revealed.",
         "book": "1 Peter",
         "reference": "4:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2ec3dead68c10958"
       },
       {
         "id": 2418,
@@ -1612,7 +1809,8 @@
         "verse": "Carry each other's burdens, and in this way you will fulfill the law of Christ.",
         "book": "Galatians",
         "reference": "6:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8f6124a735424219"
       },
       {
         "id": 2419,
@@ -1620,7 +1818,8 @@
         "verse": "Therefore if you have any encouragement from being united with Christ, if any comfort from his love, if any common sharing in the Spirit, if any tenderness and compassion, then make my joy complete by being like-minded, having the same love, being one in spirit and of one mind.",
         "book": "Philippians",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "05ffe60782e4a962"
       },
       {
         "id": 2420,
@@ -1628,7 +1827,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit. Rather, in humility value others above yourselves, not looking to your own interests but each of you to the interests of the others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "003eb8b4dd2d5b93"
       },
       {
         "id": 2421,
@@ -1636,7 +1836,8 @@
         "verse": "We are not withholding our affection from you, but you are withholding yours from us. As a fair exchange—I speak as to my children—open wide your hearts also.",
         "book": "2 Corinthians",
         "reference": "6:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b234bfdf8e881b59"
       },
       {
         "id": 2422,
@@ -1644,7 +1845,8 @@
         "verse": "Submit to one another out of reverence for Christ.",
         "book": "Ephesians",
         "reference": "5:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3b1332a9c553db15"
       },
       {
         "id": 2423,
@@ -1652,7 +1854,8 @@
         "verse": "But they kept quiet because on the way they had argued about who was the greatest. Sitting down, Jesus called the Twelve and said, \"Anyone who wants to be first must be the very last, and the servant of all.\"",
         "book": "Mark",
         "reference": "9:34-35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c0cd2d9fe5522d18"
       },
       {
         "id": 2424,
@@ -1660,7 +1863,8 @@
         "verse": "See to it that no one falls short of the grace of God and that no bitter root grows up to cause trouble and defile many.",
         "book": "Hebrews",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f3c6d9738b6fdd41"
       },
       {
         "id": 2425,
@@ -1668,7 +1872,8 @@
         "verse": "Have nothing to do with the fruitless deeds of darkness, but rather expose them.",
         "book": "Ephesians",
         "reference": "5:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d1687f3357b758c2"
       },
       {
         "id": 2426,
@@ -1676,7 +1881,8 @@
         "verse": "No one serving as a soldier gets entangled in civilian affairs, but rather tries to please his commanding officer.",
         "book": "2 Timothy",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "82cfaf89158bfaa5"
       },
       {
         "id": 2427,
@@ -1684,7 +1890,8 @@
         "verse": "Therefore, if you are offering your gift at the altar and there remember that your brother or sister has something against you, leave your gift there in front of the altar. First go and be reconciled to them; then come and offer your gift.",
         "book": "Matthew",
         "reference": "5:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70766a8c061484a1"
       },
       {
         "id": 2428,
@@ -1692,7 +1899,8 @@
         "verse": "If your brother or sister sins, go and point out their fault, just between the two of you. If they listen to you, you have won them over.",
         "book": "Matthew",
         "reference": "18:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f98e381dfc5609ee"
       },
       {
         "id": 2429,
@@ -1700,7 +1908,8 @@
         "verse": "If we confess our sins, he is faithful and just and will forgive us our sins and purify us from all unrighteousness.",
         "book": "1 John",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ecbc539fcd01bb79"
       },
       {
         "id": 2430,
@@ -1708,13 +1917,14 @@
         "verse": "Whoever conceals their sins does not prosper, but the one who confesses and renounces them finds mercy.",
         "book": "Proverbs",
         "reference": "28:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2c71d56fa3d0e05b"
       }
     ]
   },
   {
     "name": "DEP 6: Witnessing",
-    "color": "#14c7cc",
+    "color": "#0090D0",
     "accentText": "6",
     "verses": [
       {
@@ -1723,7 +1933,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "42d32896a4d2dbc4"
       },
       {
         "id": 2502,
@@ -1731,7 +1942,8 @@
         "verse": "All this is from God, who reconciled us to himself through Christ and gave us the ministry of reconciliation: that God was reconciling the world to himself in Christ, not counting people's sins against them. And he has committed to us the message of reconciliation.",
         "book": "2 Corinthians",
         "reference": "5:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "18fd8b95b8493fe0"
       },
       {
         "id": 2503,
@@ -1739,7 +1951,8 @@
         "verse": "In the presence of God and of Christ Jesus, who will judge the living and the dead, and in view of his appearing and his kingdom, I give you this charge: Preach the word; be prepared in season and out of season; correct, rebuke and encourage—with great patience and careful instruction.",
         "book": "2 Timothy",
         "reference": "4:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8450d0c69ccff067"
       },
       {
         "id": 2504,
@@ -1747,7 +1960,8 @@
         "verse": "For the Son of Man came to seek and to save the lost.",
         "book": "Luke",
         "reference": "19:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a3c641f0768b66f6"
       },
       {
         "id": 2505,
@@ -1755,7 +1969,8 @@
         "verse": "On the contrary, we speak as those approved by God to be entrusted with the gospel. We are not trying to please people but God, who tests our hearts.",
         "book": "1 Thessalonians",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "796de829c27a8b0f"
       },
       {
         "id": 2506,
@@ -1763,7 +1978,8 @@
         "verse": "For when I preach the gospel, I cannot boast, since I am compelled to preach. Woe to me if I do not preach the gospel!",
         "book": "1 Corinthians",
         "reference": "9:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "47f50bd3719f9dd9"
       },
       {
         "id": 2507,
@@ -1771,7 +1987,8 @@
         "verse": "How, then, can they call on the one they have not believed in? And how can they believe in the one of whom they have not heard? And how can they hear without someone preaching to them?",
         "book": "Romans",
         "reference": "10:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87b64570af3a0ecc"
       },
       {
         "id": 2508,
@@ -1779,7 +1996,8 @@
         "verse": "This is good, and pleases God our Savior, who wants all people to be saved and to come to a knowledge of the truth.",
         "book": "1 Timothy",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03c1259b89eb0d13"
       },
       {
         "id": 2509,
@@ -1787,7 +2005,8 @@
         "verse": "But the Lord said, \"You have been concerned about this plant, though you did not tend it or make it grow. It sprang up overnight and died overnight. And should I not have concern for the great city of Nineveh, in which there are more than a hundred and twenty thousand people who cannot tell their right hand from their left—and also many animals?\"",
         "book": "Jonah",
         "reference": "4:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "14ca94f31b70f845"
       },
       {
         "id": 2510,
@@ -1795,7 +2014,8 @@
         "verse": "I tell you that in the same way there will be more rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent.",
         "book": "Luke",
         "reference": "15:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f4b72ea2ac2df154"
       },
       {
         "id": 2511,
@@ -1803,7 +2023,8 @@
         "verse": "We proclaim to you what we have seen and heard, so that you also may have fellowship with us. And our fellowship is with the Father and with his Son, Jesus Christ.",
         "book": "1 John",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1b4e207919ef5a98"
       },
       {
         "id": 2512,
@@ -1811,7 +2032,8 @@
         "verse": "Those who are wise will shine like the brightness of the heavens, and those who lead many to righteousness, like the stars for ever and ever.",
         "book": "Daniel",
         "reference": "12:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "471a02f6807cfe9b"
       },
       {
         "id": 2513,
@@ -1819,7 +2041,8 @@
         "verse": "\"Come, follow me,\" Jesus said, \"and I will send you out to fish for people.\"",
         "book": "Matthew",
         "reference": "4:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a562c26b910f45c"
       },
       {
         "id": 2514,
@@ -1827,7 +2050,8 @@
         "verse": "so that you may become blameless and pure, \"children of God without fault in a warped and crooked generation.\" Then you will shine among them like stars in the sky as you hold firmly to the word of life. And then I will be able to boast on the day of Christ that I did not run or labor in vain.",
         "book": "Philippians",
         "reference": "2:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6caa572ca7098f83"
       },
       {
         "id": 2515,
@@ -1835,7 +2059,8 @@
         "verse": "Pray also for me, that whenever I speak, words may be given me so that I will fearlessly make known the mystery of the gospel,",
         "book": "Ephesians",
         "reference": "6:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a726b675872941c8"
       },
       {
         "id": 2516,
@@ -1843,7 +2068,8 @@
         "verse": "But in your hearts revere Christ as Lord. Always be prepared to give an answer to everyone who asks you to give the reason for the hope that you have. But do this with gentleness and respect,",
         "book": "1 Peter",
         "reference": "3:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fdd0269c8535ec8f"
       },
       {
         "id": 2517,
@@ -1851,7 +2077,8 @@
         "verse": "Many of the Samaritans from that town believed in him because of the woman's testimony, \"He told me everything I ever did.\"",
         "book": "John",
         "reference": "4:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5e6de217dbf7f892"
       },
       {
         "id": 2518,
@@ -1859,7 +2086,8 @@
         "verse": "For the word of God is alive and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7100d4f006d43f0b"
       },
       {
         "id": 2519,
@@ -1867,7 +2095,8 @@
         "verse": "so is my word that goes out from my mouth: It will not return to me empty, but will accomplish what I desire and achieve the purpose for which I sent it.",
         "book": "Isaiah",
         "reference": "55:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e71ee053bb84e1f2"
       },
       {
         "id": 2520,
@@ -1875,7 +2104,8 @@
         "verse": "but we preach Christ crucified: a stumbling block to Jews and foolishness to Gentiles, but to those whom God has called, both Jews and Greeks, Christ the power of God and the wisdom of God.",
         "book": "1 Corinthians",
         "reference": "1:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "90b0ff12647b90ca"
       },
       {
         "id": 2521,
@@ -1883,7 +2113,8 @@
         "verse": "because our gospel came to you not simply with words but also with power, with the Holy Spirit and deep conviction. You know how we lived among you for your sake.",
         "book": "1 Thessalonians",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bfb5bd8e3ae7ad5e"
       },
       {
         "id": 2522,
@@ -1891,7 +2122,8 @@
         "verse": "If you declare with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you profess your faith and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d84c71c21053f92c"
       },
       {
         "id": 2523,
@@ -1899,7 +2131,8 @@
         "verse": "For he says, \"In the time of my favor I heard you, and in the day of salvation I helped you.\" I tell you, now is the time of God's favor, now is the day of salvation.",
         "book": "2 Corinthians",
         "reference": "6:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ed585ba601cbbd9b"
       },
       {
         "id": 2524,
@@ -1907,7 +2140,8 @@
         "verse": "Examine yourselves to see whether you are in the faith; test yourselves. Do you not realize that Christ Jesus is in you—unless, of course, you fail the test?",
         "book": "2 Corinthians",
         "reference": "13:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "27843920558c8d5f"
       },
       {
         "id": 2525,
@@ -1915,7 +2149,8 @@
         "verse": "As was his custom, Paul went into the synagogue, and on three Sabbath days he reasoned with them from the Scriptures, explaining and proving that the Messiah had to suffer and rise from the dead. \"This Jesus I am proclaiming to you is the Messiah,\" he said.",
         "book": "Acts",
         "reference": "17:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9622580e7c6b1191"
       },
       {
         "id": 2526,
@@ -1923,7 +2158,8 @@
         "verse": "However, I consider my life worth nothing to me; my only aim is to finish the race and complete the task the Lord Jesus has given me—the task of testifying to the good news of God's grace.",
         "book": "Acts",
         "reference": "20:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a68b0cf6a363059c"
       },
       {
         "id": 2527,
@@ -1931,7 +2167,8 @@
         "verse": "The Spirit told Philip, \"Go to that chariot and stay near it.\" Then Philip ran up to the chariot and heard the man reading Isaiah the prophet. \"Do you understand what you are reading?\" Philip asked.",
         "book": "Acts",
         "reference": "8:29-30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ba5726b0240962b4"
       },
       {
         "id": 2528,
@@ -1939,7 +2176,8 @@
         "verse": "As for us, we cannot help speaking about what we have seen and heard.",
         "book": "Acts",
         "reference": "4:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef7c5e1ce7b05012"
       },
       {
         "id": 2529,
@@ -1947,7 +2185,8 @@
         "verse": "So God created mankind in his own image, in the image of God he created them; male and female he created them.",
         "book": "Genesis",
         "reference": "1:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "74ad102a507ac9de"
       },
       {
         "id": 2530,
@@ -1955,7 +2194,8 @@
         "verse": "Surely the arm of the Lord is not too short to save, nor his ear too dull to hear. But your iniquities have separated you from your God; your sins have hidden his face from you, so that he will not hear.",
         "book": "Isaiah",
         "reference": "59:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d92ff2297902730a"
       },
       {
         "id": 2531,
@@ -1963,7 +2203,8 @@
         "verse": "Therefore, just as sin entered the world through one man, and death through sin, and in this way death came to all people, because all sinned—",
         "book": "Romans",
         "reference": "5:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "df6c5ddf2a846315"
       },
       {
         "id": 2532,
@@ -1971,7 +2212,8 @@
         "verse": "for all have sinned and fall short of the glory of God,",
         "book": "Romans",
         "reference": "3:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6fc02e7f3d5a1a92"
       },
       {
         "id": 2533,
@@ -1979,7 +2221,8 @@
         "verse": "Just as people are destined to die once, and after that to face judgment,",
         "book": "Hebrews",
         "reference": "9:27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b15fc4f39cc45bb4"
       },
       {
         "id": 2534,
@@ -1987,7 +2230,8 @@
         "verse": "He will punish those who do not know God and do not obey the gospel of our Lord Jesus. They will be punished with everlasting destruction and shut out from the presence of the Lord and from the glory of his might",
         "book": "2 Thessalonians",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a91aa9bf635fee8"
       },
       {
         "id": 2535,
@@ -1995,7 +2239,8 @@
         "verse": "For the wages of sin is death, but the gift of God is eternal life in Christ Jesus our Lord.",
         "book": "Romans",
         "reference": "6:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "46f486793eff08bc"
       },
       {
         "id": 2536,
@@ -2003,7 +2248,8 @@
         "verse": "But the cowardly, the unbelieving, the vile, the murderers, the sexually immoral, those who practice magic arts, the idolaters and all liars—they will be consigned to the fiery lake of burning sulfur. This is the second death.",
         "book": "Revelation",
         "reference": "21:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "16d56d1c1c607084"
       },
       {
         "id": 2537,
@@ -2011,7 +2257,8 @@
         "verse": "For it is by grace you have been saved, through faith—and this is not from yourselves, it is the gift of God— not by works, so that no one can boast.",
         "book": "Ephesians",
         "reference": "2:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f7cd4531c1748fa5"
       },
       {
         "id": 2538,
@@ -2019,7 +2266,8 @@
         "verse": "I do not set aside the grace of God, for if righteousness could be gained through the law, Christ died for nothing!",
         "book": "Galatians",
         "reference": "2:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4042588b4b1ae2a2"
       },
       {
         "id": 2539,
@@ -2027,7 +2275,8 @@
         "verse": "Salvation is found in no one else, for there is no other name under heaven given to mankind by which we must be saved.",
         "book": "Acts",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cdfb48caaad46ba7"
       },
       {
         "id": 2540,
@@ -2035,7 +2284,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your ancestors,",
         "book": "1 Peter",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9e407216615ea0ac"
       },
       {
         "id": 2541,
@@ -2043,7 +2293,8 @@
         "verse": "Jews demand signs and Greeks look for wisdom, but we preach Christ crucified: a stumbling block to Jews and foolishness to Gentiles,",
         "book": "1 Corinthians",
         "reference": "1:22-23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "25ec47827abd1293"
       },
       {
         "id": 2542,
@@ -2051,7 +2302,8 @@
         "verse": "For since in the wisdom of God the world through its wisdom did not know him, God was pleased through the foolishness of what was preached to save those who believe.",
         "book": "1 Corinthians",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b6176d2da12b6302"
       },
       {
         "id": 2543,
@@ -2059,7 +2311,8 @@
         "verse": "See to it that no one takes you captive through hollow and deceptive philosophy, which depends on human tradition and the elemental spiritual forces of this world rather than on Christ.",
         "book": "Colossians",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "655f8c5a96949696"
       },
       {
         "id": 2544,
@@ -2067,7 +2320,8 @@
         "verse": "children born not of natural descent, nor of human decision or a husband's will, but born of God.",
         "book": "John",
         "reference": "1:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2e9f0b24bb32ca91"
       },
       {
         "id": 2545,
@@ -2075,7 +2329,8 @@
         "verse": "Flesh gives birth to flesh, but the Spirit gives birth to spirit. You should not be surprised at my saying, 'You must be born again.'",
         "book": "John",
         "reference": "3:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bc4301af4d3bc643"
       },
       {
         "id": 2546,
@@ -2083,7 +2338,8 @@
         "verse": "The Spirit gives life; the flesh counts for nothing. The words I have spoken to you—they are full of the Spirit and life.",
         "book": "John",
         "reference": "6:63",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b4007135935d86d9"
       },
       {
         "id": 2547,
@@ -2091,7 +2347,8 @@
         "verse": "For Christ also suffered once for sins, the righteous for the unrighteous, to bring you to God. He was put to death in the body but made alive in the Spirit.",
         "book": "1 Peter",
         "reference": "3:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9cd43164e840fbf8"
       },
       {
         "id": 2548,
@@ -2099,7 +2356,8 @@
         "verse": "For God so loved the world that he gave his one and only Son, that whoever believes in him shall not perish but have eternal life.",
         "book": "John",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61cb35edc10396cf"
       },
       {
         "id": 2549,
@@ -2107,7 +2365,8 @@
         "verse": "But God demonstrates his own love for us in this: While we were still sinners, Christ died for us.",
         "book": "Romans",
         "reference": "5:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a90ad23df1b8716c"
       },
       {
         "id": 2550,
@@ -2115,7 +2374,8 @@
         "verse": "For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day according to the Scriptures,",
         "book": "1 Corinthians",
         "reference": "15:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e9a225100315dfa4"
       },
       {
         "id": 2551,
@@ -2123,7 +2383,8 @@
         "verse": "When you were dead in your sins and in the uncircumcision of your flesh, God made you alive with Christ. He forgave us all our sins,",
         "book": "Colossians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f5ec7373c98e59aa"
       },
       {
         "id": 2552,
@@ -2131,7 +2392,8 @@
         "verse": "\"Very truly I tell you, whoever hears my word and believes him who sent me has eternal life and will not be judged but has crossed over from death to life.\"",
         "book": "John",
         "reference": "5:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f3fb749fb62914c5"
       },
       {
         "id": 2553,
@@ -2139,7 +2401,8 @@
         "verse": "Yet to all who did receive him, to those who believed in his name, he gave the right to become children of God—",
         "book": "John",
         "reference": "1:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b0423d531d0ff503"
       },
       {
         "id": 2554,
@@ -2147,7 +2410,8 @@
         "verse": "Here I am! I stand at the door and knock. If anyone hears my voice and opens the door, I will come in and eat with that person, and they with me.",
         "book": "Revelation",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bf12ed32e00a4544"
       },
       {
         "id": 2555,
@@ -2155,13 +2419,14 @@
         "verse": "If you declare with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you profess your faith and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57bb2d28e2cb658d"
       }
     ]
   },
   {
     "name": "DEP 7: The Lordship of Christ",
-    "color": "#0032ff",
+    "color": "#01409E",
     "accentText": "7",
     "verses": [
       {
@@ -2170,7 +2435,8 @@
         "verse": "He was with God in the beginning. Through him all things were made; without him nothing was made that has been made.",
         "book": "John",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e3826d02963fa08f"
       },
       {
         "id": 2602,
@@ -2178,7 +2444,8 @@
         "verse": "For in him all things were created: things in heaven and on earth, visible and invisible, whether thrones or powers or rulers or authorities; all things have been created through him and for him. He is before all things, and in him all things hold together.",
         "book": "Colossians",
         "reference": "1:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f68a939769d759fb"
       },
       {
         "id": 2603,
@@ -2186,7 +2453,8 @@
         "verse": "And he is the head of the body, the church; he is the beginning and the firstborn from among the dead, so that in everything he might have the supremacy.",
         "book": "Colossians",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "678639d1f4e8c15c"
       },
       {
         "id": 2604,
@@ -2194,7 +2462,8 @@
         "verse": "far above all rule and authority, power and dominion, and every name that is invoked, not only in the present age but also in the one to come.",
         "book": "Ephesians",
         "reference": "1:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "680faf2e6e7e691a"
       },
       {
         "id": 2605,
@@ -2202,7 +2471,8 @@
         "verse": "that at the name of Jesus every knee should bow, in heaven and on earth and under the earth, and every tongue acknowledge that Jesus Christ is Lord, to the glory of God the Father.",
         "book": "Philippians",
         "reference": "2:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dff34281e8231c62"
       },
       {
         "id": 2606,
@@ -2210,7 +2480,8 @@
         "verse": "For this very reason, Christ died and returned to life so that he might be the Lord of both the dead and the living.",
         "book": "Romans",
         "reference": "14:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f971219321809d88"
       },
       {
         "id": 2607,
@@ -2218,7 +2489,8 @@
         "verse": "Do you not know that your bodies are temples of the Holy Spirit, who is in you, whom you have received from God? You are not your own; you were bought at a price. Therefore honor God with your bodies.",
         "book": "1 Corinthians",
         "reference": "6:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb77cab02059d213"
       },
       {
         "id": 2608,
@@ -2226,7 +2498,8 @@
         "verse": "And he died for all, that those who live should no longer live for themselves but for him who died for them and was raised again.",
         "book": "2 Corinthians",
         "reference": "5:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b5ceb1d868294633"
       },
       {
         "id": 2609,
@@ -2234,7 +2507,8 @@
         "verse": "But seek first his kingdom and his righteousness, and all these things will be given to you as well.",
         "book": "Matthew",
         "reference": "6:33",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5fea29f2b0512d37"
       },
       {
         "id": 2610,
@@ -2242,7 +2516,8 @@
         "verse": "\"Truly I tell you,\" Jesus replied, \"no one who has left home or brothers or sisters or mother or father or children or fields for me and the gospel will fail to receive a hundred times as much in this present age: homes, brothers, sisters, mothers, children and fields—along with persecutions—and in the age to come eternal life.\"",
         "book": "Mark",
         "reference": "10:29-30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "30072efb63ad246d"
       },
       {
         "id": 2611,
@@ -2250,7 +2525,8 @@
         "verse": "and said, \"I swear by myself, declares the Lord, that because you have done this and have not withheld your son, your only son, I will surely bless you and make your descendants as numerous as the stars in the sky and as the sand on the seashore. Your descendants will take possession of the cities of their enemies,\"",
         "book": "Genesis",
         "reference": "22:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "60b184454c2177e2"
       },
       {
         "id": 2612,
@@ -2258,7 +2534,8 @@
         "verse": "\"And you, my son Solomon, acknowledge the God of your father, and serve him with wholehearted devotion and with a willing mind, for the Lord searches every heart and understands every desire and every thought. If you seek him, he will be found by you; but if you forsake him, he will reject you forever.\"",
         "book": "1 Chronicles",
         "reference": "28:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c00a83066f8068a4"
       },
       {
         "id": 2613,
@@ -2266,7 +2543,8 @@
         "verse": "For the eyes of the Lord range throughout the earth to strengthen those whose hearts are fully committed to him. You have done a foolish thing, and from now on you will be at war.",
         "book": "2 Chronicles",
         "reference": "16:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2192a04982adea91"
       },
       {
         "id": 2614,
@@ -2274,7 +2552,8 @@
         "verse": "\"Because he loves me,\" says the Lord, \"I will rescue him; I will protect him, for he acknowledges my name.\"",
         "book": "Psalm",
         "reference": "91:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb292fec34bc3108"
       },
       {
         "id": 2615,
@@ -2282,7 +2561,8 @@
         "verse": "\"Therefore the Lord, the God of Israel, declares: 'I promised that members of your family would minister before me forever.' But now the Lord declares: 'Far be it from me! Those who honor me I will honor, but those who despise me will be disdained.\"",
         "book": "1 Samuel",
         "reference": "2:30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e704bcbdab78a580"
       },
       {
         "id": 2616,
@@ -2290,7 +2570,8 @@
         "verse": "Then he said to them all: \"Whoever wants to be my disciple must deny themselves and take up their cross daily and follow me.\"",
         "book": "Luke",
         "reference": "9:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0871aa32bb0314d1"
       },
       {
         "id": 2617,
@@ -2298,7 +2579,8 @@
         "verse": "When the Lord takes pleasure in anyone's way, he causes their enemies to make peace with them.",
         "book": "Proverbs",
         "reference": "16:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5d7456b07d13bad5"
       },
       {
         "id": 2618,
@@ -2306,7 +2588,8 @@
         "verse": "Trust in the Lord with all your heart and lean not on your own understanding; in all your ways submit to him, and he will make your paths straight.",
         "book": "Proverbs",
         "reference": "3:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d981c28f08240492"
       },
       {
         "id": 2619,
@@ -2314,7 +2597,8 @@
         "verse": "You were taught, with regard to your former way of life, to put off your old self, which is being corrupted by its deceitful desires; to be made new in the attitude of your minds; and to put on the new self, created to be like God in true righteousness and holiness.",
         "book": "Ephesians",
         "reference": "4:22-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "136a02728eed50c4"
       },
       {
         "id": 2620,
@@ -2322,7 +2606,8 @@
         "verse": "Flee the evil desires of youth and pursue righteousness, faith, love and peace, along with those who call on the Lord out of a pure heart.",
         "book": "2 Timothy",
         "reference": "2:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3c64366969cc14f9"
       },
       {
         "id": 2621,
@@ -2330,7 +2615,8 @@
         "verse": "For we brought nothing into the world, and we can take nothing out of it. But if we have food and clothing, we will be content with that. Those who want to get rich fall into temptation and a trap and into many foolish and harmful desires that plunge people into ruin and destruction.",
         "book": "1 Timothy",
         "reference": "6:7-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b7ec843291b0f424"
       },
       {
         "id": 2622,
@@ -2338,7 +2624,8 @@
         "verse": "Be very careful, then, how you live—not as unwise but as wise, making the most of every opportunity, because the days are evil.",
         "book": "Ephesians",
         "reference": "5:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc7985a0e5111596"
       },
       {
         "id": 2623,
@@ -2346,7 +2633,8 @@
         "verse": "Without delay he called them, and they left their father Zebedee in the boat with the hired men and followed him.",
         "book": "Mark",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a5458d5f99fc5526"
       },
       {
         "id": 2624,
@@ -2354,7 +2642,8 @@
         "verse": "I eagerly expect and hope that I will in no way be ashamed, but will have sufficient courage so that now as always Christ will be exalted in my body, whether by life or by death.",
         "book": "Philippians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4910b66021ad4396"
       },
       {
         "id": 2625,
@@ -2362,7 +2651,8 @@
         "verse": "For everyone looks out for their own interests, not those of Jesus Christ. But you know that Timothy has proved himself, because as a son with his father he has served with me in the work of the gospel.",
         "book": "Philippians",
         "reference": "2:21-22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "845ecb9a20404bf1"
       },
       {
         "id": 2626,
@@ -2370,13 +2660,14 @@
         "verse": "Some faced jeers and flogging, and even chains and imprisonment. They were put to death by stoning; they were sawed in two; they were killed by the sword. They went about in sheepskins and goatskins, destitute, persecuted and mistreated— the world was not worthy of them. They wandered in deserts and mountains, living in caves and in holes in the ground.",
         "book": "Hebrews",
         "reference": "11:36-38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "81acad9ea2995c82"
       }
     ]
   },
   {
     "name": "DEP 8: World Vision",
-    "color": "#8900ff",
+    "color": "#362B8A",
     "accentText": "8",
     "verses": [
       {
@@ -2385,7 +2676,8 @@
         "verse": "I will make you into a great nation, and I will bless you; I will make your name great, and you will be a blessing. I will bless those who bless you, and whoever curses you I will curse; and all peoples on earth will be blessed through you.",
         "book": "Genesis",
         "reference": "12:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e23696a3eda4308c"
       },
       {
         "id": 2702,
@@ -2393,7 +2685,8 @@
         "verse": "he says: It is too small a thing for you to be my servant to restore the tribes of Jacob and bring back those of Israel I have kept. I will also make you a light for the Gentiles, that my salvation may reach to the ends of the earth.",
         "book": "Isaiah",
         "reference": "49:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "250ae3d6a5c53191"
       },
       {
         "id": 2703,
@@ -2401,7 +2694,8 @@
         "verse": "Therefore go and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, and teaching them to obey everything I have commanded you. And surely I am with you always, to the very end of the age.",
         "book": "Matthew",
         "reference": "28:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f50834c9f82a1676"
       },
       {
         "id": 2704,
@@ -2409,7 +2703,8 @@
         "verse": "But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.",
         "book": "Acts",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f9754a40a89ec8ba"
       },
       {
         "id": 2705,
@@ -2417,7 +2712,8 @@
         "verse": "Then I heard the voice of the Lord saying, \"Whom shall I send? And who will go for us?\" And I said, \"Here am I. Send me!\"",
         "book": "Isaiah",
         "reference": "6:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ada587118a33373a"
       },
       {
         "id": 2706,
@@ -2425,7 +2721,8 @@
         "verse": "to be a minister of Christ Jesus to the Gentiles. He gave me the priestly duty of proclaiming the gospel of God, so that the Gentiles might become an offering acceptable to God, sanctified by the Holy Spirit.",
         "book": "Romans",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e10b720b0f11e070"
       },
       {
         "id": 2707,
@@ -2433,7 +2730,8 @@
         "verse": "Ask me, and I will make the nations your inheritance, the ends of the earth your possession.",
         "book": "Psalm",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bde180e4c954cd94"
       },
       {
         "id": 2708,
@@ -2441,7 +2739,8 @@
         "verse": "Be exalted, O God, above the heavens; let your glory be over all the earth.",
         "book": "Psalm",
         "reference": "57:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "72e8ed68e7724c16"
       },
       {
         "id": 2709,
@@ -2449,7 +2748,8 @@
         "verse": "in the hope of eternal life, which God, who does not lie, promised before the beginning of time, and which now at his appointed season he has brought to light through the preaching entrusted to me by the command of God our Savior,",
         "book": "Titus",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7d1f3d4844590cb7"
       },
       {
         "id": 2710,
@@ -2457,7 +2757,8 @@
         "verse": "But the Lord stood at my side and gave me strength, so that through me the message might be fully proclaimed and all the Gentiles might hear it. And I was delivered from the lion's mouth.",
         "book": "2 Timothy",
         "reference": "4:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b54223f0569d385b"
       },
       {
         "id": 2711,
@@ -2465,7 +2766,8 @@
         "verse": "He is the one we proclaim, admonishing and teaching everyone with all wisdom, so that we may present everyone fully mature in Christ. To this end I strenuously contend with all the energy Christ so powerfully works in me.",
         "book": "Colossians",
         "reference": "1:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6717dd3397b469ca"
       },
       {
         "id": 2712,
@@ -2473,7 +2775,8 @@
         "verse": "And this is my prayer: that your love may abound more and more in knowledge and depth of insight, so that you may be able to discern what is best and may be pure and blameless for the day of Christ, filled with the fruit of righteousness that comes through Jesus Christ—to the glory and praise of God.",
         "book": "Philippians",
         "reference": "1:9-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "91188675a80c177d"
       },
       {
         "id": 2713,
@@ -2481,7 +2784,8 @@
         "verse": "And the things you have heard me say in the presence of many witnesses entrust to reliable people who will also be qualified to teach others.",
         "book": "2 Timothy",
         "reference": "2:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "da0386c36c4a831c"
       },
       {
         "id": 2714,
@@ -2489,7 +2793,8 @@
         "verse": "The least of you will become a thousand, the smallest a mighty nation. I am the Lord; in its time I will do this swiftly.",
         "book": "Isaiah",
         "reference": "60:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0fb59b1a61e73bf6"
       },
       {
         "id": 2715,
@@ -2497,7 +2802,8 @@
         "verse": "Therefore, since we are surrounded by such a great cloud of witnesses, let us throw off everything that hinders and the sin that so easily entangles. And let us run with perseverance the race marked out for us,",
         "book": "Hebrews",
         "reference": "12:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "672305c21d39dbc4"
       },
       {
         "id": 2716,
@@ -2505,7 +2811,8 @@
         "verse": "For the eyes of the Lord range throughout the earth to strengthen those whose hearts are fully committed to him. You have done a foolish thing, and from now on you will be at war.",
         "book": "2 Chronicles",
         "reference": "16:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6e316c176c8737d8"
       },
       {
         "id": 2717,
@@ -2513,7 +2820,8 @@
         "verse": "For the earth will be filled with the knowledge of the glory of the Lord as the waters cover the sea.",
         "book": "Habakkuk",
         "reference": "2:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d1b556de7966dae4"
       },
       {
         "id": 2718,
@@ -2521,13 +2829,14 @@
         "verse": "My name will be great among the nations, from where the sun rises to where it sets. In every place incense and pure offerings will be brought to me, because my name will be great among the nations, says the Lord Almighty.",
         "book": "Malachi",
         "reference": "1:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "16c71d811b477a8b"
       }
     ]
   },
   {
     "name": "TMS 180 · Getting to Know God",
-    "color": "#6A4C93",
+    "color": "#5E3A87",
     "accentText": "1",
     "verses": [
       {
@@ -2536,7 +2845,8 @@
         "verse": "In the beginning was the Word, and the Word was with God, and the Word was God. The Word became flesh and made his dwelling among us. We have seen his glory, the glory of the one and only Son, who came from the Father, full of grace and truth.",
         "book": "John",
         "reference": "1:1,14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ad0fd6a5607c6206"
       },
       {
         "id": 10002,
@@ -2544,7 +2854,8 @@
         "verse": "But about the Son he says, \"Your throne, O God, will last for ever and ever; a scepter of justice will be the scepter of your kingdom.",
         "book": "Hebrews",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6acde3c43628147f"
       },
       {
         "id": 10003,
@@ -2552,7 +2863,8 @@
         "verse": "For we do not have a high priest who is unable to empathize with our weaknesses, but we have one who has been tempted in every way, just as we are—yet he did not sin.",
         "book": "Hebrews",
         "reference": "4:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7d9b9e7292cd2201"
       },
       {
         "id": 10004,
@@ -2560,7 +2872,8 @@
         "verse": "And Jesus grew in wisdom and stature, and in favor with God and man.",
         "book": "Luke",
         "reference": "2:52",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2888e1e2bd72d8c8"
       },
       {
         "id": 10005,
@@ -2568,7 +2881,8 @@
         "verse": "For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day according to the Scriptures,",
         "book": "1 Corinthians",
         "reference": "15:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e01fa1abc4c824dc"
       },
       {
         "id": 10006,
@@ -2576,7 +2890,8 @@
         "verse": "But Christ has indeed been raised from the dead, the firstfruits of those who have fallen asleep.",
         "book": "1 Corinthians",
         "reference": "15:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "088c7dbc0517e935"
       },
       {
         "id": 10007,
@@ -2584,7 +2899,8 @@
         "verse": "No one has ever seen God, but the one and only Son, who is himself God and is in closest relationship with the Father, has made him known.",
         "book": "John",
         "reference": "1:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce14c2ec2ccf422b"
       },
       {
         "id": 10008,
@@ -2592,7 +2908,8 @@
         "verse": "The Son is the radiance of God's glory and the exact representation of his being, sustaining all things by his powerful word. After he had provided purification for sins, he sat down at the right hand of the Majesty in heaven.",
         "book": "Hebrews",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ca24432e0ba3341a"
       },
       {
         "id": 10009,
@@ -2600,7 +2917,8 @@
         "verse": "For the Son of Man came to seek and to save the lost.",
         "book": "Luke",
         "reference": "19:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ab2695c0099c3ddf"
       },
       {
         "id": 10010,
@@ -2608,7 +2926,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your ancestors, but with the precious blood of Christ, a lamb without blemish or defect.",
         "book": "1 Peter",
         "reference": "1:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c084bca16a5249b1"
       },
       {
         "id": 10011,
@@ -2616,7 +2935,8 @@
         "verse": "For the Lord himself will come down from heaven, with a loud command, with the voice of the archangel and with the trumpet call of God, and the dead in Christ will rise first. After that, we who are still alive and are left will be caught up together with them in the clouds to meet the Lord in the air. And so we will be with the Lord forever.",
         "book": "1 Thessalonians",
         "reference": "4:16-17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e40a5387c97e290c"
       },
       {
         "id": 10012,
@@ -2624,7 +2944,8 @@
         "verse": "Dear friends, now we are children of God, and what we will be has not yet been made known. But we know that when Christ appears, we shall be like him, for we shall see him as he is. All who have this hope in him purify themselves, just as he is pure.",
         "book": "1 John",
         "reference": "3:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cb877f495a4fe3d5"
       },
       {
         "id": 10013,
@@ -2632,7 +2953,8 @@
         "verse": "But when he, the Spirit of truth, comes, he will guide you into all the truth. He will not speak on his own; he will speak only what he hears, and he will tell you what is yet to come. He will glorify me because it is from me that he will receive what he will make known to you.",
         "book": "John",
         "reference": "16:13-14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6c11e294ab00721e"
       },
       {
         "id": 10014,
@@ -2640,7 +2962,8 @@
         "verse": "Therefore I want you to know that no one who is speaking by the Spirit of God says, \"Jesus be cursed,\" and no one can say, \"Jesus is Lord,\" except by the Holy Spirit.",
         "book": "1 Corinthians",
         "reference": "12:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "94590e66b55fbf56"
       },
       {
         "id": 10015,
@@ -2648,7 +2971,8 @@
         "verse": "You, however, are not in the realm of the flesh but are in the realm of the Spirit, if indeed the Spirit of God lives in you. And if anyone does not have the Spirit of Christ, they do not belong to Christ.",
         "book": "Romans",
         "reference": "8:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f84e56d9698659ed"
       },
       {
         "id": 10016,
@@ -2656,7 +2980,8 @@
         "verse": "Because you are his sons, God sent the Spirit of his Son into our hearts, the Spirit who calls out, \"Abba, Father.\"",
         "book": "Galatians",
         "reference": "4:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2d0c0113984c1c62"
       },
       {
         "id": 10017,
@@ -2664,7 +2989,8 @@
         "verse": "Do not get drunk on wine, which leads to debauchery. Instead, be filled with the Spirit,",
         "book": "Ephesians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "934cf5ee6c5e0793"
       },
       {
         "id": 10018,
@@ -2672,7 +2998,8 @@
         "verse": "So I say, walk by the Spirit, and you will not gratify the desires of the flesh.",
         "book": "Galatians",
         "reference": "5:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a9a55158fafd358d"
       },
       {
         "id": 10019,
@@ -2680,7 +3007,8 @@
         "verse": "However, as it is written: \"What no eye has seen, what no ear has heard, and what no human mind has conceived\"—the things God has prepared for those who love him—these are the things God has revealed to us by his Spirit. The Spirit searches all things, even the deep things of God.",
         "book": "1 Corinthians",
         "reference": "2:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fb52c890d7c702fe"
       },
       {
         "id": 10020,
@@ -2688,7 +3016,8 @@
         "verse": "But the Advocate, the Holy Spirit, whom the Father will send in my name, will teach you all things and will remind you of everything I have said to you.",
         "book": "John",
         "reference": "14:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7e5b8f2a9ce2f2ec"
       },
       {
         "id": 10021,
@@ -2696,7 +3025,8 @@
         "verse": "My message and my preaching were not with wise and persuasive words, but with a demonstration of the Spirit's power, so that your faith might not rest on human wisdom, but on God's power.",
         "book": "1 Corinthians",
         "reference": "2:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c94d71e4e1be5f02"
       },
       {
         "id": 10022,
@@ -2704,7 +3034,8 @@
         "verse": "because our gospel came to you not simply with words but also with power, with the Holy Spirit and deep conviction. You know how we lived among you for your sake.",
         "book": "1 Thessalonians",
         "reference": "1:5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "346c64a29af2dffa"
       },
       {
         "id": 10023,
@@ -2712,7 +3043,8 @@
         "verse": "All these are the work of one and the same Spirit, and he distributes them to each one, just as he determines.",
         "book": "1 Corinthians",
         "reference": "12:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8e9590712ff9022e"
       },
       {
         "id": 10024,
@@ -2720,7 +3052,8 @@
         "verse": "There are different kinds of gifts, but the same Spirit distributes them. There are different kinds of service, but the same Lord. There are different kinds of working, but in all of them and in everyone it is the same God at work.",
         "book": "1 Corinthians",
         "reference": "12:4-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d0a67cdcb1ca8032"
       },
       {
         "id": 10025,
@@ -2728,7 +3061,8 @@
         "verse": "\"Ah, Sovereign Lord, you have made the heavens and the earth by your great power and outstretched arm. Nothing is too hard for you.",
         "book": "Jeremiah",
         "reference": "32:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "63af1504260b6d44"
       },
       {
         "id": 10026,
@@ -2736,7 +3070,8 @@
         "verse": "Oh, the depth of the riches of the wisdom and knowledge of God! How unsearchable his judgments, and his paths beyond tracing out!",
         "book": "Romans",
         "reference": "11:33",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9a1d29c7f5d1cba9"
       },
       {
         "id": 10027,
@@ -2744,7 +3079,8 @@
         "verse": "Who can hide in secret places so that I cannot see them?\" declares the Lord. \"Do not I fill heaven and earth?\" declares the Lord.",
         "book": "Jeremiah",
         "reference": "23:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ffec9be019bc9028"
       },
       {
         "id": 10028,
@@ -2752,7 +3088,8 @@
         "verse": "And God is able to bless you abundantly, so that in all things at all times, having all that you need, you will abound in every good work.",
         "book": "2 Corinthians",
         "reference": "9:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a2f3f455fd612c0a"
       },
       {
         "id": 10029,
@@ -2760,7 +3097,8 @@
         "verse": "Yours, Lord, is the greatness and the power and the glory and the majesty and the splendor, for everything in heaven and earth is yours. Yours, Lord, is the kingdom; you are exalted as head over all. Wealth and honor come from you; you are the ruler of all things. In your hands are strength and power to exalt and give strength to all. Now, our God, we give you thanks, and praise your glorious name.",
         "book": "1 Chronicles",
         "reference": "29:11-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b458144f068a002c"
       },
       {
         "id": 10030,
@@ -2768,7 +3106,8 @@
         "verse": "But the Lord is faithful, and he will strengthen you and protect you from the evil one.",
         "book": "2 Thessalonians",
         "reference": "3:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d3623bbdfbd7a5e6"
       },
       {
         "id": 10031,
@@ -2776,7 +3115,8 @@
         "verse": "God is spirit, and his worshipers must worship in the Spirit and in truth.\"",
         "book": "John",
         "reference": "4:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0c1e0ff9f5051499"
       },
       {
         "id": 10032,
@@ -2784,7 +3124,8 @@
         "verse": "But just as he who called you is holy, so be holy in all you do; for it is written: \"Be holy, because I am holy.\"",
         "book": "1 Peter",
         "reference": "1:15-16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87c3b0c2b4922da5"
       },
       {
         "id": 10033,
@@ -2792,7 +3133,8 @@
         "verse": "Great is the Lord and most worthy of praise; his greatness no one can fathom.",
         "book": "Psalm",
         "reference": "145:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "414d0b41aca470cd"
       },
       {
         "id": 10034,
@@ -2800,7 +3142,8 @@
         "verse": "This is love: not that we loved God, but that he loved us and sent his Son as an atoning sacrifice for our sins.",
         "book": "1 John",
         "reference": "4:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e005d0657d7a7677"
       },
       {
         "id": 10035,
@@ -2808,7 +3151,8 @@
         "verse": "But you, Lord, are a compassionate and gracious God, slow to anger, abounding in love and faithfulness.",
         "book": "Psalm",
         "reference": "86:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "37af79e3a159dfce"
       },
       {
         "id": 10036,
@@ -2816,13 +3160,14 @@
         "verse": "And we know that in all things God works for the good of those who love him, who have been called according to his purpose.",
         "book": "Romans",
         "reference": "8:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "21a48c3904b01d89"
       }
     ]
   },
   {
     "name": "TMS 180 · Growing in Love",
-    "color": "#C9184A",
+    "color": "#8E3339",
     "accentText": "2",
     "verses": [
       {
@@ -2831,7 +3176,8 @@
         "verse": "Instead, speaking the truth in love, we will grow to become in every respect the mature body of him who is the head, that is, Christ.",
         "book": "Ephesians",
         "reference": "4:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "11e78ee8c60ce5c3"
       },
       {
         "id": 10038,
@@ -2839,7 +3185,8 @@
         "verse": "Do not lie to each other, since you have taken off your old self with its practices",
         "book": "Colossians",
         "reference": "3:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "872a33c8833cb8c0"
       },
       {
         "id": 10039,
@@ -2847,7 +3194,8 @@
         "verse": "Whoever would foster love covers over an offense, but whoever repeats the matter separates close friends.",
         "book": "Proverbs",
         "reference": "17:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d75462755ef041c9"
       },
       {
         "id": 10040,
@@ -2855,7 +3203,8 @@
         "verse": "A gossip betrays a confidence, but a trustworthy person keeps a secret.",
         "book": "Proverbs",
         "reference": "11:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "efa987c982d29584"
       },
       {
         "id": 10041,
@@ -2863,7 +3212,8 @@
         "verse": "Pray that I may proclaim it clearly, as I should. Be wise in the way you act toward outsiders; make the most of every opportunity. Let your conversation be always full of grace, seasoned with salt, so that you may know how to answer everyone.",
         "book": "Colossians",
         "reference": "4:4-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8722804ef75a7d5e"
       },
       {
         "id": 10042,
@@ -2871,7 +3221,8 @@
         "verse": "A gentle answer turns away wrath, but a harsh word stirs up anger.",
         "book": "Proverbs",
         "reference": "15:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5c132d4b09302f09"
       },
       {
         "id": 10043,
@@ -2879,7 +3230,8 @@
         "verse": "Therefore confess your sins to each other and pray for each other so that you may be healed. The prayer of a righteous person is powerful and effective.",
         "book": "James",
         "reference": "5:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "813c49277fd475c3"
       },
       {
         "id": 10044,
@@ -2887,7 +3239,8 @@
         "verse": "Therefore, if you are offering your gift at the altar and there remember that your brother or sister has something against you, leave your gift there in front of the altar. First go and be reconciled to them; then come and offer your gift.",
         "book": "Matthew",
         "reference": "5:23-24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c9ecfd87bb0a09ca"
       },
       {
         "id": 10045,
@@ -2895,7 +3248,8 @@
         "verse": "My dear brothers and sisters, take note of this: Everyone should be quick to listen, slow to speak and slow to become angry,",
         "book": "James",
         "reference": "1:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "85649b891714205e"
       },
       {
         "id": 10046,
@@ -2903,7 +3257,8 @@
         "verse": "To answer before listening—that is folly and shame.",
         "book": "Proverbs",
         "reference": "18:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "18089a507336ab09"
       },
       {
         "id": 10047,
@@ -2911,7 +3266,8 @@
         "verse": "Do not rebuke mockers or they will hate you; rebuke the wise and they will love you. Instruct the wise and they will be wiser still; teach the righteous and they will add to their learning.",
         "book": "Proverbs",
         "reference": "9:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "048db2ee06b91498"
       },
       {
         "id": 10048,
@@ -2919,7 +3275,8 @@
         "verse": "If your brother or sister sins, go and point out their fault, just between the two of you. If they listen to you, you have won them over.",
         "book": "Matthew",
         "reference": "18:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ccba60cd59c75916"
       },
       {
         "id": 10049,
@@ -2927,7 +3284,8 @@
         "verse": "Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you.",
         "book": "Ephesians",
         "reference": "4:32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "53a7b4e11dacac07"
       },
       {
         "id": 10050,
@@ -2935,7 +3293,8 @@
         "verse": "Bear with each other and forgive one another if any of you has a grievance against someone. Forgive as the Lord forgave you.",
         "book": "Colossians",
         "reference": "3:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8decb3b7b3a54386"
       },
       {
         "id": 10051,
@@ -2943,7 +3302,8 @@
         "verse": "Be completely humble and gentle; be patient, bearing with one another in love.",
         "book": "Ephesians",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a43d9a576dbbca87"
       },
       {
         "id": 10052,
@@ -2951,7 +3311,8 @@
         "verse": "And the Lord's servant must not be quarrelsome but must be kind to everyone, able to teach, not resentful. Opponents must be gently instructed, in the hope that God will grant them repentance leading them to a knowledge of the truth,",
         "book": "2 Timothy",
         "reference": "2:24-25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "75e6c58cbc58e778"
       },
       {
         "id": 10053,
@@ -2959,7 +3320,8 @@
         "verse": "\"In your anger do not sin\": Do not let the sun go down while you are still angry,",
         "book": "Ephesians",
         "reference": "4:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4ac16250f278b4d1"
       },
       {
         "id": 10054,
@@ -2967,7 +3329,8 @@
         "verse": "But now you must also rid yourselves of all such things as these: anger, rage, malice, slander, and filthy language from your lips.",
         "book": "Colossians",
         "reference": "3:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a438dd5a60ce77f4"
       },
       {
         "id": 10055,
@@ -2975,7 +3338,8 @@
         "verse": "See to it that no one falls short of the grace of God and that no bitter root grows up to cause trouble and defile many.",
         "book": "Hebrews",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5fc9ab7e18196f69"
       },
       {
         "id": 10056,
@@ -2983,7 +3347,8 @@
         "verse": "Get rid of all bitterness, rage and anger, brawling and slander, along with every form of malice.",
         "book": "Ephesians",
         "reference": "4:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "26023181f40150cb"
       },
       {
         "id": 10057,
@@ -2991,7 +3356,17 @@
         "verse": "But how is it to your credit if you receive a beating for doing wrong and endure it? But if you suffer for doing good and you endure it, this is commendable before God. To this you were called, because Christ suffered for you, leaving you an example, that you should follow in his steps.",
         "book": "1 Peter",
         "reference": "2:20-21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2536ca7cdf835907"
+      },
+      {
+        "id": 20001,
+        "title": "Endure Injustice",
+        "verse": "Do not take revenge, my dear friends, but leave room for God’s wrath, for it is written: “It is mine to avenge; I will repay,” says the Lord.",
+        "book": "Romans",
+        "reference": "12:19",
+        "subpack": "",
+        "cardUid": "2f0b947e5be05ec1"
       },
       {
         "id": 10058,
@@ -2999,7 +3374,8 @@
         "verse": "Anger is cruel and fury overwhelming, but who can stand before jealousy?",
         "book": "Proverbs",
         "reference": "27:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6e481bccd76cb08e"
       },
       {
         "id": 10059,
@@ -3007,7 +3383,8 @@
         "verse": "For where you have envy and selfish ambition, there you find disorder and every evil practice.",
         "book": "James",
         "reference": "3:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4e0aa82a4f2980dd"
       },
       {
         "id": 10060,
@@ -3015,7 +3392,8 @@
         "verse": "May the God who gives endurance and encouragement give you the same attitude of mind toward each other that Christ Jesus had, so that with one mind and one voice you may glorify the God and Father of our Lord Jesus Christ.",
         "book": "Romans",
         "reference": "15:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dc3a406c36c50e6e"
       },
       {
         "id": 10061,
@@ -3023,7 +3401,8 @@
         "verse": "I appeal to you, brothers and sisters, in the name of our Lord Jesus Christ, that all of you agree with one another in what you say and that there be no divisions among you, but that you be perfectly united in mind and thought.",
         "book": "1 Corinthians",
         "reference": "1:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "36846201f0e81be8"
       },
       {
         "id": 10062,
@@ -3031,7 +3410,8 @@
         "verse": "Not so with you. Instead, whoever wants to become great among you must be your servant, and whoever wants to be first must be your slave—",
         "book": "Matthew",
         "reference": "20:26-27",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7f072ea7763a22c8"
       },
       {
         "id": 10063,
@@ -3039,7 +3419,8 @@
         "verse": "You, my brothers and sisters, were called to be free. But do not use your freedom to indulge the flesh; rather, serve one another humbly in love.",
         "book": "Galatians",
         "reference": "5:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9b82340a369679d6"
       },
       {
         "id": 10064,
@@ -3047,7 +3428,8 @@
         "verse": "Each of us should please our neighbors for their good, to build them up.",
         "book": "Romans",
         "reference": "15:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "41aa402b865a4118"
       },
       {
         "id": 10065,
@@ -3055,7 +3437,8 @@
         "verse": "Do nothing out of selfish ambition or vain conceit. Rather, in humility value others above yourselves, not looking to your own interests but each of you to the interests of the others.",
         "book": "Philippians",
         "reference": "2:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "03667fb75c855075"
       },
       {
         "id": 10066,
@@ -3063,7 +3446,8 @@
         "verse": "Therefore encourage one another and build each other up, just as in fact you are doing.",
         "book": "1 Thessalonians",
         "reference": "5:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "78201e7718866680"
       },
       {
         "id": 10067,
@@ -3071,7 +3455,8 @@
         "verse": "Two are better than one, because they have a good return for their labor: If either of them falls down, one can help the other up. But pity anyone who falls and has no one to help them up.",
         "book": "Ecclesiastes",
         "reference": "4:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3336f4844b76863d"
       },
       {
         "id": 10068,
@@ -3079,7 +3464,8 @@
         "verse": "When he saw the crowds, he had compassion on them, because they were harassed and helpless, like sheep without a shepherd.",
         "book": "Matthew",
         "reference": "9:36",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "835f9cba837bbe84"
       },
       {
         "id": 10069,
@@ -3087,7 +3473,8 @@
         "verse": "Rejoice with those who rejoice; mourn with those who mourn.",
         "book": "Romans",
         "reference": "12:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "06b7b9c92c05840d"
       },
       {
         "id": 10070,
@@ -3095,7 +3482,8 @@
         "verse": "But the wisdom that comes from heaven is first of all pure; then peace-loving, considerate, submissive, full of mercy and good fruit, impartial and sincere.",
         "book": "James",
         "reference": "3:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "890ba6720c15bbdb"
       },
       {
         "id": 10071,
@@ -3103,13 +3491,14 @@
         "verse": "Brothers and sisters, if someone is caught in a sin, you who live by the Spirit should restore that person gently. But watch yourselves, or you also may be tempted.",
         "book": "Galatians",
         "reference": "6:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "71db06fd0bdcf929"
       }
     ]
   },
   {
     "name": "TMS 180 · Growing in Faith",
-    "color": "#1B998B",
+    "color": "#2E86B8",
     "accentText": "3",
     "verses": [
       {
@@ -3118,7 +3507,8 @@
         "verse": "His divine power has given us everything we need for a godly life through our knowledge of him who called us by his own glory and goodness. Through these he has given us his very great and precious promises, so that through them you may participate in the divine nature, having escaped the corruption in the world caused by evil desires.",
         "book": "2 Peter",
         "reference": "1:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef02d3aee1d50539"
       },
       {
         "id": 10073,
@@ -3126,7 +3516,8 @@
         "verse": "For no matter how many promises God has made, they are \"Yes\" in Christ. And so through him the \"Amen\" is spoken by us to the glory of God.",
         "book": "2 Corinthians",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "774e855fbdabfd6e"
       },
       {
         "id": 10074,
@@ -3134,7 +3525,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ, the Father of compassion and the God of all comfort, who comforts us in all our troubles, so that we can comfort those in any trouble with the comfort we ourselves receive from God.",
         "book": "2 Corinthians",
         "reference": "1:3-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d08a657e650c3eda"
       },
       {
         "id": 10075,
@@ -3142,7 +3534,8 @@
         "verse": "So neither the one who plants nor the one who waters is anything, but only God, who makes things grow. The one who plants and the one who waters have one purpose, and they will each be rewarded according to their own labor.",
         "book": "1 Corinthians",
         "reference": "3:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "56a51c22bcb41dcf"
       },
       {
         "id": 10076,
@@ -3150,7 +3543,8 @@
         "verse": "but whose delight is in the law of the Lord, and who meditates on his law day and night. That person is like a tree planted by streams of water, which yields its fruit in season and whose leaf does not wither—whatever they do prospers.",
         "book": "Psalm",
         "reference": "1:2-3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "591b37ed6ad03f6c"
       },
       {
         "id": 10077,
@@ -3158,7 +3552,8 @@
         "verse": "For if you possess these qualities in increasing measure, they will keep you from being ineffective and unproductive in your knowledge of our Lord Jesus Christ.",
         "book": "2 Peter",
         "reference": "1:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5a5bf10ed89a6439"
       },
       {
         "id": 10078,
@@ -3166,7 +3561,17 @@
         "verse": "And the God of all grace, who called you to his eternal glory in Christ, after you have suffered a little while, will himself restore you and make you strong, firm and steadfast.",
         "book": "1 Peter",
         "reference": "5:10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ce5bf5d8dc8629ae"
+      },
+      {
+        "id": 20002,
+        "title": "Promises for Help in Trouble",
+        "verse": "But he said to me, “My grace is sufficient for you, for my power is made perfect in weakness.” Therefore I will boast all the more gladly about my weaknesses, so that Christ’s power may rest on me.",
+        "book": "2 Corinthians",
+        "reference": "12:9",
+        "subpack": "",
+        "cardUid": "79ef8e7360ce5484"
       },
       {
         "id": 10079,
@@ -3174,7 +3579,8 @@
         "verse": "Praise be to the God and Father of our Lord Jesus Christ, who has blessed us in the heavenly realms with every spiritual blessing in Christ.",
         "book": "Ephesians",
         "reference": "1:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "25cd3f2672c6a6ed"
       },
       {
         "id": 10080,
@@ -3182,7 +3588,8 @@
         "verse": "Take delight in the Lord, and he will give you the desires of your heart. Commit your way to the Lord; trust in him and he will do this:",
         "book": "Psalm",
         "reference": "37:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5f19e5534fa2f7ea"
       },
       {
         "id": 10081,
@@ -3190,7 +3597,8 @@
         "verse": "My dear children, I write this to you so that you will not sin. But if anybody does sin, we have an advocate with the Father—Jesus Christ, the Righteous One. He is the atoning sacrifice for our sins, and not only for ours but also for the sins of the whole world.",
         "book": "1 John",
         "reference": "2:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "692cffe3a091d7f5"
       },
       {
         "id": 10082,
@@ -3198,7 +3606,8 @@
         "verse": "as far as the east is from the west, so far has he removed our transgressions from us.",
         "book": "Psalm",
         "reference": "103:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5b91eda5d730a0b4"
       },
       {
         "id": 10083,
@@ -3206,7 +3615,8 @@
         "verse": "For the word of God is alive and active. Sharper than any double-edged sword, it penetrates even to dividing soul and spirit, joints and marrow; it judges the thoughts and attitudes of the heart.",
         "book": "Hebrews",
         "reference": "4:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1abaf7aa796fed7a"
       },
       {
         "id": 10084,
@@ -3214,7 +3624,8 @@
         "verse": "As the rain and the snow come down from heaven, and do not return to it without watering the earth and making it bud and flourish, so that it yields seed for the sower and bread for the eater, so is my word that goes out from my mouth: It will not return to me empty, but will accomplish what I desire and achieve the purpose for which I sent it.",
         "book": "Isaiah",
         "reference": "55:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d7cbbf0256f7201f"
       },
       {
         "id": 10085,
@@ -3222,7 +3633,8 @@
         "verse": "Above all, you must understand that no prophecy of Scripture came about by the prophet's own interpretation of things. For prophecy never had its origin in the human will, but prophets, though human, spoke from God as they were carried along by the Holy Spirit.",
         "book": "2 Peter",
         "reference": "1:20-21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "20350effdd439fc0"
       },
       {
         "id": 10086,
@@ -3230,7 +3642,8 @@
         "verse": "And we also thank God continually because, when you received the word of God, which you heard from us, you accepted it not as a human word, but as it actually is, the word of God, which is indeed at work in you who believe.",
         "book": "1 Thessalonians",
         "reference": "2:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6dbe34129bc8feed"
       },
       {
         "id": 10087,
@@ -3238,7 +3651,8 @@
         "verse": "When your words came, I ate them; they were my joy and my heart's delight, for I bear your name, Lord God Almighty.",
         "book": "Jeremiah",
         "reference": "15:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "76da5408958980a0"
       },
       {
         "id": 10088,
@@ -3246,7 +3660,8 @@
         "verse": "I have not departed from the commands of his lips; I have treasured the words of his mouth more than my daily bread.",
         "book": "Job",
         "reference": "23:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "96115d4dcdaf863d"
       },
       {
         "id": 10089,
@@ -3254,7 +3669,8 @@
         "verse": "Now the Berean Jews were of more noble character than those in Thessalonica, for they received the message with great eagerness and examined the Scriptures every day to see if what Paul said was true.",
         "book": "Acts",
         "reference": "17:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "86e6550aa5bf9704"
       },
       {
         "id": 10090,
@@ -3262,7 +3678,8 @@
         "verse": "You study the Scriptures diligently because you think that in them you have eternal life. These are the very Scriptures that testify about me, yet you refuse to come to me to have life.",
         "book": "John",
         "reference": "5:39-40",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "87370dc5ed549d87"
       },
       {
         "id": 10091,
@@ -3270,7 +3687,17 @@
         "verse": "To the Jews who had believed him, Jesus said, \"If you hold to my teaching, you are really my disciples. Then you will know the truth, and the truth will set you free.\"",
         "book": "John",
         "reference": "8:31-32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c5d3591e1fce395"
+      },
+      {
+        "id": 20003,
+        "title": "Obey",
+        "verse": "Jesus answered, “It is written: ‘Man shall not live on bread alone, but on every word that comes from the mouth of God.’”",
+        "book": "Matthew",
+        "reference": "4:4",
+        "subpack": "",
+        "cardUid": "4668ba1f5984f1be"
       },
       {
         "id": 10092,
@@ -3278,7 +3705,8 @@
         "verse": "Heaven and earth will pass away, but my words will never pass away.",
         "book": "Matthew",
         "reference": "24:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "280e3df0637ff130"
       },
       {
         "id": 10093,
@@ -3286,7 +3714,8 @@
         "verse": "Sanctify them by the truth; your word is truth.",
         "book": "John",
         "reference": "17:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b908bbcdb8145961"
       },
       {
         "id": 10094,
@@ -3294,7 +3723,8 @@
         "verse": "In all this you greatly rejoice, though now for a little while you may have had to suffer grief in all kinds of trials. These have come so that the proven genuineness of your faith—of greater worth than gold, which perishes even though refined by fire—may result in praise, glory and honor when Jesus Christ is revealed.",
         "book": "1 Peter",
         "reference": "1:6-7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c371f333631da31e"
       },
       {
         "id": 10095,
@@ -3302,7 +3732,8 @@
         "verse": "Consider it pure joy, my brothers and sisters, whenever you face trials of many kinds, because you know that the testing of your faith produces perseverance. Let perseverance finish its work so that you may be mature and complete, not lacking anything.",
         "book": "James",
         "reference": "1:2-4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "83e832f8a88050d3"
       },
       {
         "id": 10096,
@@ -3310,7 +3741,8 @@
         "verse": "For we also have had the good news proclaimed to us, just as they did; but the message they heard was of no value to them, because they did not share the faith of those who obeyed.",
         "book": "Hebrews",
         "reference": "4:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "57b01b90544057f4"
       },
       {
         "id": 10097,
@@ -3318,7 +3750,8 @@
         "verse": "And, \"But my righteous one will live by faith. And I take no pleasure in the one who shrinks back.\"",
         "book": "Hebrews",
         "reference": "10:38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "948aa9d522b1120e"
       },
       {
         "id": 10098,
@@ -3326,7 +3759,8 @@
         "verse": "In addition to all this, take up the shield of faith, with which you can extinguish all the flaming arrows of the evil one.",
         "book": "Ephesians",
         "reference": "6:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "db33ab280862de77"
       },
       {
         "id": 10099,
@@ -3334,7 +3768,8 @@
         "verse": "But you, man of God, flee from all this, and pursue righteousness, godliness, faith, love, endurance and gentleness. Fight the good fight of the faith. Take hold of the eternal life to which you were called when you made your good confession in the presence of many witnesses.",
         "book": "1 Timothy",
         "reference": "6:11-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "868850efc43ddab2"
       },
       {
         "id": 10100,
@@ -3342,7 +3777,8 @@
         "verse": "Now faith is confidence in what we hope for and assurance about what we do not see.",
         "book": "Hebrews",
         "reference": "11:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9d1b38928487cc90"
       },
       {
         "id": 10101,
@@ -3350,7 +3786,8 @@
         "verse": "Consequently, faith comes from hearing the message, and the message is heard through the word about Christ.",
         "book": "Romans",
         "reference": "10:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9bc115188c1202e5"
       },
       {
         "id": 10102,
@@ -3358,7 +3795,8 @@
         "verse": "We do not want you to become lazy, but to imitate those who through faith and patience inherit what has been promised.",
         "book": "Hebrews",
         "reference": "6:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "e1f5cbc358126d5d"
       },
       {
         "id": 10103,
@@ -3366,7 +3804,8 @@
         "verse": "In the same way, faith by itself, if it is not accompanied by action, is dead.",
         "book": "James",
         "reference": "2:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "10911412e968ced8"
       },
       {
         "id": 10104,
@@ -3374,7 +3813,8 @@
         "verse": "know that a person is not justified by the works of the law, but by faith in Jesus Christ. So we, too, have put our faith in Christ Jesus that we may be justified by faith in Christ and not by the works of the law, because by the works of the law no one will be justified.",
         "book": "Galatians",
         "reference": "2:16",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6f3150a9d0bc3da4"
       },
       {
         "id": 10105,
@@ -3382,13 +3822,14 @@
         "verse": "Therefore, since we have been justified through faith, we have peace with God through our Lord Jesus Christ,",
         "book": "Romans",
         "reference": "5:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "5ae61635c33dbfc0"
       }
     ]
   },
   {
     "name": "TMS 180 · Walking in Victory",
-    "color": "#BC6C25",
+    "color": "#8E9A3C",
     "accentText": "4",
     "verses": [
       {
@@ -3397,7 +3838,8 @@
         "verse": "But thanks be to God! He gives us the victory through our Lord Jesus Christ.",
         "book": "1 Corinthians",
         "reference": "15:57",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ef6c99115ef786a8"
       },
       {
         "id": 10107,
@@ -3405,7 +3847,8 @@
         "verse": "But thanks be to God, who always leads us as captives in Christ's triumphal procession and uses us to spread the aroma of the knowledge of him everywhere.",
         "book": "2 Corinthians",
         "reference": "2:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8d6ce4c3d4eb0f37"
       },
       {
         "id": 10108,
@@ -3413,7 +3856,8 @@
         "verse": "The weapons we fight with are not the weapons of the world. On the contrary, they have divine power to demolish strongholds. We demolish arguments and every pretension that sets itself up against the knowledge of God, and we take captive every thought to make it obedient to Christ.",
         "book": "2 Corinthians",
         "reference": "10:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ab11c93d756bb064"
       },
       {
         "id": 10109,
@@ -3421,7 +3865,8 @@
         "verse": "Finally, be strong in the Lord and in his mighty power. Put on the full armor of God, so that you can take your stand against the devil's schemes.",
         "book": "Ephesians",
         "reference": "6:10-11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3f13bfde408474b3"
       },
       {
         "id": 10110,
@@ -3429,7 +3874,8 @@
         "verse": "They triumphed over him by the blood of the Lamb and by the word of their testimony; they did not love their lives so much as to shrink from death.",
         "book": "Revelation",
         "reference": "12:11",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d10c20d806e12f0c"
       },
       {
         "id": 10111,
@@ -3437,7 +3883,8 @@
         "verse": "Submit yourselves, then, to God. Resist the devil, and he will flee from you. Come near to God and he will come near to you. Wash your hands, you sinners, and purify your hearts, you double-minded.",
         "book": "James",
         "reference": "4:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b6d5b270920d8bc0"
       },
       {
         "id": 10112,
@@ -3445,7 +3892,8 @@
         "verse": "Those who live according to the flesh have their minds set on what the flesh desires; but those who live in accordance with the Spirit have their minds set on what the Spirit desires. The mind governed by the flesh is death, but the mind governed by the Spirit is life and peace.",
         "book": "Romans",
         "reference": "8:5-6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8c18bfc3c5f8ed00"
       },
       {
         "id": 10113,
@@ -3453,7 +3901,8 @@
         "verse": "Rather, clothe yourselves with the Lord Jesus Christ, and do not think about how to gratify the desires of the flesh.",
         "book": "Romans",
         "reference": "13:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "af95e96ed1bd7d3e"
       },
       {
         "id": 10114,
@@ -3461,7 +3910,8 @@
         "verse": "You, dear children, are from God and have overcome them, because the one who is in you is greater than the one who is in the world.",
         "book": "1 John",
         "reference": "4:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61714393f371382a"
       },
       {
         "id": 10115,
@@ -3469,7 +3919,8 @@
         "verse": "for everyone born of God overcomes the world. This is the victory that has overcome the world, even our faith. Who is it that overcomes the world? Only the one who believes that Jesus is the Son of God.",
         "book": "1 John",
         "reference": "5:4-5",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7de51f8bb243f450"
       },
       {
         "id": 10116,
@@ -3477,7 +3928,8 @@
         "verse": "The law of their God is in their hearts; their feet do not slip.",
         "book": "Psalm",
         "reference": "37:31",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6427e7a6ce996c44"
       },
       {
         "id": 10117,
@@ -3485,7 +3937,8 @@
         "verse": "Therefore do not let sin reign in your mortal body so that you obey its evil desires. Do not offer any part of yourself to sin as an instrument of wickedness, but rather offer yourselves to God as those who have been brought from death to life; and offer every part of yourself to him as an instrument of righteousness.",
         "book": "Romans",
         "reference": "6:12-13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f4e8bf8bcbd51cd1"
       },
       {
         "id": 10118,
@@ -3493,7 +3946,8 @@
         "verse": "Finally, brothers and sisters, whatever is true, whatever is noble, whatever is right, whatever is pure, whatever is lovely, whatever is admirable—if anything is excellent or praiseworthy—think about such things.",
         "book": "Philippians",
         "reference": "4:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "6c813d6dbaa848c7"
       },
       {
         "id": 10119,
@@ -3501,7 +3955,8 @@
         "verse": "To the pure, all things are pure, but to those who are corrupted and do not believe, nothing is pure. In fact, both their minds and consciences are corrupted.",
         "book": "Titus",
         "reference": "1:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8dffcfa2f90c604a"
       },
       {
         "id": 10120,
@@ -3509,7 +3964,8 @@
         "verse": "A good man brings good things out of the good stored up in his heart, and an evil man brings evil things out of the evil stored up in his heart. For the mouth speaks what the heart is full of.",
         "book": "Luke",
         "reference": "6:45",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "69f78182e31c7a2d"
       },
       {
         "id": 10121,
@@ -3517,7 +3973,8 @@
         "verse": "Above all else, guard your heart, for everything you do flows from it.",
         "book": "Proverbs",
         "reference": "4:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "490592c80f9eefb9"
       },
       {
         "id": 10122,
@@ -3525,7 +3982,8 @@
         "verse": "\"The eye is the lamp of the body. If your eyes are healthy, your whole body will be full of light.",
         "book": "Matthew",
         "reference": "6:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "bb88344e7ad33eca"
       },
       {
         "id": 10123,
@@ -3533,7 +3991,8 @@
         "verse": "But I tell you that anyone who looks at a woman lustfully has already committed adultery with her in his heart.",
         "book": "Matthew",
         "reference": "5:28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9e6f2af10e2c4a16"
       },
       {
         "id": 10124,
@@ -3541,7 +4000,8 @@
         "verse": "It is God's will that you should be sanctified: that you should avoid sexual immorality;",
         "book": "1 Thessalonians",
         "reference": "4:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3ce1baf4bc851270"
       },
       {
         "id": 10125,
@@ -3549,7 +4009,8 @@
         "verse": "You say, \"Food for the stomach and the stomach for food, and God will destroy them both.\" The body, however, is not meant for sexual immorality but for the Lord, and the Lord for the body.",
         "book": "1 Corinthians",
         "reference": "6:13",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8fe292821bd17612"
       },
       {
         "id": 10126,
@@ -3557,7 +4018,8 @@
         "verse": "Do not let any unwholesome talk come out of your mouths, but only what is helpful for building others up according to their needs, that it may benefit those who listen.",
         "book": "Ephesians",
         "reference": "4:29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d7921a27159b212e"
       },
       {
         "id": 10127,
@@ -3565,7 +4027,8 @@
         "verse": "But I tell you that everyone will have to give account on the day of judgment for every empty word they have spoken. For by your words you will be acquitted, and by your words you will be condemned.\"",
         "book": "Matthew",
         "reference": "12:36-37",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "8a2f67d1c9858cf9"
       },
       {
         "id": 10128,
@@ -3573,7 +4036,8 @@
         "verse": "reject every kind of evil.",
         "book": "1 Thessalonians",
         "reference": "5:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0ac40c30429e4bbe"
       },
       {
         "id": 10129,
@@ -3581,7 +4045,8 @@
         "verse": "Do not rebuke an older man harshly, but exhort him as if he were your father. Treat younger men as brothers, older women as mothers, and younger women as sisters, with absolute purity.",
         "book": "1 Timothy",
         "reference": "5:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3622acb13fa16041"
       },
       {
         "id": 10130,
@@ -3589,7 +4054,8 @@
         "verse": "If you believe, you will receive whatever you ask for in prayer.",
         "book": "Matthew",
         "reference": "21:22",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d8e4fa462c36c12c"
       },
       {
         "id": 10131,
@@ -3597,7 +4063,8 @@
         "verse": "\"Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; the one who seeks finds; and to the one who knocks, the door will be opened.",
         "book": "Matthew",
         "reference": "7:7-8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dbfd98060dcce681"
       },
       {
         "id": 10132,
@@ -3605,7 +4072,8 @@
         "verse": "But when you pray, go into your room, close the door and pray to your Father, who is unseen. Then your Father, who sees what is done in secret, will reward you.",
         "book": "Matthew",
         "reference": "6:6",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fe37a295cf9d21d4"
       },
       {
         "id": 10133,
@@ -3613,7 +4081,8 @@
         "verse": "Very early in the morning, while it was still dark, Jesus got up, left the house and went off to a solitary place, where he prayed.",
         "book": "Mark",
         "reference": "1:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "17903a9c2ecb61d8"
       },
       {
         "id": 10134,
@@ -3621,7 +4090,8 @@
         "verse": "'Call to me and I will answer you and tell you great and unsearchable things you do not know.'",
         "book": "Jeremiah",
         "reference": "33:3",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "72db4a4990f5a4d3"
       },
       {
         "id": 10135,
@@ -3629,7 +4099,8 @@
         "verse": "Now to him who is able to do immeasurably more than all we ask or imagine, according to his power that is at work within us,",
         "book": "Ephesians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "a1910f617cadeb45"
       },
       {
         "id": 10136,
@@ -3637,7 +4108,8 @@
         "verse": "This is the confidence we have in approaching God: that if we ask anything according to his will, he hears us. And if we know that he hears us—whatever we ask—we know that we have what we asked of him.",
         "book": "1 John",
         "reference": "5:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0e1c038620d70bcb"
       },
       {
         "id": 10137,
@@ -3645,7 +4117,8 @@
         "verse": "pray continually, give thanks in all circumstances; for this is God's will for you in Christ Jesus.",
         "book": "1 Thessalonians",
         "reference": "5:17-18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "b7b2f14446f05d48"
       },
       {
         "id": 10138,
@@ -3653,7 +4126,8 @@
         "verse": "As for me, far be it from me that I should sin against the Lord by failing to pray for you. And I will teach you the way that is good and right.",
         "book": "1 Samuel",
         "reference": "12:23",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "fa5b4c14979333b6"
       },
       {
         "id": 10139,
@@ -3661,7 +4135,8 @@
         "verse": "Then he said to his disciples, \"The harvest is plentiful but the workers are few. Ask the Lord of the harvest, therefore, to send out workers into his harvest field.\"",
         "book": "Matthew",
         "reference": "9:37-38",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7cee46d467f5d565"
       },
       {
         "id": 10140,
@@ -3669,7 +4144,8 @@
         "verse": "Through Jesus, therefore, let us continually offer to God a sacrifice of praise—the fruit of lips that openly profess his name.",
         "book": "Hebrews",
         "reference": "13:15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "396c741fc9c6e29c"
       },
       {
         "id": 10141,
@@ -3677,13 +4153,14 @@
         "verse": "Praise the Lord. Praise the Lord, my soul. I will praise the Lord all my life; I will sing praise to my God as long as I live.",
         "book": "Psalm",
         "reference": "146:1-2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d47cb34c1082651e"
       }
     ]
   },
   {
     "name": "TMS 180 · Sharing Christ with Others",
-    "color": "#277DA1",
+    "color": "#D9925C",
     "accentText": "5",
     "verses": [
       {
@@ -3692,7 +4169,8 @@
         "verse": "To them God has chosen to make known among the Gentiles the glorious riches of this mystery, which is Christ in you, the hope of glory. He is the one we proclaim, admonishing and teaching everyone with all wisdom, so that we may present everyone fully mature in Christ.",
         "book": "Colossians",
         "reference": "1:27-28",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "2d8f6a42022b4fac"
       },
       {
         "id": 10143,
@@ -3700,7 +4178,8 @@
         "verse": "that God was reconciling the world to himself in Christ, not counting people's sins against them. And he has committed to us the message of reconciliation. We are therefore Christ's ambassadors, as though God were making his appeal through us. We implore you on Christ's behalf: Be reconciled to God.",
         "book": "2 Corinthians",
         "reference": "5:19-20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "79bc265815fe3cf9"
       },
       {
         "id": 10144,
@@ -3708,7 +4187,8 @@
         "verse": "On the contrary, we speak as those approved by God to be entrusted with the gospel. We are not trying to please people but God, who tests our hearts.",
         "book": "1 Thessalonians",
         "reference": "2:4",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "29658bfc39ef6394"
       },
       {
         "id": 10145,
@@ -3716,7 +4196,8 @@
         "verse": "Though I am free and belong to no one, I have made myself a slave to everyone, to win as many as possible.",
         "book": "1 Corinthians",
         "reference": "9:19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7b857eb429d1d40e"
       },
       {
         "id": 10146,
@@ -3724,7 +4205,8 @@
         "verse": "Don't you have a saying, 'It's still four months until harvest'? I tell you, open your eyes and look at the fields! They are ripe for harvest.",
         "book": "John",
         "reference": "4:35",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "7a0695f18c11f66c"
       },
       {
         "id": 10147,
@@ -3732,7 +4214,8 @@
         "verse": "so we cared for you. Because we loved you so much, we were delighted to share with you not only the gospel of God but our lives as well.",
         "book": "1 Thessalonians",
         "reference": "2:8",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "11d5b9f231cbc1d7"
       },
       {
         "id": 10148,
@@ -3740,7 +4223,8 @@
         "verse": "As it is written: \"There is no one righteous, not even one; there is no one who understands; there is no one who seeks God. All have turned away, they have together become worthless; there is no one who does good, not even one.\"",
         "book": "Romans",
         "reference": "3:10-12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "02796341ce14ceb2"
       },
       {
         "id": 10149,
@@ -3748,7 +4232,8 @@
         "verse": "He will punish those who do not know God and do not obey the gospel of our Lord Jesus. They will be punished with everlasting destruction and shut out from the presence of the Lord and from the glory of his might",
         "book": "2 Thessalonians",
         "reference": "1:8-9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "cadae55e55fb7885"
       },
       {
         "id": 10150,
@@ -3756,7 +4241,8 @@
         "verse": "\"He himself bore our sins\" in his body on the cross, so that we might die to sins and live for righteousness; \"by his wounds you have been healed.\"",
         "book": "1 Peter",
         "reference": "2:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4dfdaa57ba457f40"
       },
       {
         "id": 10151,
@@ -3764,7 +4250,8 @@
         "verse": "He has saved us and called us to a holy life—not because of anything we have done but because of his own purpose and grace. This grace was given us in Christ Jesus before the beginning of time,",
         "book": "2 Timothy",
         "reference": "1:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c15a1d646552214e"
       },
       {
         "id": 10152,
@@ -3772,7 +4259,8 @@
         "verse": "If you declare with your mouth, \"Jesus is Lord,\" and believe in your heart that God raised him from the dead, you will be saved. For it is with your heart that you believe and are justified, and it is with your mouth that you profess your faith and are saved.",
         "book": "Romans",
         "reference": "10:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "d4c353e0a264a83e"
       },
       {
         "id": 10153,
@@ -3780,7 +4268,8 @@
         "verse": "I give them eternal life, and they shall never perish; no one will snatch them out of my hand. My Father, who has given them to me, is greater than all; no one can snatch them out of my Father's hand.",
         "book": "John",
         "reference": "10:28-29",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "09068f9544a53662"
       },
       {
         "id": 10154,
@@ -3788,7 +4277,8 @@
         "verse": "A person may think their own ways are right, but the Lord weighs the heart.",
         "book": "Proverbs",
         "reference": "21:2",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "1af4487bab249a9c"
       },
       {
         "id": 10155,
@@ -3796,7 +4286,8 @@
         "verse": "What good is it for someone to gain the whole world, yet forfeit their soul?",
         "book": "Mark",
         "reference": "8:36",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f876bef822c59b06"
       },
       {
         "id": 10156,
@@ -3804,7 +4295,8 @@
         "verse": "Anyone who chooses to do the will of God will find out whether my teaching comes from God or whether I speak on my own.",
         "book": "John",
         "reference": "7:17",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "418086039ff57dc3"
       },
       {
         "id": 10157,
@@ -3812,7 +4304,8 @@
         "verse": "Jesus answered them, \"It is not the healthy who need a doctor, but the sick. I have not come to call the righteous, but sinners to repentance.\"",
         "book": "Luke",
         "reference": "5:31-32",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70040b779965a43c"
       },
       {
         "id": 10158,
@@ -3820,7 +4313,8 @@
         "verse": "How can you believe since you accept glory from one another but do not seek the glory that comes from the only God?",
         "book": "John",
         "reference": "5:44",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f730075719c00814"
       },
       {
         "id": 10159,
@@ -3828,7 +4322,8 @@
         "verse": "Therefore he is able to save completely those who come to God through him, because he always lives to intercede for them.",
         "book": "Hebrews",
         "reference": "7:25",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "4d949afb30fea4b3"
       },
       {
         "id": 10160,
@@ -3836,7 +4331,8 @@
         "verse": "Do not boast about tomorrow, for you do not know what a day may bring.",
         "book": "Proverbs",
         "reference": "27:1",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "ed25837ecf494348"
       },
       {
         "id": 10161,
@@ -3844,7 +4340,8 @@
         "verse": "So then, each of us will give an account of ourselves to God.",
         "book": "Romans",
         "reference": "14:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "553bb10cea9b3131"
       },
       {
         "id": 10162,
@@ -3852,7 +4349,8 @@
         "verse": "You study the Scriptures diligently because you think that in them you have eternal life. These are the very Scriptures that testify about me,",
         "book": "John",
         "reference": "5:39",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "aa4048b283e6efe8"
       },
       {
         "id": 10163,
@@ -3860,7 +4358,17 @@
         "verse": "There is a way that appears to be right, but in the end it leads to death.",
         "book": "Proverbs",
         "reference": "14:12",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "dcd1353504785dec"
+      },
+      {
+        "id": 20004,
+        "title": "God Won't Send Anyone to Hell",
+        "verse": "“Then he will say to those on his left, ‘Depart from me, you who are cursed, into the eternal fire prepared for the devil and his angels.",
+        "book": "Matthew",
+        "reference": "25:41",
+        "subpack": "",
+        "cardUid": "fa49520b7758dc6f"
       },
       {
         "id": 10164,
@@ -3868,7 +4376,8 @@
         "verse": "For since the creation of the world God's invisible qualities—his eternal power and divine nature—have been clearly seen, being understood from what has been made, so that people are without excuse.",
         "book": "Romans",
         "reference": "1:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "3ebb7a5a67e9f8cb"
       },
       {
         "id": 10165,
@@ -3876,7 +4385,8 @@
         "verse": "For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your ancestors, but with the precious blood of Christ, a lamb without blemish or defect.",
         "book": "1 Peter",
         "reference": "1:18-19",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "485db829f2e09ccc"
       },
       {
         "id": 10166,
@@ -3884,7 +4394,8 @@
         "verse": "All this is from God, who reconciled us to himself through Christ and gave us the ministry of reconciliation:",
         "book": "2 Corinthians",
         "reference": "5:18",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c8e7d2b351b78ec2"
       },
       {
         "id": 10167,
@@ -3892,7 +4403,8 @@
         "verse": "In him we have redemption through his blood, the forgiveness of sins, in accordance with the riches of God's grace",
         "book": "Ephesians",
         "reference": "1:7",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "c87d19b4c2a8d0f4"
       },
       {
         "id": 10168,
@@ -3900,7 +4412,8 @@
         "verse": "For sin shall no longer be your master, because you are not under the law, but under grace. What then? Shall we sin because we are not under the law but under grace? By no means!",
         "book": "Romans",
         "reference": "6:14-15",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "61526805bbcdd38e"
       },
       {
         "id": 10169,
@@ -3908,7 +4421,8 @@
         "verse": "So in Christ Jesus you are all children of God through faith,",
         "book": "Galatians",
         "reference": "3:26",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f894c2e7cb721d7d"
       },
       {
         "id": 10170,
@@ -3916,7 +4430,8 @@
         "verse": "But you are a chosen people, a royal priesthood, a holy nation, God's special possession, that you may declare the praises of him who called you out of darkness into his wonderful light.",
         "book": "1 Peter",
         "reference": "2:9",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "716b640fd19e2c92"
       },
       {
         "id": 10171,
@@ -3924,7 +4439,8 @@
         "verse": "God made him who had no sin to be sin for us, so that in him we might become the righteousness of God.",
         "book": "2 Corinthians",
         "reference": "5:21",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "0097805421838754"
       },
       {
         "id": 10172,
@@ -3932,7 +4448,8 @@
         "verse": "It is because of him that you are in Christ Jesus, who has become for us wisdom from God—that is, our righteousness, holiness and redemption.",
         "book": "1 Corinthians",
         "reference": "1:30",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "9c130b394973678e"
       },
       {
         "id": 10173,
@@ -3940,7 +4457,8 @@
         "verse": "For by one sacrifice he has made perfect forever those who are being made holy.",
         "book": "Hebrews",
         "reference": "10:14",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "34454e430a4ecbe6"
       },
       {
         "id": 10174,
@@ -3948,7 +4466,8 @@
         "verse": "and all are justified freely by his grace through the redemption that came by Christ Jesus.",
         "book": "Romans",
         "reference": "3:24",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "011f81407de1aca9"
       },
       {
         "id": 10175,
@@ -3956,7 +4475,8 @@
         "verse": "But our citizenship is in heaven. And we eagerly await a Savior from there, the Lord Jesus Christ,",
         "book": "Philippians",
         "reference": "3:20",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "f94f3170e8b1b787"
       },
       {
         "id": 10176,
@@ -3964,7 +4484,8 @@
         "verse": "For in Christ all the fullness of the Deity lives in bodily form, and in Christ you have been brought to fullness. He is the head over every power and authority.",
         "book": "Colossians",
         "reference": "2:9-10",
-        "subpack": ""
+        "subpack": "",
+        "cardUid": "70c389041d50c7bb"
       }
     ]
   }

--- a/scripture memory/Utilities/SharedUtilities.swift
+++ b/scripture memory/Utilities/SharedUtilities.swift
@@ -245,6 +245,8 @@ struct PeekOverlayCard: View {
     let width:     CGFloat
     let height:    CGFloat
     let isPeeking: Bool
+    /// Matches the card underneath — see `FlashcardView.showCardLabel`.
+    var showCardLabel: Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -267,9 +269,13 @@ struct PeekOverlayCard: View {
 
             Spacer(minLength: 6)
 
-            Text(cardLabel)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(.secondary.opacity(0.5))
+            if showCardLabel {
+                Text(cardLabel)
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundColor(.secondary.opacity(0.5))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
         }
         .flashcardStyle()
         .frame(width: width, height: height)

--- a/scripture memory/Utilities/SharedUtilities.swift
+++ b/scripture memory/Utilities/SharedUtilities.swift
@@ -18,6 +18,17 @@ extension Color {
         )
     }
 
+    /// The same hue, darker. Unlike `muted` this keeps the saturation, so it
+    /// reads as a shadow of the colour rather than a wash of it — for bands and
+    /// panels that sit on a coloured field.
+    func darkened(by amount: Double) -> Color {
+        let uic = UIColor(self)
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uic.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        return Color(hue: Double(h), saturation: Double(s),
+                     brightness: Double(b) * (1 - amount))
+    }
+
     /// A desaturated, darker variant suitable for muted pack-cover backgrounds.
     var muted: Color {
         let uic = UIColor(self)
@@ -95,6 +106,39 @@ extension Image {
             )
             .frame(width: 44, height: 44)
             .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Outlined Text
+
+/// Hollow lettering — the printed "242" on a DEP pack is an outline, not a solid.
+///
+/// SwiftUI can't stroke a `Text`, so this draws the glyphs eight times in the
+/// stroke colour, nudged one width in each direction, then lays a solid copy in
+/// the field colour on top. What's left visible is the rim.
+struct OutlinedText: View {
+    let text:   String
+    let font:   Font
+    let stroke: Color
+    /// Must match whatever sits behind, since the fill is what hollows the glyph.
+    let fill:   Color
+    var width:  CGFloat = 1.6
+
+    private static let directions: [(CGFloat, CGFloat)] = [
+        (-1, -1), (0, -1), (1, -1),
+        (-1,  0),          (1,  0),
+        (-1,  1), (0,  1), (1,  1),
+    ]
+
+    var body: some View {
+        ZStack {
+            ForEach(Array(Self.directions.enumerated()), id: \.offset) { _, d in
+                Text(text).font(font).foregroundColor(stroke)
+                    .offset(x: d.0 * width, y: d.1 * width)
+            }
+            Text(text).font(font).foregroundColor(fill)
+        }
+        .fixedSize()
     }
 }
 
@@ -237,6 +281,70 @@ struct PressReportingButtonStyle: ButtonStyle {
     }
 }
 
+/// Filling an Entire Verse answer box one word at a time.
+///
+/// The hint types the next word straight into the field rather than showing it
+/// beside one. Consistent with the other two study modes, where a hint reveals
+/// the word in place and the card still counts as finished — hints are free
+/// everywhere, so a separate "this was given to you" display would be the odd
+/// one out. It also means Try Again clears the hints for nothing extra: the
+/// hints *are* the field, and Try Again already empties it.
+///
+/// Splits on whitespace rather than `String.wordTokens`, because tokens have
+/// their surrounding quotation marks stripped for matching — filling from them
+/// would type a subtly different verse to the one printed on the card.
+enum HintFill {
+
+    static func words(_ text: String) -> [String] {
+        text.split(whereSeparator: { $0 == " " || $0.isNewline }).map(String.init)
+    }
+
+    /// `typed` extended by one more word of `target`, or `nil` when there's
+    /// nothing left to give.
+    ///
+    /// Counts what's already in the box and rewrites the whole prefix, so the
+    /// hint continues from wherever the user got to — and quietly corrects a
+    /// wrong word rather than appending after it.
+    static func next(target: String, typed: String) -> String? {
+        let targetWords = words(target)
+        let typedCount  = words(typed).count
+        guard typedCount < targetWords.count else { return nil }
+        return targetWords.prefix(typedCount + 1).joined(separator: " ")
+    }
+}
+
+/// The star that adds a verse to favourites, living in a card's footer corner.
+///
+/// Shared by every card surface so the control is in the same place with the
+/// same size wherever a verse can be starred. In the card rather than the screen
+/// chrome because chrome refers to the pack — there'd be no way for a chrome
+/// button to say *which* verse it meant.
+struct FavoriteStarButton: View {
+    let verse: Verse
+    @ObservedObject private var favorites = FavoritesStore.shared
+
+    init(verse: Verse) { self.verse = verse }
+
+    var body: some View {
+        let isFavorite = favorites.isFavorite(verse)
+        return Button {
+            favorites.toggle(verse)
+            HapticEngine.light()
+        } label: {
+            Image(systemName: isFavorite ? "star.fill" : "star")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(isFavorite ? AnyShapeStyle(.yellow) : AnyShapeStyle(.tertiary))
+                .contentTransition(.symbolEffect(.replace))
+                // 30pt target: the card footer can't spare the full 44, and the
+                // control sits alone in its corner with nothing to mis-hit.
+                .frame(width: 30, height: 30)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isFavorite ? "Remove from favourites" : "Add to favourites")
+    }
+}
+
 /// Card-style overlay matching the real card but with all text in secondary color.
 /// Shown while the user holds a `PeekHoldButton`.
 struct PeekOverlayCard: View {
@@ -250,6 +358,12 @@ struct PeekOverlayCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            if let pinned = verse.pinnedVersion {
+                Text("(\(pinned))")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(.secondary)
+                Spacer().frame(height: 6)
+            }
             Text("\(verse.book) \(verse.reference)")
                 .font(.system(size: 18, weight: .bold, design: .serif))
                 .foregroundColor(.secondary)

--- a/scripture memory/Utilities/WidgetBridge.swift
+++ b/scripture memory/Utilities/WidgetBridge.swift
@@ -9,6 +9,16 @@ enum WidgetBridge {
     /// Shared between the app and the widget extension (see both .entitlements).
     static let appGroup    = "group.joel.scripture-memory"
     static let snapshotKey = "widget.snapshot.v1"
+    /// Which edition the user is reading, so the widget picks the same one out
+    /// of the shared catalog file.
+    static let editionKey  = "widget.edition.v1"
+
+    /// Mirror the selected translation into the group. Cheap and idempotent.
+    static func setEdition(_ edition: String) {
+        guard let defaults, defaults.string(forKey: editionKey) != edition else { return }
+        defaults.set(edition, forKey: editionKey)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
 
     /// Compact, Codable mirror of a verse — enough to render and to deep-link back.
     struct SharedVerse: Codable, Equatable {

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -6,10 +6,10 @@ struct CardStudyView: View {
 
     @StateObject private var vm:     CardStudyViewModel
     @StateObject private var speech: SpeechRecognizer = SpeechRecognizer()
-    @ObservedObject private var learning = LearningStore.shared
+    @ObservedObject private var learning  = LearningStore.shared
+    @ObservedObject private var favorites = FavoritesStore.shared
 
     @AppStorage("studyMode")       private var studyMode:       StudyMode = .firstLetter
-    @AppStorage("isVerticalScroll") private var isVerticalScroll = false
 
     @FocusState private var isInputFocused: Bool
     @FocusState private var submitFocus:    SubmitField?
@@ -194,21 +194,22 @@ struct CardStudyView: View {
             VStack(spacing: 0) {
                 topBar(width: geo.size.width)
 
-                // Vertical scroll is for browsing in read mode only.
-                // Review mode always shows a single focused card.
-                if isVerticalScroll && !vm.isReviewMode {
+                // Read mode is a scrolling list of cards — the only browse layout.
+                // (A single-card, swipe-through read mode used to sit behind a
+                // toggle here; nobody used it, so the toggle and the layout are
+                // gone.) Review mode still shows one focused card: it's a
+                // question you answer, not a thing you browse.
+                if !vm.isReviewMode {
                     verticalScrollCards(cardWidth: cardWidth, cardHeight: cardHeight)
                         .frame(maxHeight: .infinity)
                 } else {
-                    // Read mode keeps the original 5:3 card. Review mode grows the
-                    // card into the otherwise-empty vertical space (capped so it
-                    // stays card-shaped) — the masked underscores need the extra
-                    // room — and as the flexible middle it also absorbs the keyboard
-                    // inset, shrinking to fit when typing rather than overflowing.
+                    // Review grows the card into the otherwise-empty vertical space
+                    // (capped so it stays card-shaped) — the masked underscores need
+                    // the extra room — and as the flexible middle it also absorbs the
+                    // keyboard inset, shrinking to fit when typing rather than
+                    // overflowing.
                     GeometryReader { area in
-                        let cardH = vm.isReviewMode
-                            ? max(cardHeight, min(cardWidth * 0.82, area.size.height - 16))
-                            : cardHeight
+                        let cardH = max(cardHeight, min(cardWidth * 0.82, area.size.height - 16))
                         ZStack {
                             cardStack
                                 .frame(width: cardWidth, height: cardH)
@@ -248,7 +249,10 @@ struct CardStudyView: View {
                     }
                 }
 
-                if (!isVerticalScroll || vm.isReviewMode),
+                // The scrubber steps between cards, which only means something on
+                // the single-card review surface — the read list scrolls, and has
+                // its own fast-scroll thumb.
+                if vm.isReviewMode,
                    vm.verses.count > 1 || canCrossBackward || canCrossForward {
                     scrubberRow
                         .padding(.horizontal, AppLayout.screenMargin)
@@ -262,6 +266,12 @@ struct CardStudyView: View {
         .undoToast($undoToastState)
         .speechErrorAlert(speech)
         .onChange(of: vm.isReviewMode) { _, reviewing in handleReviewModeChange(reviewing) }
+        // Un-starring the last favourite while the filter is on would leave the
+        // session showing nothing at all, with the control that got you there now
+        // hidden. Fall back to the whole pack instead.
+        .onChange(of: favorites.keys) { _, _ in
+            if vm.isFavoritesFiltered, vm.favoriteCount == 0 { vm.setFavoritesFilter(false) }
+        }
         .onChange(of: vm.currentIndex) { _, _ in
             vm.clearInputs()
             vm.resetDictation()
@@ -335,7 +345,7 @@ struct CardStudyView: View {
                 } else {
                     HStack(spacing: 8) {
                         Button {
-                            let isList = isVerticalScroll && !vm.isReviewMode
+                            let isList = !vm.isReviewMode
                             vm.toggleShuffle(restartFromTop: isList)
                             // `currentIndex` may already be 0, in which case its
                             // onChange won't fire — drive the list to the top here.
@@ -347,16 +357,30 @@ struct CardStudyView: View {
                         }
                         .accessibilityLabel("Shuffle")
                         .accessibilityValue(vm.isShuffled ? "On" : "Off")
-                        // The list/single-card toggle only matters in Read mode —
-                        // Review always shows one focused card — so hide it there.
-                        if !vm.isReviewMode {
+
+                        if showsFavoritesFilter {
                             Button {
-                                isVerticalScroll.toggle()
+                                // Changing *what's in the list* is a chrome
+                                // action, not arriving at a new card to answer —
+                                // so it shouldn't summon the keyboard. Rebuilding
+                                // moves `currentIndex`, which normally means
+                                // "next card, start typing"; `isScrubbing` is the
+                                // existing signal for "this move was programmatic".
+                                isInputFocused = false
+                                submitFocus    = nil
+                                isScrubbing    = true
+                                vm.setFavoritesFilter(!vm.isFavoritesFiltered)
+                                if !vm.isReviewMode { scrollListToTop() }
+                                HapticEngine.light()
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                                    isScrubbing = false
+                                }
                             } label: {
-                                Image(systemName: isVerticalScroll ? "rectangle.stack" : "list.bullet.rectangle")
-                                    .studyChromeToggle(isOn: isVerticalScroll)
+                                Image(systemName: vm.isFavoritesFiltered ? "star.fill" : "star")
+                                    .studyChromeToggle(isOn: vm.isFavoritesFiltered)
                             }
-                            .accessibilityLabel(isVerticalScroll ? "Switch to single card" : "Switch to list view")
+                            .accessibilityLabel("Show only favourites")
+                            .accessibilityValue(vm.isFavoritesFiltered ? "On" : "Off")
                         }
                     }
                 }
@@ -371,18 +395,23 @@ struct CardStudyView: View {
     /// True whenever either text input has keyboard focus.
     private var isEditing: Bool { isInputFocused || submitFocus != nil }
 
+    /// Offer the favourites filter only where it can do something: this pack has
+    /// starred verses, and it isn't already *the* favourites collection (where
+    /// filtering to favourites is the identity).
+    private var showsFavoritesFilter: Bool {
+        vm.packName != FavoritesStore.packName && vm.favoriteCount > 0
+    }
+
     /// Read mode shows where each verse sits (`"A-1 · TMS 60"`); review mode hides
     /// it. Once the verse is masked, its subpack and pack name are a clue about the
     /// answer rather than a caption — see `FlashcardView.showCardLabel`.
     private var showsCardLabel: Bool { !vm.isReviewMode }
 
-    /// "3 of 37" for the top bar. Single-card modes track `currentIndex`; list mode
-    /// tracks what's actually on screen, since scrolling there doesn't move
-    /// `currentIndex` (it only changes when you tap a card). The counter used to be
-    /// hidden entirely in list mode for that reason — but "where am I in this pack?"
-    /// is exactly the question a long scrolling list raises.
+    /// "3 of 37" for the top bar. Review tracks `currentIndex`; the read list tracks
+    /// what's actually on screen, since scrolling there doesn't move `currentIndex`
+    /// (it only changes when you tap a card).
     private var positionLabel: String {
-        let i = (isVerticalScroll && !vm.isReviewMode) ? visibleListIndex : vm.currentIndex
+        let i = vm.isReviewMode ? vm.currentIndex : visibleListIndex
         return "\(i + 1) of \(vm.verses.count)"
     }
 
@@ -421,15 +450,21 @@ struct CardStudyView: View {
                 // focus to the title would steal taps meant for the verse editor.
                 if vm.isReviewMode && studyMode != .submit {
                     swipingCard
-                        // Simultaneous so a tap on the title/verse underscores still
-                        // reaches FlashcardView's section handler (which picks the
-                        // section) while taps elsewhere just open the keyboard.
-                        .simultaneousGesture(
-                            TapGesture().onEnded {
-                                guard !vm.isCardComplete else { return }
-                                focusInput()
-                            }
-                        )
+                        // A plain tap gesture, NOT `simultaneousGesture`. Simultaneous
+                        // means "fire as well as whatever was actually hit", so every
+                        // control on the card — the star, in particular — summoned the
+                        // keyboard on top of doing its own job.
+                        //
+                        // Nothing is lost by yielding to the controls: a tap on the
+                        // title/verse underscores hits FlashcardView's section handler,
+                        // which focuses the input itself, and the verse section already
+                        // stretches over the blank space below it. This only has to
+                        // cover what's genuinely dead — the reference line and the
+                        // footer's empty middle.
+                        .onTapGesture {
+                            guard !vm.isCardComplete else { return }
+                            focusInput()
+                        }
                 } else {
                     swipingCard
                 }
@@ -456,17 +491,6 @@ struct CardStudyView: View {
                                 makeCard(verse: verse, verseIndex: index, interactive: index == vm.currentIndex)
                                     .frame(width: cardWidth, height: cardHeight)
                                     .id(index)
-                                    .overlay {
-                                        // Skip the focus-tap on the cursor card so its
-                                        // on-card "Mark as Complete" button stays tappable.
-                                        if index != vm.currentIndex, !learning.isCurrent(verse) {
-                                            Color.clear.contentShape(Rectangle())
-                                                .onTapGesture {
-                                                    HapticEngine.light()
-                                                    vm.currentIndex = index
-                                                }
-                                        }
-                                    }
                             }
                         }
                         .scrollTargetLayout()
@@ -491,25 +515,20 @@ struct CardStudyView: View {
                         if abs(f - scrollFraction) > 0.0001 { scrollFraction = f }
                         if abs(listScrollOffset - m.offset) > 0.5 { listScrollOffset = m.offset }
 
-                        // Which card is under the middle of the viewport. Cards are a
-                        // fixed height here, so inverting the same layout the jump
-                        // button uses (12pt top pad, card + 20pt spacing) gives the
-                        // index directly.
+                        // Where the counter says you are. Mapped straight off the
+                        // scroll fraction — the same function the fast-scroll thumb
+                        // uses — so the number in the top bar and the thumb beside it
+                        // can never disagree, and both ends are exact by construction:
+                        // fraction 0 is card 1, fraction 1 is card N.
                         //
-                        // Both ends are special-cased: the list can't scroll far enough
-                        // to centre the first or last card, so at rest against either
-                        // stop the middle of the viewport is still pointing a card or
-                        // two inward — and "1 of 18" is what the top of the list means.
-                        let idx: Int
-                        if m.offset <= 1 {
-                            idx = 0
-                        } else if m.offset >= maxScroll - 1 {
-                            idx = max(0, vm.verses.count - 1)
-                        } else {
-                            let viewportCentre = m.offset + outerGeo.size.height / 2
-                            let raw = (viewportCentre - 12 - cardHeight / 2) / (cardHeight + 20)
-                            idx = min(max(Int(raw.rounded()), 0), max(0, vm.verses.count - 1))
-                        }
+                        // This used to invert the card layout to find whichever card
+                        // sat under the middle of the viewport, with the two ends
+                        // special-cased. But the viewport is taller than one card and
+                        // can't scroll far enough to centre the first or last one, so
+                        // at rest against either stop the middle of the screen points
+                        // a card or two inward — the top of the list read "2 of 32",
+                        // and the special cases only papered over the exact stops.
+                        let idx = ScrubberMath.index(fraction: f, count: vm.verses.count)
                         if visibleListIndex != idx { visibleListIndex = idx }
                     }
                     .scrollPosition(id: $verticalScrollTarget, anchor: .center)
@@ -612,7 +631,8 @@ struct CardStudyView: View {
                 result: interactive ? vm.submitResults[verse.id] : nil,
                 focusedField: $submitFocus,
                 isCurrentLearning: learning.isCurrent(verse),
-                showCardLabel: showsCardLabel
+                showCardLabel: showsCardLabel,
+                showsFavoriteToggle: interactive
             )
             .allowsHitTesting(interactive)
         } else {
@@ -636,7 +656,16 @@ struct CardStudyView: View {
                 } : nil,
                 showCardLabel: showsCardLabel,
                 isCurrentLearning: learning.isCurrent(verse),
-                onMarkComplete: vm.isReviewMode ? nil : { markVerseComplete(verse) }
+                onMarkComplete: vm.isReviewMode ? nil : { markVerseComplete(verse) },
+                // Review: always, on the card being answered. Starring is "come
+                // back to this one", and the moment you know that is the moment
+                // you couldn't recall it.
+                //
+                // Read: on every card. Showing it only when already filled kept
+                // the list clean and made un-starring possible, but left no way to
+                // star a verse *from* the list — the obvious place to do it while
+                // reading a pack.
+                showsFavoriteToggle: vm.isReviewMode ? interactive : true
             )
         }
     }
@@ -712,18 +741,20 @@ struct CardStudyView: View {
             }
             Group {
                 if vm.isCardComplete {
-                    if offersMarkLearnt {
-                        HStack(spacing: 10) {
-                            tryAgainButton
-                            markLearntButton
-                        }
-                    } else {
-                        // Takes the slot the old "Complete!" label held. That label
-                        // only announced a state the card already shows with its
-                        // green section checks, while the one thing you actually
-                        // want next — moving on — was stranded on the scrubber
-                        // chevron. The check icon keeps the completion signal.
-                        nextButton
+                    // Try Again pairs with whichever "move on" action this card
+                    // offers. It used to appear only on the learning-cursor verse,
+                    // which left every other card with no way back into it —
+                    // finishing one was a one-way door, and re-practising a verse
+                    // meant leaving review and coming back.
+                    //
+                    // The second slot takes over from the old "Complete!" label,
+                    // which only announced a state the card already shows with its
+                    // green section checks while the thing you actually wanted —
+                    // moving on — was stranded on the scrubber chevron. The check
+                    // icon keeps the completion signal.
+                    HStack(spacing: 10) {
+                        tryAgainButton
+                        if offersMarkLearnt { markLearntButton } else { nextButton }
                     }
                 } else if studyMode == .submit {
                     submitControls
@@ -799,7 +830,12 @@ struct CardStudyView: View {
     /// Resets the current card so the user can attempt it again (clears revealed
     /// words / submitted answer for whichever study mode is active).
     private var tryAgainButton: some View {
-        Button { vm.resetCurrentCard() } label: {
+        Button {
+            vm.resetCurrentCard()
+            // The input field is remounted by the reset — bring the keyboard back
+            // with it, since typing is the only thing you tapped Try Again to do.
+            refocusIfNeeded()
+        } label: {
             Label("Try Again", systemImage: "arrow.counterclockwise")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.primary)
@@ -836,6 +872,8 @@ struct CardStudyView: View {
                             .roundedRect(12)
                     }
                     .accessibilityLabel(speech.isListening ? "Stop dictation" : "Dictate verse")
+
+                    submitHintButton
                     let isEmpty = vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
                               && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty
                     Button {
@@ -853,6 +891,44 @@ struct CardStudyView: View {
                     .disabled(isEmpty)
                 }
             }
+        }
+    }
+
+    /// Entire Verse's hint: types the next word straight into the answer box.
+    ///
+    /// A `Button` (not a bare tap target) so pressing it doesn't resign the
+    /// editor's first responder and dismiss the keyboard mid-verse.
+    private var submitHintButton: some View {
+        Button {
+            fillNextHintWord()
+            HapticEngine.light()
+        } label: {
+            Image(systemName: "lightbulb")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.primary)
+                .frame(width: 48, height: 48)
+                .background(Color(.secondarySystemGroupedBackground))
+                .roundedRect(12)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Reveal next word")
+    }
+
+    /// Extends whichever box you're in by one word, falling through to the other
+    /// once that one is complete — so repeated taps walk the whole card without
+    /// having to move focus by hand.
+    private func fillNextHintWord() {
+        guard let verse = vm.currentVerse else { return }
+        let startWithVerse = submitFocus == .verse
+        let sections: [(target: String, isTitle: Bool)] = startWithVerse
+            ? [(verse.verse, false), (verse.title, true)]
+            : [(verse.title, true), (verse.verse, false)]
+
+        for section in sections {
+            let typed = section.isTitle ? vm.titleInput : vm.verseInput
+            guard let filled = HintFill.next(target: section.target, typed: typed) else { continue }
+            if section.isTitle { vm.titleInput = filled } else { vm.verseInput = filled }
+            return
         }
     }
 
@@ -1025,6 +1101,16 @@ struct CardStudyView: View {
     // MARK: - Focus & Speech
 
     private func handleReviewModeChange(_ reviewing: Bool) {
+        // Review opens on the card the list was showing.
+        //
+        // Tapping a card in the read list used to be how you chose that, which
+        // meant a tap that scrolled the list a little and otherwise did nothing
+        // visible — the selection it set only mattered later, on a screen you
+        // hadn't switched to yet. The scroll position already says which verse
+        // you're looking at, so read it here instead.
+        if reviewing, vm.verses.indices.contains(visibleListIndex) {
+            vm.currentIndex = visibleListIndex
+        }
         if reviewing && !vm.isCardComplete {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { focusInput() }
         } else {

--- a/scripture memory/Views/CardStudyView.swift
+++ b/scripture memory/Views/CardStudyView.swift
@@ -141,6 +141,17 @@ struct CardStudyView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isScrubbing = false }
     }
 
+    /// Sends the read list back to the first card. `scrollPosition` only scrolls on a
+    /// *change* of id, so a re-entry of the same target (index 0 is a common resting
+    /// place) needs the clear-then-set — otherwise a shuffle that leaves the cursor
+    /// on 0 would reorder the list under a stationary scroll offset.
+    private func scrollListToTop() {
+        verticalScrollTarget = nil
+        DispatchQueue.main.async {
+            withAnimation(.easeInOut(duration: 0.25)) { verticalScrollTarget = 0 }
+        }
+    }
+
     /// List (vertical-scroll read) visibility: show the jump shortcut whenever the
     /// cursor card's centre has scrolled out of the viewport. Cards are a fixed
     /// height here, so the centre is `topPadding + index·(card+spacing) + card/2`.
@@ -212,7 +223,8 @@ struct CardStudyView: View {
                                     cardLabel: vm.cardLabel(for: verse),
                                     width: cardWidth,
                                     height: cardH,
-                                    isPeeking: isPeeking
+                                    isPeeking: isPeeking,
+                                    showCardLabel: showsCardLabel
                                 )
                                 .allowsHitTesting(false)
                                 .transition(.opacity)
@@ -323,7 +335,11 @@ struct CardStudyView: View {
                 } else {
                     HStack(spacing: 8) {
                         Button {
-                            vm.toggleShuffle()
+                            let isList = isVerticalScroll && !vm.isReviewMode
+                            vm.toggleShuffle(restartFromTop: isList)
+                            // `currentIndex` may already be 0, in which case its
+                            // onChange won't fire — drive the list to the top here.
+                            if isList { scrollListToTop() }
                             HapticEngine.light()
                         } label: {
                             Image(systemName: "shuffle")
@@ -354,6 +370,11 @@ struct CardStudyView: View {
 
     /// True whenever either text input has keyboard focus.
     private var isEditing: Bool { isInputFocused || submitFocus != nil }
+
+    /// Read mode shows where each verse sits (`"A-1 · TMS 60"`); review mode hides
+    /// it. Once the verse is masked, its subpack and pack name are a clue about the
+    /// answer rather than a caption — see `FlashcardView.showCardLabel`.
+    private var showsCardLabel: Bool { !vm.isReviewMode }
 
     /// "3 of 37" for the top bar. Single-card modes track `currentIndex`; list mode
     /// tracks what's actually on screen, since scrolling there doesn't move
@@ -474,9 +495,21 @@ struct CardStudyView: View {
                         // fixed height here, so inverting the same layout the jump
                         // button uses (12pt top pad, card + 20pt spacing) gives the
                         // index directly.
-                        let viewportCentre = m.offset + outerGeo.size.height / 2
-                        let raw = (viewportCentre - 12 - cardHeight / 2) / (cardHeight + 20)
-                        let idx = min(max(Int(raw.rounded()), 0), max(0, vm.verses.count - 1))
+                        //
+                        // Both ends are special-cased: the list can't scroll far enough
+                        // to centre the first or last card, so at rest against either
+                        // stop the middle of the viewport is still pointing a card or
+                        // two inward — and "1 of 18" is what the top of the list means.
+                        let idx: Int
+                        if m.offset <= 1 {
+                            idx = 0
+                        } else if m.offset >= maxScroll - 1 {
+                            idx = max(0, vm.verses.count - 1)
+                        } else {
+                            let viewportCentre = m.offset + outerGeo.size.height / 2
+                            let raw = (viewportCentre - 12 - cardHeight / 2) / (cardHeight + 20)
+                            idx = min(max(Int(raw.rounded()), 0), max(0, vm.verses.count - 1))
+                        }
                         if visibleListIndex != idx { visibleListIndex = idx }
                     }
                     .scrollPosition(id: $verticalScrollTarget, anchor: .center)
@@ -578,7 +611,8 @@ struct CardStudyView: View {
                 verseText: interactive ? $vm.verseInput : .constant(""),
                 result: interactive ? vm.submitResults[verse.id] : nil,
                 focusedField: $submitFocus,
-                isCurrentLearning: learning.isCurrent(verse)
+                isCurrentLearning: learning.isCurrent(verse),
+                showCardLabel: showsCardLabel
             )
             .allowsHitTesting(interactive)
         } else {
@@ -600,6 +634,7 @@ struct CardStudyView: View {
                     vm.activeSection = section
                     DispatchQueue.main.async { focusInput() }
                 } : nil,
+                showCardLabel: showsCardLabel,
                 isCurrentLearning: learning.isCurrent(verse),
                 onMarkComplete: vm.isReviewMode ? nil : { markVerseComplete(verse) }
             )

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -20,10 +20,17 @@ final class CardStudyViewModel: ObservableObject {
     // MARK: - Initialisation
 
     @Published var packName: String
+    /// The verses actually on screen: `originalVerses` after shuffle and the
+    /// favourites filter. Everything else in the session indexes into this.
     @Published var verses: [Verse]
     @Published private(set) var isShuffled = false
+    @Published private(set) var isFavoritesFiltered = false
 
     private var originalVerses: [Verse]
+
+    /// The shuffled permutation, held so that turning the favourites filter on
+    /// and off doesn't silently reshuffle the pack underneath the user.
+    private var shuffledVerses: [Verse] = []
 
     init(packName: String, verses: [Verse], initialIndex: Int = 0, initialReviewMode: Bool = false) {
         self.packName       = packName
@@ -105,7 +112,9 @@ final class CardStudyViewModel: ObservableObject {
             packName            = name
             verses              = newVerses
             originalVerses      = newVerses
+            shuffledVerses      = []
             isShuffled          = false
+            isFavoritesFiltered = false
             currentIndex        = min(max(index, 0), max(newVerses.count - 1, 0))
             titleRevealedCounts = [:]
             verseRevealedCounts = [:]
@@ -130,12 +139,49 @@ final class CardStudyViewModel: ObservableObject {
     /// it landed just drops you mid-list with no sense of the new order — so the
     /// list restarts at the first card.
     func toggleShuffle(restartFromTop: Bool = false) {
-        let anchorId = restartFromTop ? nil : currentVerse?.id
+        isShuffled.toggle()
+        if isShuffled { shuffledVerses = originalVerses.shuffled() }
+        rebuild(anchorId: restartFromTop ? nil : currentVerse?.id)
+    }
+
+    /// Narrow the session to starred verses (or widen it back).
+    ///
+    /// Applied on top of the current order rather than replacing it, so a
+    /// shuffled pack stays shuffled — and, more importantly, the filtered list is
+    /// what Review then tests, which is the whole point of being able to filter.
+    ///
+    /// The caller is responsible for not filtering a pack down to nothing; see
+    /// `favoriteCount`.
+    func setFavoritesFilter(_ on: Bool) {
+        guard isFavoritesFiltered != on else { return }
+        isFavoritesFiltered = on
+        rebuild(anchorId: currentVerse?.id)
+    }
+
+    /// How many of this pack's verses are starred — gates the filter control, and
+    /// lets the view drop the filter if the last one is un-starred while it's on.
+    var favoriteCount: Int {
+        let keys = FavoritesStore.shared.keys
+        return originalVerses.reduce(0) { $0 + (keys.contains($1.srsKey) ? 1 : 0) }
+    }
+
+    /// Recompute `verses` from the pack plus the current order/filter, keeping the
+    /// user parked on `anchorId` if it survived the rebuild.
+    ///
+    /// Reordering and filtering are purely presentational: every bit of progress
+    /// (revealed word counts, submitted answers) is keyed by verse **id**, not by
+    /// position, so neither can invalidate any of it — which is why nothing is
+    /// cleared here beyond the in-flight text inputs.
+    private func rebuild(anchorId: Int?) {
+        var next = isShuffled ? shuffledVerses : originalVerses
+        if isFavoritesFiltered {
+            let keys = FavoritesStore.shared.keys
+            next = next.filter { keys.contains($0.srsKey) }
+        }
         var t = Transaction(); t.disablesAnimations = true
         withTransaction(t) {
-            isShuffled = !isShuffled
-            verses     = isShuffled ? originalVerses.shuffled() : originalVerses
-            currentIndex = anchorId.flatMap { id in verses.firstIndex { $0.id == id } } ?? 0
+            verses       = next
+            currentIndex = anchorId.flatMap { id in next.firstIndex { $0.id == id } } ?? 0
             inputText  = ""
             titleInput = ""
             verseInput = ""

--- a/scripture memory/Views/CardStudyViewModel.swift
+++ b/scripture memory/Views/CardStudyViewModel.swift
@@ -122,10 +122,15 @@ final class CardStudyViewModel: ObservableObject {
     /// counts, submitted answers) is keyed by verse **id**, not by position, so
     /// shuffling can't invalidate any of it. Wiping those dictionaries here meant
     /// toggling shuffle off — the natural "put it back how it was" gesture — threw
-    /// away the whole session. Keep the progress, and stay parked on the verse the
-    /// user is looking at rather than snapping back to the top.
-    func toggleShuffle() {
-        let anchorId = currentVerse?.id
+    /// away the whole session. Keep the progress.
+    ///
+    /// `restartFromTop` picks where the reorder leaves you. A single card is a
+    /// place you're standing, so it stays parked on the verse you were looking at.
+    /// A list is a thing you read top-down, and following the old verse to wherever
+    /// it landed just drops you mid-list with no sense of the new order — so the
+    /// list restarts at the first card.
+    func toggleShuffle(restartFromTop: Bool = false) {
+        let anchorId = restartFromTop ? nil : currentVerse?.id
         var t = Transaction(); t.disablesAnimations = true
         withTransaction(t) {
             isShuffled = !isShuffled
@@ -149,15 +154,11 @@ final class CardStudyViewModel: ObservableObject {
 
     // MARK: - Card Label
 
-    /// Returns the footer label for a card, e.g. `"A-1 · TMS 60"`. Uses the
-    /// verse's own pack (not the session's) so cross-pack "Continue Learning"
-    /// sessions still show which pack each verse belongs to.
+    /// Returns the footer label for a card, e.g. `"A-12 · Live the New Life"`.
+    /// Keyed off the verse's own pack (not the session's) so cross-pack "Continue
+    /// Learning" sessions still label each verse correctly.
     func cardLabel(for verse: Verse) -> String {
-        let pack = verse.packName.isEmpty ? packName : verse.packName
-        guard !verse.subpack.isEmpty else { return pack }
-        let subpackVerses = verses.filter { $0.subpack == verse.subpack && $0.packName == verse.packName }
-        let position = (subpackVerses.firstIndex(where: { $0.id == verse.id }) ?? 0) + 1
-        return "\(verse.subpack)-\(position) · \(pack)"
+        CardFooter.label(for: verse, fallbackPack: packName)
     }
 
     // MARK: - Reveal State

--- a/scripture memory/Views/ContentView.swift
+++ b/scripture memory/Views/ContentView.swift
@@ -107,6 +107,7 @@ struct ContentView: View {
         let week      = StreakStore.shared.thisWeek().map {
             WidgetBridge.WeekDay(letter: $0.initial, done: $0.done, today: $0.isToday)
         }
+        WidgetBridge.setEdition(bibleVersion.rawValue)
         WidgetBridge.update(verse: displayed?.verse,
                             isPinned: displayed?.isPinned ?? false,
                             streak: StreakStore.shared.current,

--- a/scripture memory/Views/DragSelect.swift
+++ b/scripture memory/Views/DragSelect.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import UIKit
+
+/// Two-finger drag to select a run of rows, the way Telegram, Photos and Files do.
+///
+/// Picking forty consecutive verses by tapping forty checkboxes is the tedium
+/// this removes. Two fingers rather than one because a single-finger drag is
+/// already spoken for — it scrolls the list — whereas a two-finger pan is
+/// otherwise unused, so the two gestures never have to arbitrate.
+///
+/// The direction of the first row decides the whole drag: start on an unselected
+/// row and the run selects, start on a selected one and it clears. Toggling each
+/// row independently would leave a dragged-over run alternating, which is never
+/// what's wanted.
+
+// MARK: - Row geometry
+
+/// Where each row currently is on screen.
+///
+/// A plain class, not an `ObservableObject`: these are rewritten on every frame
+/// of a scroll, and publishing that would re-render the whole list continuously.
+/// Nothing reads the frames except the drag, and the drag reads them live.
+final class DragSelectFrames {
+    private(set) var frames: [Int: CGRect] = [:]
+
+    func record(_ id: Int, _ frame: CGRect) { frames[id] = frame }
+    func forget(_ id: Int) { frames.removeValue(forKey: id) }
+
+    /// The row under `point`, in global coordinates.
+    func row(at point: CGPoint) -> Int? {
+        frames.first { $0.value.contains(point) }?.key
+    }
+}
+
+extension View {
+    /// Registers this row's position so a two-finger drag can find it.
+    func dragSelectRow(id: Int, in store: DragSelectFrames) -> some View {
+        background(
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear    { store.record(id, geo.frame(in: .global)) }
+                    .onDisappear { store.forget(id) }
+                    .onChange(of: geo.frame(in: .global)) { _, new in store.record(id, new) }
+            }
+        )
+    }
+}
+
+// MARK: - The gesture
+
+/// Installs a two-finger pan on the enclosing scroll view and reports where it is.
+///
+/// The recogniser goes on the `UIScrollView` rather than on an overlay: an
+/// overlay big enough to catch the drag would also swallow the taps meant for
+/// the rows underneath, and a view that refuses hit-testing never sees the
+/// gesture either.
+struct TwoFingerDragSelect: UIViewRepresentable {
+    /// Global-coordinate point, and whether this is the first callback of a drag.
+    var onDrag: (CGPoint, Bool) -> Void
+    var onEnd:  () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        view.isUserInteractionEnabled = false      // never intercepts taps
+        context.coordinator.attach(from: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.parent = self
+        // The scroll view may not exist yet on the first layout pass.
+        context.coordinator.attach(from: uiView)
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var parent: TwoFingerDragSelect
+        private weak var attachedTo: UIScrollView?
+        private var began = false
+
+        init(_ parent: TwoFingerDragSelect) { self.parent = parent }
+
+        func attach(from view: UIView) {
+            guard attachedTo == nil else { return }
+            // Walk up to the List's scroll view.
+            var node: UIView? = view
+            while let current = node, !(current is UIScrollView) { node = current.superview }
+            guard let scroll = node as? UIScrollView else {
+                // Layout isn't settled yet; try again next runloop turn.
+                DispatchQueue.main.async { [weak view] in
+                    if let view { self.attach(from: view) }
+                }
+                return
+            }
+            let pan = UIPanGestureRecognizer(target: self, action: #selector(handle(_:)))
+            pan.minimumNumberOfTouches = 2
+            pan.maximumNumberOfTouches = 2
+            pan.delegate = self
+            scroll.addGestureRecognizer(pan)
+            attachedTo = scroll
+        }
+
+        @objc func handle(_ gesture: UIPanGestureRecognizer) {
+            switch gesture.state {
+            case .began:
+                began = false
+                fallthrough
+            case .changed:
+                // `nil` gives window coordinates, which is what SwiftUI's
+                // `.global` frames are measured in — so the two agree without
+                // any conversion.
+                let point = gesture.location(in: nil)
+                parent.onDrag(point, !began)
+                began = true
+            case .ended, .cancelled, .failed:
+                began = false
+                parent.onEnd()
+            default:
+                break
+            }
+        }
+
+        /// Runs alongside the scroll view's own recognisers rather than fighting
+        /// them; a two-finger pan won't trigger a one-finger scroll anyway.
+        func gestureRecognizer(_ g: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+}

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -9,6 +9,13 @@ struct FlashcardView: View {
     let activeSection:       CardSection
     var onSectionTap:        ((CardSection) -> Void)? = nil
 
+    /// Whether the footer may name the pack the verse came from. Off wherever the
+    /// card is a question — quiz and review both draw from a set the user chose,
+    /// so "TMS 60" under a masked verse narrows the answer before they've recalled
+    /// anything. Spaced repetition keeps it: there the pack is the context you
+    /// need, not a clue.
+    var showCardLabel:       Bool = true
+
     /// Marks this card as the "current stopped verse" (the learning cursor) with a
     /// small badge — shown wherever the verse appears: study card and test card.
     var isCurrentLearning:   Bool = false
@@ -49,9 +56,16 @@ struct FlashcardView: View {
                 if isReviewMode { reviewContent(cardSize: geo.size) } else { readContent(cardSize: geo.size) }
                 Spacer(minLength: 16)
                 HStack(spacing: 6) {
-                    Text(cardLabel)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(.secondary)
+                    if showCardLabel {
+                        // Just under the reference line rather than fine print —
+                        // "A-12 · Live the New Life" is how you find the card in the
+                        // booklet, so it has to be readable at a glance.
+                        Text(cardLabel)
+                            .font(.system(size: 12.5, weight: .medium))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
                     Spacer(minLength: 8)
                     if isCurrentLearning {
                         if let onMarkComplete {
@@ -144,7 +158,7 @@ struct FlashcardView: View {
         // that's actually free: the progress block (spacer + bar) and the card's
         // own bottom spacer + label. Undercounting here picks a font one step too
         // big — which is exactly what made long verses overflow and truncate.
-        let reserved = refH + 12 + titleH + 8 + (showsProgress ? 24 : 0) + 34
+        let reserved = refH + 12 + titleH + 8 + (showsProgress ? 24 : 0) + (showCardLabel ? 40 : 24)
         let avail = max(48, cardSize.height - reserved)
         let verseSize = VerseFit.fontSize(verse.verse, width: cardWidth, height: avail,
                                           lineSpacing: verseGap, minSize: 10, maxSize: 16)

--- a/scripture memory/Views/FlashcardView.swift
+++ b/scripture memory/Views/FlashcardView.swift
@@ -25,6 +25,12 @@ struct FlashcardView: View {
     /// card — read mode has no test-completion event to surface it otherwise.
     var onMarkComplete:      (() -> Void)? = nil
 
+    /// Whether this card offers the star. On wherever the card is something the
+    /// user is *reading* — starring is a "come back to this one" gesture, and the
+    /// moment you want it is while the verse is in front of you. Off on quiz and
+    /// test cards, where the footer row is already carrying the answer state.
+    var showsFavoriteToggle: Bool = false
+
     @AppStorage("hardMode") private var hardMode = false
 
     // MARK: - Adaptive Typography
@@ -67,6 +73,7 @@ struct FlashcardView: View {
                             .minimumScaleFactor(0.8)
                     }
                     Spacer(minLength: 8)
+                    if showsFavoriteToggle { FavoriteStarButton(verse: verse) }
                     if isCurrentLearning {
                         if let onMarkComplete {
                             markCompleteButton(onMarkComplete)
@@ -100,6 +107,21 @@ struct FlashcardView: View {
         .accessibilityLabel("Mark current verse as complete")
     }
 
+    /// "(KJV)" chip for the handful of cards printed in a translation other than
+    /// the edition the rest of the pack uses. Without it the card reads as a
+    /// mistake — Jacobean English sitting in the middle of an NIV pack — and the
+    /// user has no way to tell that the wording is deliberate and is what they're
+    /// meant to memorise. Sits above the reference, the first thing read.
+    private var versionBadge: some View {
+        Text("(\(verse.pinnedVersion ?? ""))")
+            .font(.system(size: 10, weight: .bold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color(.tertiarySystemFill)))
+            .accessibilityLabel("King James Version")
+    }
+
     /// Small "Current" chip marking the learning-cursor verse on any flashcard —
     /// a bookmark (distinct from the pin used for the Home spotlight) so it reads
     /// as "this is where you stopped."
@@ -125,6 +147,7 @@ struct FlashcardView: View {
         let titleSize = scaledTypeSize(base: 15, extra: 3.5, cardWidth: cardWidth)
         let refSize = scaledTypeSize(base: 14, extra: 3.0, cardWidth: cardWidth)
         return VStack(alignment: .leading, spacing: 0) {
+            if verse.pinnedVersion != nil { versionBadge; Spacer().frame(height: 6) }
             Text(verse.title)
                 .font(.system(size: titleSize, weight: .bold, design: .serif))
             Spacer().frame(height: 8)
@@ -158,12 +181,14 @@ struct FlashcardView: View {
         // that's actually free: the progress block (spacer + bar) and the card's
         // own bottom spacer + label. Undercounting here picks a font one step too
         // big — which is exactly what made long verses overflow and truncate.
-        let reserved = refH + 12 + titleH + 8 + (showsProgress ? 24 : 0) + (showCardLabel ? 40 : 24)
+        let badgeH: CGFloat = verse.pinnedVersion != nil ? 22 : 0
+        let reserved = badgeH + refH + 12 + titleH + 8 + (showsProgress ? 24 : 0) + (showCardLabel ? 40 : 24)
         let avail = max(48, cardSize.height - reserved)
         let verseSize = VerseFit.fontSize(verse.verse, width: cardWidth, height: avail,
                                           lineSpacing: verseGap, minSize: 10, maxSize: 16)
 
         return VStack(alignment: .leading, spacing: 0) {
+            if verse.pinnedVersion != nil { versionBadge; Spacer().frame(height: 6) }
             Text("\(verse.book) \(verse.reference)")
                 .font(.system(size: refSize, weight: .bold, design: .serif))
 

--- a/scripture memory/Views/LeafBranch.swift
+++ b/scripture memory/Views/LeafBranch.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// The leaf-and-tendril line drawing from the cover of *Lessons on Assurance*.
+///
+/// Drawn rather than shipped as an asset so it inherits the cover's stroke
+/// colour and scales cleanly with the pack tile, which renders at a fixed design
+/// canvas and then scales to whatever width the grid gives it.
+///
+/// Everything is expressed as a fraction of the frame, so the proportions hold
+/// at any size.
+struct LeafBranch: Shape {
+
+    /// Where along the stem each leaf sits, which side it falls on, and how long
+    /// it is relative to the frame. Roughly the arrangement on the book: a run of
+    /// leaves down the lower side, two shorter ones opposite.
+    private static let leaves: [(t: CGFloat, below: Bool, length: CGFloat)] = [
+        (0.20, true,  0.30),
+        (0.34, true,  0.34),
+        (0.50, true,  0.31),
+        (0.64, true,  0.25),
+        (0.40, false, 0.20),
+        (0.56, false, 0.17),
+    ]
+
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let w = rect.width, h = rect.height
+
+        // The stem: a shallow S sweeping up from the lower left.
+        let start = CGPoint(x: 0.02 * w, y: 0.80 * h)
+        let end   = CGPoint(x: 0.74 * w, y: 0.20 * h)
+        let c1    = CGPoint(x: 0.34 * w, y: 0.82 * h)
+        let c2    = CGPoint(x: 0.52 * w, y: 0.40 * h)
+        p.move(to: start)
+        p.addCurve(to: end, control1: c1, control2: c2)
+
+        // The tendril: continues past the tip and curls back on itself.
+        p.move(to: end)
+        p.addCurve(to: CGPoint(x: 0.93 * w, y: 0.16 * h),
+                   control1: CGPoint(x: 0.82 * w, y: 0.10 * h),
+                   control2: CGPoint(x: 0.93 * w, y: 0.03 * h))
+        p.addCurve(to: CGPoint(x: 0.86 * w, y: 0.20 * h),
+                   control1: CGPoint(x: 0.93 * w, y: 0.26 * h),
+                   control2: CGPoint(x: 0.85 * w, y: 0.28 * h))
+
+        for leaf in Self.leaves {
+            addLeaf(to: &p, at: leaf.t, below: leaf.below, length: leaf.length * w,
+                    start: start, c1: c1, c2: c2, end: end)
+        }
+        return p
+    }
+
+    /// A single leaf: two arcs meeting at a point, plus its midrib.
+    ///
+    /// Anchored to the stem's own curve and angled off its tangent, so the leaves
+    /// follow the branch instead of being scattered near it.
+    private func addLeaf(to p: inout Path, at t: CGFloat, below: Bool, length: CGFloat,
+                         start: CGPoint, c1: CGPoint, c2: CGPoint, end: CGPoint) {
+        let base = bezierPoint(t, start, c1, c2, end)
+        let d    = bezierTangent(t, start, c1, c2, end)
+        let mag  = max(0.0001, sqrt(d.x * d.x + d.y * d.y))
+        let unit = CGPoint(x: d.x / mag, y: d.y / mag)
+
+        // Off the stem at roughly 45°, leaning back toward its root.
+        let sign: CGFloat = below ? 1 : -1
+        let normal = CGPoint(x: -unit.y * sign, y: unit.x * sign)
+        let dir    = CGPoint(x: normal.x * 0.82 - unit.x * 0.42,
+                             y: normal.y * 0.82 - unit.y * 0.42)
+        let dmag   = max(0.0001, sqrt(dir.x * dir.x + dir.y * dir.y))
+        let axis   = CGPoint(x: dir.x / dmag, y: dir.y / dmag)
+        let tip    = CGPoint(x: base.x + axis.x * length, y: base.y + axis.y * length)
+
+        // Bulge the two sides out perpendicular to the leaf's own axis.
+        let side  = CGPoint(x: -axis.y, y: axis.x)
+        let belly = length * 0.30
+        let mid   = CGPoint(x: (base.x + tip.x) / 2, y: (base.y + tip.y) / 2)
+        let a = CGPoint(x: mid.x + side.x * belly, y: mid.y + side.y * belly)
+        let b = CGPoint(x: mid.x - side.x * belly, y: mid.y - side.y * belly)
+
+        p.move(to: base)
+        p.addQuadCurve(to: tip, control: a)
+        p.addQuadCurve(to: base, control: b)
+
+        p.move(to: base)
+        p.addLine(to: tip)
+    }
+
+    private func bezierPoint(_ t: CGFloat, _ p0: CGPoint, _ p1: CGPoint,
+                             _ p2: CGPoint, _ p3: CGPoint) -> CGPoint {
+        let u = 1 - t
+        let x = u*u*u*p0.x + 3*u*u*t*p1.x + 3*u*t*t*p2.x + t*t*t*p3.x
+        let y = u*u*u*p0.y + 3*u*u*t*p1.y + 3*u*t*t*p2.y + t*t*t*p3.y
+        return CGPoint(x: x, y: y)
+    }
+
+    private func bezierTangent(_ t: CGFloat, _ p0: CGPoint, _ p1: CGPoint,
+                               _ p2: CGPoint, _ p3: CGPoint) -> CGPoint {
+        let u = 1 - t
+        let x = 3*u*u*(p1.x - p0.x) + 6*u*t*(p2.x - p1.x) + 3*t*t*(p3.x - p2.x)
+        let y = 3*u*u*(p1.y - p0.y) + 6*u*t*(p2.y - p1.y) + 3*t*t*(p3.y - p2.y)
+        return CGPoint(x: x, y: y)
+    }
+}

--- a/scripture memory/Views/LearningSetupView.swift
+++ b/scripture memory/Views/LearningSetupView.swift
@@ -209,7 +209,7 @@ private struct StartingPointScreen: View {
                     }
                 }
             } header: {
-                Text("Already memorizing? Pick where you stopped")
+                Text("Pick where you stopped")
             }
         }
         .navigationTitle(isOnboarding ? "Your Starting Point" : "Current Verse")
@@ -278,18 +278,20 @@ private struct VerseListScreen: View {
                         onSelect(verse)
                         dismiss()
                     } label: {
-                        HStack(alignment: .top, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 3) {
+                        // Reference and title only. You pick your starting point by
+                        // recognising *which card* you stopped at, and the reference
+                        // is what names it — two lines of verse text underneath
+                        // tripled the row height and made the list something you
+                        // scroll through rather than scan.
+                        HStack(spacing: 12) {
+                            VStack(alignment: .leading, spacing: 2) {
                                 Text("\(verse.book) \(verse.reference)")
-                                    .font(.headline)
+                                    .font(.system(size: 15, weight: .semibold))
                                     .foregroundStyle(.primary)
                                 Text(verse.title)
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(Color.accentColor)
-                                Text(verse.verse)
-                                    .font(.footnote)
+                                    .font(.system(size: 13))
                                     .foregroundStyle(.secondary)
-                                    .lineLimit(2)
+                                    .lineLimit(1)
                             }
                             Spacer(minLength: 8)
                             if verse.srsKey == selectedKey {
@@ -298,13 +300,10 @@ private struct VerseListScreen: View {
                                     .foregroundStyle(Color.accentColor)
                             }
                         }
-                        .padding(.vertical, 2)
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                 }
-            } footer: {
-                Text("Tap the verse you last memorized up to.")
             }
         }
         .navigationTitle(pack.name)

--- a/scripture memory/Views/PackListView.swift
+++ b/scripture memory/Views/PackListView.swift
@@ -4,6 +4,7 @@ struct PackListView: View {
     @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
     @ObservedObject private var packPrefs = PackPreferencesStore.shared
     @ObservedObject private var learning  = LearningStore.shared
+    @ObservedObject private var favorites = FavoritesStore.shared
 
     @State private var selectedPack:   Pack?             = nil
     @State private var searchText:     String            = ""
@@ -22,26 +23,13 @@ struct PackListView: View {
     // MARK: - Body
 
     var body: some View {
-        Group {
+        // One scroll view for the whole screen, with the grid and the search
+        // results swapping *inside* it. Two alternating scroll views left
+        // `.searchable` bound to whichever mounted first, so the screen opened
+        // already scrolled past its own large title.
+        ScrollView {
             if searchText.isEmpty {
-                ScrollView {
-                    LazyVGrid(columns: columns, spacing: 12) {
-                        ForEach(visiblePacks) { pack in
-                            Button {
-                                guard !pack.verses.isEmpty else { return }
-                                selectedPack = pack
-                            } label: {
-                                PackCover(pack: pack, isCurrentPack: pack.name == currentPackName)
-                            }
-                            .buttonStyle(CardButtonStyle())
-                            .accessibilityElement(children: .ignore)
-                            .accessibilityLabel("\(pack.name), \(pack.verses.count) cards")
-                            .accessibilityAddTraits(.isButton)
-                        }
-                    }
-                    .padding(.horizontal, AppLayout.screenMargin)
-                    .padding(.vertical, 12)
-                }
+                packGrid
             } else {
                 VerseSearchResultsList(
                     query:   searchText,
@@ -50,6 +38,7 @@ struct PackListView: View {
                 )
             }
         }
+        .scrollDismissesKeyboard(.immediately)
         .animation(nil, value: searchText.isEmpty)
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Packs")
@@ -89,6 +78,34 @@ struct PackListView: View {
         }
     }
 
+    /// The pack grid, with the favourites collection leading it when the user has
+    /// starred anything. It's presented as a pack rather than a separate screen so
+    /// everything a pack can do — read, review, shuffle — works on it unchanged.
+    private var packGrid: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            if let favorites = favorites.pack(in: visiblePacks) {
+                packTile(favorites)
+            }
+            ForEach(visiblePacks) { pack in
+                packTile(pack)
+            }
+        }
+        .padding(.horizontal, AppLayout.screenMargin)
+        .padding(.vertical, 12)
+    }
+
+    private func packTile(_ pack: Pack) -> some View {
+        Button {
+            guard !pack.verses.isEmpty else { return }
+            selectedPack = pack
+        } label: {
+            PackCover(pack: pack, isCurrentPack: pack.name == currentPackName)
+        }
+        .buttonStyle(CardButtonStyle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(pack.name), \(pack.verses.count) cards")
+        .accessibilityAddTraits(.isButton)
+    }
 }
 
 // MARK: - Pack Cover
@@ -103,6 +120,40 @@ struct PackCover: View {
     private static let designHeight: CGFloat = designWidth * 3 / 5  // 5:3
 
     private var isDEP:        Bool  { pack.name.hasPrefix("DEP") }
+    private var isTMS180:     Bool  { pack.name.hasPrefix("TMS 180") }
+    private var isFavorites:  Bool  { pack.name == FavoritesStore.packName }
+
+    /// The printed field colour, used as authored.
+    ///
+    /// Not `.muted`. That knocked 45% off the saturation and 30% off the
+    /// brightness of every cover — a reasonable hedge when the colours came from
+    /// a website where anyone could pick neon green, but these are read off the
+    /// physical packs and are already flat print inks. Muting them just made
+    /// every pack look like a washed-out version of itself.
+    private var fieldColor: Color { Color(hex: pack.color) ?? .gray }
+
+    /// Perceived lightness of the field, so type can pick its own colour.
+    ///
+    /// DEP 1 is printed on white stock with red type while the rest are white on
+    /// solid colour — driving that off luminance rather than the pack's name
+    /// means a colour changed later in Supabase stays legible on its own.
+    /// Only near-white stock counts. The threshold has to sit high: the yellow
+    /// pack is 0.74 and the orange 0.66 on this scale, yet both are printed white
+    /// on colour like the rest of the set — it's pack 1's white card, at 0.94,
+    /// that's the exception. A more intuitive-looking 0.65 flipped three packs to
+    /// red type and a ghosted watermark.
+    private var fieldIsLight: Bool {
+        let ui = UIColor(fieldColor)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        ui.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (0.299 * r + 0.587 * g + 0.114 * b) > 0.85
+    }
+
+    /// Type colour for a coloured field: white, or the Navigators red on the
+    /// white-stock pack.
+    private var inkColor: Color {
+        fieldIsLight ? Color(red: 0.72, green: 0.16, blue: 0.11) : .white
+    }
     private var baseColor:    Color { (Color(hex: pack.color) ?? .gray).muted }
     private var displayTitle: String {
         isDEP ? pack.name
@@ -112,7 +163,9 @@ struct PackCover: View {
     }
 
     private var borderColor: Color {
-        if isDEP { return .white.opacity(0.08) }
+        // The white-stock DEP pack needs a real edge or it dissolves into the
+        // grouped background behind it.
+        if isDEP { return fieldIsLight ? Color(.separator).opacity(0.5) : .white.opacity(0.08) }
         if pack.name == "TMS 60" { return Color(.separator).opacity(0.3) }
         return .clear
     }
@@ -157,73 +210,316 @@ struct PackCover: View {
 
     @ViewBuilder
     private var cardContent: some View {
-        if isDEP                      { depCover     }
-        else if pack.name == "TMS 60" { tmsCover     }
-        else                          { genericCover }
+        if isFavorites                       { favoritesCover    }
+        else if isDEP                        { depCover          }
+        else if isTMS180                     { tms180Cover       }
+        else if pack.name == "TMS 60"        { tmsCover          }
+        else if pack.name == "5 Assurances"  { assurancesCover   }
+        else                                 { genericCover      }
     }
 
-    // MARK: DEP 242 Style
+    // MARK: 5 Assurances Style
+    //
+    // After the cover of *Lessons on Assurance*, the book these five verses are
+    // drawn from: olive field, a leaf-and-tendril line drawing, the title set in
+    // serif with the second word carrying the weight, and the "Growing in Christ
+    // Series" block in a darker band along the bottom.
 
-    private var depCover: some View {
+    private var assurancesCover: some View {
+        let band = fieldColor.darkened(by: 0.34)
+        return ZStack {
+            fieldColor
+
+            LeafBranch()
+                .stroke(Color.white.opacity(0.42), style: StrokeStyle(lineWidth: 1.4, lineCap: .round))
+                .frame(width: 168, height: 132)
+                .offset(x: 78, y: -4)
+
+            // One line at the same weight as every other cover's title.
+            //
+            // This started as the book's own treatment — a small "Lessons on"
+            // over a large "ASSURANCE" — which looked right in isolation and
+            // wrong in the grid: a 37pt word beside DEP's 23pt titles made this
+            // pack shout, and the tiny "5" above it read as a stray number
+            // rather than part of the name. The serif, the leaf and the series
+            // band carry the book's character; the title doesn't have to.
+            VStack(alignment: .leading, spacing: 0) {
+                Text("5 Assurances")
+                    .font(.system(size: 24, design: .serif))
+                    .foregroundColor(.white)
+                    .tracking(0.3)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.leading, 26).padding(.top, 18).padding(.trailing, 110)
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                HStack(alignment: .bottom) {
+                    Text("\(pack.verses.count) cards")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.white.opacity(0.75))
+                    Spacer(minLength: 8)
+                    VStack(alignment: .trailing, spacing: -1) {
+                        Text("Growing in")
+                            .font(.system(size: 9, design: .serif))
+                            .foregroundColor(.white.opacity(0.75))
+                        Text("CHRIST")
+                            .font(.system(size: 16, weight: .semibold, design: .serif))
+                            .foregroundColor(.white)
+                            .tracking(1.5)
+                        Text("Series")
+                            .font(.system(size: 9, design: .serif))
+                            .foregroundColor(.white.opacity(0.75))
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 9)
+                .frame(maxWidth: .infinity)
+                .background(band)
+            }
+        }
+    }
+
+    // MARK: Favourites Style
+
+    /// Deliberately unlike the published covers around it: this one is the user's
+    /// own collection, not a booklet, and it shouldn't read as another product.
+    private var favoritesCover: some View {
         ZStack {
             baseColor
 
-            VStack {
-                HStack {
-                    Text(displayTitle)
-                        .font(.system(size: 24, weight: .semibold, design: .serif))
+            Image(systemName: "star.fill")
+                .font(.system(size: 150))
+                .foregroundColor(.white.opacity(0.1))
+                .offset(x: 95, y: 10)
+
+            HStack {
+                VStack(alignment: .leading, spacing: 5) {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(.white.opacity(0.9))
+                    Text(pack.name)
+                        .font(.system(size: 20, weight: .bold, design: .serif))
                         .foregroundColor(.white)
                         .lineLimit(2)
                         .minimumScaleFactor(0.7)
                     Spacer()
-                }
-                .padding(.leading, 18).padding(.top, 16)
-                Spacer()
-            }
-
-            VStack {
-                Spacer()
-                HStack {
-                    Spacer()
-                    VStack(alignment: .trailing, spacing: -8) {
-                        HStack(alignment: .firstTextBaseline, spacing: 4) {
-                            Text("DEP")
-                                .font(.system(size: 42, weight: .heavy, design: .serif))
-                                .italic()
-                                .foregroundColor(.white.opacity(0.8))
-                            Text("NIV")
-                                .font(.system(size: 18, weight: .bold, design: .serif))
-                                .foregroundColor(.white.opacity(0.5))
-                        }
-                        Text("242")
-                            .font(.system(size: 50, weight: .heavy, design: .serif))
-                            .italic()
-                            .foregroundColor(.white.opacity(0.25))
-                    }
-                    .padding(.trailing, 18).padding(.bottom, 28)
-                }
-            }
-
-            VStack {
-                Spacer()
-                HStack {
-                    HStack(spacing: 5) {
-                        Image(systemName: "moon.fill")
-                            .foregroundColor(.white.opacity(0.6))
-                            .font(.system(size: 12))
-                        Text("THE NAVIGATORS")
-                            .font(.system(size: 12, weight: .medium, design: .serif))
-                            .foregroundColor(.white.opacity(0.6))
-                            .tracking(0.5)
-                    }
-                    Spacer()
-                    Text("\(pack.verses.count) cards")
+                    Text("\(pack.verses.count) starred")
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.white.opacity(0.5))
+                        .foregroundColor(.white.opacity(0.65))
                 }
-                .padding(.horizontal, 18).padding(.bottom, 12)
+                Spacer()
+            }
+            .padding(18)
+        }
+    }
+
+    // MARK: DEP 242 Style
+    //
+    // Faithful to the printed pack: numbered title top-left in plain sans, the
+    // gold DEP wordmark with an outlined 242 tucked under it bottom-right, and
+    // the Navigators mark bottom-left. Pack 1 is white stock with red type; the
+    // rest are white on a solid field.
+
+    /// Ink for the DEP/242 lockup.
+    ///
+    /// Not gold on every pack, which is what I first assumed. Sampling the
+    /// wordmark on each of the eight shows the warm half (red, orange, yellow,
+    /// green) printed in gold and the cool half (sky, royal, violet) printed in
+    /// white — gold on a blue field is exactly the jarring combination that
+    /// doesn't appear on any real pack. Pack 1's white stock carries it as a pale
+    /// tint of nothing, a watermark.
+    ///
+    /// Decided by hue rather than by pack name, so a colour edited later in
+    /// Supabase picks the right ink on its own.
+    private var depGold: Color {
+        if fieldIsLight { return Color(red: 0.90, green: 0.78, blue: 0.72) }
+
+        let ui = UIColor(fieldColor)
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        ui.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        let degrees = h * 360
+        let isCool = degrees >= 185 && degrees <= 300      // sky through violet
+        return isCool ? .white : Color(red: 0.98, green: 0.80, blue: 0.36)
+    }
+
+    private var depCover: some View {
+        ZStack {
+            fieldColor
+
+            VStack {
+                HStack {
+                    Text(displayTitle)
+                        .font(.system(size: 23, weight: .regular))
+                        .foregroundColor(inkColor)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.7)
+                        .multilineTextAlignment(.leading)
+                    Spacer(minLength: 0)
+                }
+                // 12, not 16. A 23pt line box carries ~4pt of ascender space above
+                // the cap, so equal padding top and bottom does not read as equal:
+                // measured off screenshots, 16/12 gave a ~20pt optical gap at the
+                // top against ~13pt at the bottom. These numbers are chosen so the
+                // *ink* sits the same distance from both edges.
+                .padding(.leading, 28).padding(.trailing, 16).padding(.top, 18)
+                Spacer(minLength: 0)
+            }
+
+            // DEP / NIV / 242 lockup, positioned from measurements off the
+            // printed pack rather than stacked and hoped for.
+            //
+            // The three are not a neat right-aligned column: 242 is the largest
+            // and runs almost to the card edge, DEP is smaller and sits well
+            // inside it, and NIV is tucked into the gap between them at the
+            // right. Stacking DEP over 242 in a VStack — which is what this was —
+            // lines up two edges that don't line up in print, and shrinks the 242
+            // to look like a caption under a heading instead of the other way
+            // round.
+            ZStack(alignment: .bottomTrailing) {
+                OutlinedText(text: "242",
+                             font: .system(size: 64, weight: .black).italic(),
+                             stroke: depGold,
+                             fill: fieldColor,
+                             width: 1.5)
+                    .padding(.trailing, 9)
+                    .padding(.bottom, 6)
+
+                // 62, not 55. The two are sized very differently, so equal-looking
+                // paddings don't give equal-looking gaps: at 46pt DEP's baseline
+                // lands ~66pt off the bottom edge while the 64pt numeral's cap top
+                // lands ~67pt — within a point of each other, so the glyphs touch
+                // wherever they overlap horizontally. This lifts DEP clear.
+                Text("DEP")
+                    .font(.system(size: 42, weight: .black))
+                    .italic()
+                    .tracking(-0.5)
+                    .foregroundColor(depGold)
+                    .padding(.trailing, 68)
+                    .padding(.bottom, 62)
+
+                // Clear above the 242, not tucked into it.
+                //
+                // On the printed pack this sits right in the notch above the
+                // numeral, and copying that measurement literally reads as a
+                // collision on screen: the italic slant throws the last "2"'s
+                // top-right corner out underneath it, and the outlined numeral is
+                // drawn with a stroke that widens its bounds further. Given the
+                // choice between matching a tight print detail and looking
+                // deliberate, this takes the clearance.
+                // Serif, unlike everything else in the lockup. DEP, 242 and the
+                // Navigators wordmark are all sans on the printed pack — a heavy
+                // geometric italic and a condensed grotesque — but the translation
+                // mark is set in a roman italic with visible serifs.
+                Text("NIV")
+                    .font(.system(size: 13, weight: .semibold, design: .serif))
+                    .italic()
+                    .foregroundColor(depGold)
+                    .padding(.trailing, 12)
+                    .padding(.bottom, 72)
+            }
+            // Fill the card. Without this the ZStack shrinks to fit the lockup and
+            // the enclosing ZStack centres that block in the middle of the cover —
+            // the `bottomTrailing` alignment then only positions the three pieces
+            // relative to each other, not against the card. The paddings above are
+            // all measured from the card's own edges, so they only mean anything
+            // once this stack actually spans it.
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+
+            VStack {
+                Spacer(minLength: 0)
+                HStack(alignment: .bottom) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "moon.fill")
+                                .font(.system(size: 11))
+                            Text("THE NAVIGATORS")
+                                .font(.system(size: 12, weight: .medium))
+                                .tracking(0.2)
+                        }
+                        // The printed card carries the price here. A price means
+                        // nothing in the app, so the slot keeps its shape and
+                        // says something worth knowing instead.
+                        Text("\(pack.verses.count) cards")
+                            .font(.system(size: 10))
+                            .opacity(0.8)
+                    }
+                    .foregroundColor(inkColor)
+                    Spacer(minLength: 0)
+                }
+                // 15 against the title's 12 — the 10pt line here has almost no
+                // descender slack, so it needs the larger number to land at the
+                // same optical distance from the edge.
+                .padding(.leading, 28).padding(.bottom, 15)
             }
         }
+    }
+
+    // MARK: TMS 180 Style
+    //
+    // "series N" small at top-right, the title right-aligned and bold beneath it,
+    // and the Korean publisher line bottom-left.
+
+    private var tms180Cover: some View {
+        ZStack {
+            fieldColor
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(seriesLabel)
+                    .font(.system(size: 15))
+                    .foregroundColor(.white.opacity(0.95))
+                Text(seriesTitle)
+                    .font(.system(size: 30, weight: .bold))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.trailing)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.6)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.trailing, 20).padding(.top, 16).padding(.leading, 20)
+
+            VStack {
+                Spacer(minLength: 0)
+                HStack(alignment: .bottom) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 4) {
+                            Text("네비게이토")
+                                .font(.system(size: 13, weight: .semibold))
+                            Image(systemName: "moon.fill")
+                                .font(.system(size: 10))
+                            Text("출판사")
+                                .font(.system(size: 13, weight: .semibold))
+                        }
+                        Text("TO KNOW CHRIST AND TO MAKE HIM KNOWN")
+                            .font(.system(size: 7, weight: .medium))
+                            .tracking(0.2)
+                    }
+                    .foregroundColor(.white.opacity(0.92))
+                    Spacer(minLength: 0)
+                    Text("\(pack.verses.count) cards")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.7))
+                }
+                .padding(.horizontal, 20).padding(.bottom, 12)
+            }
+        }
+    }
+
+    /// `TMS 180 · Growing in Faith` -> `series 3`, from the pack's own position
+    /// in the series rather than anything in its name.
+    private var seriesLabel: String {
+        let code = VerseNumbering.packCode(for: pack.name)   // "TMS 180 S3"
+        let number = code.split(separator: "S").last.map(String.init) ?? ""
+        return number.isEmpty ? "" : "series \(number)"
+    }
+
+    /// The part after the separator — the title as printed on the pack.
+    private var seriesTitle: String {
+        pack.name.components(separatedBy: " · ").last ?? pack.name
     }
 
     // MARK: TMS 60 Style

--- a/scripture memory/Views/PackOrganizerView.swift
+++ b/scripture memory/Views/PackOrganizerView.swift
@@ -57,22 +57,23 @@ struct PackOrganizerView: View {
         }
     }
 
+    /// One line per pack: name, show/hide, drag handle.
+    ///
+    /// The colour swatch is gone. It cost a row of height and a column of width
+    /// to restate something the name already says — and worse, it showed the
+    /// `.muted` cover colour rather than the real one, so it wasn't even an
+    /// accurate swatch. Without it the names fit on one line, which is what was
+    /// making this list twice as tall as it needed to be.
     private func row(_ pack: Pack) -> some View {
         let isHidden = store.isHidden(pack.name)
-        return HStack(spacing: 12) {
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill((Color(hex: pack.color) ?? .gray).muted)
-                .frame(width: 36, height: 24)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .strokeBorder(Color(.separator).opacity(0.4), lineWidth: 0.5)
-                )
-
+        return HStack(spacing: 8) {
             Text(pack.name)
                 .font(.body)
                 .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
 
-            Spacer()
+            Spacer(minLength: 4)
 
             Button {
                 store.setHidden(pack.name, !isHidden)
@@ -81,7 +82,9 @@ struct PackOrganizerView: View {
                 Image(systemName: isHidden ? "eye.slash" : "eye")
                     .font(.system(size: 17))
                     .foregroundStyle(isHidden ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color.accentColor))
-                    .frame(width: 44, height: 44)
+                    // Still a 44pt target, but only 30 of it counts toward the
+                    // row's height — the drag handle sets that anyway.
+                    .frame(width: 44, height: 30)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.borderless)

--- a/scripture memory/Views/SRSDashboardView.swift
+++ b/scripture memory/Views/SRSDashboardView.swift
@@ -58,7 +58,7 @@ struct SRSDashboardView: View {
     private var now:          Date   { Date() }
 
     /// All visible verses flattened in pack order — the linear "learning" sequence.
-    private var ordered:      [Verse] { packs.flatMap(\.verses) }
+    private var ordered:      [Verse] { Catalogue.verses(in: packs) }
 
     /// The verse to feature on Home — the pinned one if the user pinned one, else
     /// the current learning verse — resolved to its pack + index, plus whether
@@ -98,7 +98,10 @@ struct SRSDashboardView: View {
     }
 
     var body: some View {
-        Group {
+        // One scroll view for the whole screen — see `PackListView.body`. Two
+        // alternating scroll views under one `.searchable` is what made Home open
+        // scrolled past its own large title.
+        ScrollView {
             if searchText.isEmpty {
                 dashboard
             } else {
@@ -109,6 +112,7 @@ struct SRSDashboardView: View {
                 )
             }
         }
+        .scrollDismissesKeyboard(.immediately)
         // Swapping the whole screen shouldn't animate — matches Packs.
         .animation(nil, value: searchText.isEmpty)
         .background(Color(.systemGroupedBackground))
@@ -136,25 +140,26 @@ struct SRSDashboardView: View {
     }
 
     private var dashboard: some View {
-        ScrollView {
-            VStack(spacing: Layout.sectionSpacing) {
-                streakCard
-                continueLearningCard
-                goToCurrentVerseCard
-                Text("Daily Review")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.leading, 4)
-                    .padding(.top, 4)
-                heroCard
-                packsReviewLink
-            }
-            .padding(.horizontal, Layout.edgeMargin)
-            .padding(.top, 8)
-            .padding(.bottom, 24)
+        VStack(spacing: Layout.sectionSpacing) {
+            streakCard
+            continueLearningCard
+            goToCurrentVerseCard
+            // Title Case at 17pt semibold, not 13pt uppercase — the grouped-list
+            // header iOS Settings actually uses now. The small all-caps form is
+            // the older style and reads as a label stuck above a card rather than
+            // as the section's own heading.
+            Text("Daily Review")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 4)
+                .padding(.top, 4)
+            heroCard
+            packsReviewLink
         }
+        .padding(.horizontal, Layout.edgeMargin)
+        .padding(.top, 8)
+        .padding(.bottom, 24)
     }
 
     // MARK: - Streak
@@ -227,10 +232,10 @@ struct SRSDashboardView: View {
                     Menu {
                         if cur.isPinned {
                             Button { showPinPicker = true } label: {
-                                Label("Change pinned verse…", systemImage: "pin")
+                                Label("Change verse", systemImage: "pin")
                             }
                             Button { learning.unpin(); HapticEngine.light() } label: {
-                                Label("Back to current verse", systemImage: "arrow.uturn.backward")
+                                Label("Unpin verse", systemImage: "pin.slash")
                             }
                         } else {
                             Button { showPinPicker = true } label: {
@@ -417,8 +422,9 @@ struct SRSDashboardView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, Layout.cardPadding)
-        .padding(.horizontal, Layout.cardPadding)
+        // A one-line row doesn't need the 20pt inset a tall stack did.
+        .padding(.vertical, 14)
+        .padding(.horizontal, Layout.rowPaddingH)
         .background(
             RoundedRectangle(cornerRadius: Layout.containerRadius, style: .continuous)
                 .fill(Color(.secondarySystemGroupedBackground))
@@ -426,62 +432,86 @@ struct SRSDashboardView: View {
     }
 
     private var heroNoActivePacks: some View {
-        VStack(spacing: 8) {
+        HStack(spacing: 12) {
             Image(systemName: "square.stack.3d.up.slash")
-                .font(.system(size: 36))
+                .font(.system(size: 26))
                 .foregroundStyle(.secondary)
-            Text("No active packs")
-                .font(.system(size: 17, weight: .semibold))
-            Text("Turn on a pack below to start your daily review.")
-                .font(.system(size: 14))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("No active packs")
+                    .font(.system(size: 16, weight: .semibold))
+                Text("Turn on a pack to start your daily review.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
         }
     }
 
+    /// One row: what's due, and the button to do it.
+    ///
+    /// This was a stack — a 48pt numeral, a full-width Start button, then the
+    /// breakdown — roughly 200pt tall to say "1 card due today". iOS puts a
+    /// summary like this on one line with the action trailing (Software Update,
+    /// the App Store's Update All, a Reminders smart list): the count reads at a
+    /// glance, the button is still the most prominent thing in the row, and the
+    /// rest of Home moves up to meet it.
     private func heroQueue(agg: Aggregate) -> some View {
-        VStack(spacing: 16) {
-            VStack(spacing: 4) {
-                Text("\(agg.queueSize)")
-                    .font(.system(size: 48, weight: .bold, design: .rounded))
-                    .contentTransition(.numericText())
-                Text(agg.queueSize == 1 ? "card due today" : "cards due today")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.secondary)
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    // Rounded for the numeral only — the label beside it stays on
+                    // the standard face.
+                    Text("\(agg.queueSize)")
+                        .font(.system(size: 26, weight: .bold, design: .rounded))
+                        .contentTransition(.numericText())
+                    Text(agg.queueSize == 1 ? "card due today" : "cards due today")
+                        .font(.system(size: 15))
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+
+                HStack(spacing: 10) {
+                    breakdownChip(label: "Learning", value: agg.learning,     color: .orange)
+                    breakdownChip(label: "Review",   value: agg.review,       color: .blue)
+                    breakdownChip(label: "New",      value: agg.newProjected, color: .green)
+                }
             }
-            .accessibilityElement(children: .combine)
+
+            Spacer(minLength: 8)
 
             Button {
                 startSession(forPacks: activePacks)
             } label: {
-                Label("Start Review", systemImage: "play.fill")
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
+                Text("Start")
+                    .font(.system(size: 15, weight: .semibold))
+                    .padding(.horizontal, 6)
             }
             .buttonStyle(.borderedProminent)
-            .controlSize(.large)
+            .controlSize(.regular)
+            .buttonBorderShape(.capsule)
             .tint(.accentColor)
-
-            HStack(spacing: 12) {
-                breakdownChip(label: "Learning", value: agg.learning,     color: .orange)
-                breakdownChip(label: "Review",   value: agg.review,       color: .blue)
-                breakdownChip(label: "New",      value: agg.newProjected, color: .green)
-            }
+            .accessibilityLabel("Start review")
         }
     }
 
+    /// Same row shape as the queue state, so the card doesn't resize as you
+    /// finish a session.
     private func heroCaughtUp(agg: Aggregate) -> some View {
-        VStack(spacing: 8) {
+        HStack(spacing: 12) {
             Image(systemName: "checkmark.seal.fill")
-                .font(.system(size: 36))
+                .font(.system(size: 26))
                 .foregroundStyle(.green)
                 .symbolEffect(.bounce, options: .nonRepeating)
-            Text("All caught up")
-                .font(.system(size: 17, weight: .semibold))
-            Text(caughtUpMessage(agg: agg))
-                .font(.system(size: 14))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("All caught up")
+                    .font(.system(size: 16, weight: .semibold))
+                Text(caughtUpMessage(agg: agg))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
         }
     }
 
@@ -541,7 +571,11 @@ struct SRSDashboardView: View {
             }
             .font(.system(size: 13))
             .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity)
+            // Leading, not centred. This sits where a grouped-list *footer* sits,
+            // and iOS aligns those to the section's leading edge — centred, it
+            // read as a standalone button floating under the card.
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 4)
             .padding(.vertical, 2)
             .contentShape(Rectangle())
         }
@@ -712,18 +746,19 @@ private struct PinVersePicker: View {
                     onPick(verse)
                     dismiss()
                 } label: {
-                    HStack(alignment: .top, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 3) {
+                    // Reference and title only — see the matching picker in
+                    // `LearningSetupView`. You're identifying a card you already
+                    // know, and two lines of body text per row turn a list you'd
+                    // scan into one you have to scroll.
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 2) {
                             Text("\(verse.book) \(verse.reference)")
-                                .font(.headline)
+                                .font(.system(size: 15, weight: .semibold))
                                 .foregroundStyle(.primary)
                             Text(verse.title)
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(Color.accentColor)
-                            Text(verse.verse)
-                                .font(.footnote)
+                                .font(.system(size: 13))
                                 .foregroundStyle(.secondary)
-                                .lineLimit(2)
+                                .lineLimit(1)
                         }
                         Spacer(minLength: 8)
                         if verse.srsKey == pinnedKey {
@@ -732,7 +767,6 @@ private struct PinVersePicker: View {
                                 .foregroundStyle(Color.accentColor)
                         }
                     }
-                    .padding(.vertical, 2)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)

--- a/scripture memory/Views/SubmitCardView.swift
+++ b/scripture memory/Views/SubmitCardView.swift
@@ -18,6 +18,10 @@ struct SubmitCardView: View {
     /// See `FlashcardView.showCardLabel` — the pack name is a clue on a card the
     /// user is being asked to recall.
     var showCardLabel:     Bool = true
+    /// See `FlashcardView.showsFavoriteToggle`. Entire Verse is still review, so
+    /// it gets the same star in the same corner as the other two modes.
+    var showsFavoriteToggle: Bool = false
+
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -42,6 +46,7 @@ struct SubmitCardView: View {
                         .minimumScaleFactor(0.8)
                 }
                 Spacer(minLength: 8)
+                if showsFavoriteToggle { FavoriteStarButton(verse: verse) }
                 if isCurrentLearning { currentBadge }
             }
             .padding(.top, 6)

--- a/scripture memory/Views/SubmitCardView.swift
+++ b/scripture memory/Views/SubmitCardView.swift
@@ -15,6 +15,9 @@ struct SubmitCardView: View {
     let result:      SubmitResult?
     @FocusState.Binding var focusedField: SubmitField?
     var isCurrentLearning: Bool = false
+    /// See `FlashcardView.showCardLabel` — the pack name is a clue on a card the
+    /// user is being asked to recall.
+    var showCardLabel:     Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -31,9 +34,13 @@ struct SubmitCardView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
             HStack(spacing: 6) {
-                Text(cardLabel)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.secondary)
+                if showCardLabel {
+                    Text(cardLabel)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
                 Spacer(minLength: 8)
                 if isCurrentLearning { currentBadge }
             }

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -61,6 +61,11 @@ struct TestSessionView: View {
         sessionKind == .srs ? "Review" : "Quiz"
     }
 
+    /// A quiz is drawn from packs the user hand-picked, so naming the pack on the
+    /// card hands them half the answer. The SRS deck is dealt to them and mixes
+    /// everything they're learning, so there the label is orientation, not a clue.
+    private var showsCardLabel: Bool { sessionKind == .srs }
+
     // MARK: - Body
 
     var body: some View {
@@ -90,7 +95,8 @@ struct TestSessionView: View {
                                 cardLabel: vm.cardLabel(for: verse),
                                 width: cardWidth,
                                 height: cardH,
-                                isPeeking: isPeeking
+                                isPeeking: isPeeking,
+                                showCardLabel: showsCardLabel
                             )
                             .allowsHitTesting(false)
                             .transition(.opacity)
@@ -440,7 +446,8 @@ struct TestSessionView: View {
                 verseText: interactive ? $vm.verseInput : .constant(""),
                 result: interactive ? vm.submitResults[verse.id] : nil,
                 focusedField: $submitFocus,
-                isCurrentLearning: learning.isCurrent(verse)
+                isCurrentLearning: learning.isCurrent(verse),
+                showCardLabel: showsCardLabel
             )
             .allowsHitTesting(interactive)
         } else {
@@ -460,6 +467,7 @@ struct TestSessionView: View {
                     vm.activeSection = section
                     DispatchQueue.main.async { focusInput() }
                 } : nil,
+                showCardLabel: showsCardLabel,
                 isCurrentLearning: learning.isCurrent(verse)
             )
         }

--- a/scripture memory/Views/TestSessionView.swift
+++ b/scripture memory/Views/TestSessionView.swift
@@ -781,6 +781,9 @@ struct TestSessionView: View {
                             .roundedRect(12)
                     }
                     .accessibilityLabel(speech.isListening ? "Stop dictation" : "Dictate verse")
+
+                    submitHintButton
+
                     let isEmpty = vm.titleInput.trimmingCharacters(in: .whitespaces).isEmpty
                               && vm.verseInput.trimmingCharacters(in: .whitespaces).isEmpty
                     Button {
@@ -887,6 +890,40 @@ struct TestSessionView: View {
                 .roundedRect(12)
         }
         .buttonStyle(.plain)
+    }
+
+    /// Entire Verse's hint: types the next word straight into the answer box.
+    private var submitHintButton: some View {
+        Button {
+            fillNextHintWord()
+            HapticEngine.light()
+        } label: {
+            Image(systemName: "lightbulb")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.primary)
+                .frame(width: 48, height: 48)
+                .background(Color(.secondarySystemGroupedBackground))
+                .roundedRect(12)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Reveal next word")
+    }
+
+    /// Extends whichever box you're in by one word, falling through to the other
+    /// once that one is complete. Mirrors `CardStudyView.fillNextHintWord`.
+    private func fillNextHintWord() {
+        guard let verse = vm.currentVerse else { return }
+        let startWithVerse = submitFocus == .verse
+        let sections: [(target: String, isTitle: Bool)] = startWithVerse
+            ? [(verse.verse, false), (verse.title, true)]
+            : [(verse.title, true), (verse.verse, false)]
+
+        for section in sections {
+            let typed = section.isTitle ? vm.titleInput : vm.verseInput
+            guard let filled = HintFill.next(target: section.target, typed: typed) else { continue }
+            if section.isTitle { vm.titleInput = filled } else { vm.verseInput = filled }
+            return
+        }
     }
 
     // MARK: - Swipe Gesture

--- a/scripture memory/Views/TestSessionViewModel.swift
+++ b/scripture memory/Views/TestSessionViewModel.swift
@@ -125,7 +125,7 @@ final class TestSessionViewModel: ObservableObject {
 
     // MARK: - Card Label
 
-    func cardLabel(for verse: Verse) -> String { verse.packName }
+    func cardLabel(for verse: Verse) -> String { CardFooter.label(for: verse) }
 
     // MARK: - Reveal State
 

--- a/scripture memory/Views/TestSetupView.swift
+++ b/scripture memory/Views/TestSetupView.swift
@@ -20,9 +20,19 @@ struct TestSetupView: View {
 
     @AppStorage("bibleVersion") private var bibleVersion: BibleVersion = .niv84
     @ObservedObject private var packPrefs = PackPreferencesStore.shared
+    @ObservedObject private var learning  = LearningStore.shared
+    @ObservedObject private var favorites = FavoritesStore.shared
 
     @State private var selectedVerseIds:  Set<Int>    = []
     @State private var expandedPackIds:   Set<String> = []
+
+    /// Live row positions, and the state of an in-flight two-finger drag.
+    @State private var dragFrames = DragSelectFrames()
+    /// What the drag is doing: `true` selects everything it crosses, `false`
+    /// clears. Decided by the first row touched, so a run never alternates.
+    @State private var dragSelects = true
+    /// Rows already handled by this drag — re-entering one mustn't flip it back.
+    @State private var dragVisited: Set<Int> = []
     @State private var quizCount:         Int         = 15
     @State private var activeSession:     TestSession? = nil
     @State private var savedSession:      TestSession? = nil
@@ -48,10 +58,16 @@ struct TestSetupView: View {
     private var selectedCount: Int { selectedVerseIds.count }
     private var clampedCount:  Int { max(1, min(quizCount, selectedCount)) }
 
+    private var visiblePacks: [Pack] { packPrefs.visible(from: bibleVersion.packs) }
+
+    /// Every visible verse in catalogue order — the sequence the learning cursor
+    /// walks, and what "everything before this one" means.
+    private var catalogue: [Verse] { Catalogue.verses(in: visiblePacks) }
+
     // Flat items for packs + their expanded verses — driven by expandedPackIds
     private var packItems: [PackListItem] {
         var items: [PackListItem] = []
-        for pack in packPrefs.visible(from: bibleVersion.packs) {
+        for pack in visiblePacks {
             items.append(.packHeader(pack))
             if expandedPackIds.contains(pack.id) {
                 for verse in pack.verses {
@@ -71,6 +87,10 @@ struct TestSetupView: View {
                 }
             }
 
+            Section {
+                shortcutRows
+            }
+
             // All packs in one compact section
             Section {
                 ForEach(packItems) { item in
@@ -86,12 +106,25 @@ struct TestSetupView: View {
                 }
             }
         }
+        // Two-finger drag anywhere over the list to select a run of verses.
+        // Zero-sized and non-interactive: it only exists to find the enclosing
+        // scroll view and hang a gesture off it.
+        .background(
+            TwoFingerDragSelect(
+                onDrag: { point, isFirst in handleDragSelect(at: point, isFirst: isFirst) },
+                onEnd:  { dragVisited.removeAll() }
+            )
+            .frame(width: 0, height: 0)
+        )
         .listStyle(.insetGrouped)
         .listSectionSpacing(savedSession == nil ? 12 : 22)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: expandedPackIds)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: savedSession != nil)
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Quiz")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) { deselectAllButton }
+        }
         .onAppear {
             loadPersistedQuizCount()
             loadSavedSession()
@@ -162,14 +195,86 @@ struct TestSetupView: View {
         }
     }
 
+    // MARK: - Shortcuts
+    //
+    // Picking a quiz almost always means one of a few spans, and reaching them by
+    // hand is the tedious part: "everything I've learnt so far" is a hundred-odd
+    // taps, or one pack checkbox plus un-ticking the tail of the pack you're in.
+
+    /// The two smart presets, as visible rows.
+    ///
+    /// These stay on screen rather than folding into a menu: they're for use
+    /// *while* choosing verses, and a control you need mid-task has to be in
+    /// sight — a `⋯` menu is where occasional commands go, not the ones you're
+    /// reaching for. They sit in their own group above the packs, so they read as
+    /// shortcuts rather than as two more packs.
+    @ViewBuilder
+    private var shortcutRows: some View {
+        let upToCurrent = versesUpToCurrent()
+        if !upToCurrent.isEmpty {
+            shortcutRow(
+                title: "Up to current verse",
+                detail: learning.currentVerse.flatMap { VerseNumbering.code(for: $0) }
+                    ?? verseCount(upToCurrent.count)
+            ) { select(upToCurrent) }
+        }
+
+        let starred = favorites.verses(in: visiblePacks)
+        if !starred.isEmpty {
+            shortcutRow(title: "Favourites", detail: "\(starred.count)") { select(starred) }
+        }
+    }
+
+    /// Clearing the selection, in the navigation bar — where Mail and Files put
+    /// it. It acts on the whole selection rather than adding a span to it, so as
+    /// a list row it had to appear the moment you picked something, shoving every
+    /// pack down under a finger already moving toward one.
+    @ViewBuilder
+    private var deselectAllButton: some View {
+        if !selectedVerseIds.isEmpty {
+            Button("Deselect All") {
+                selectedVerseIds = []
+                HapticEngine.light()
+            }
+        }
+    }
+
+    private func verseCount(_ n: Int) -> String { "\(n) \(n == 1 ? "verse" : "verses")" }
+
+    /// A plain title-and-value row, the shape iOS uses for exactly this. No icon:
+    /// coloured glyphs down the left edge implied unrelated kinds of thing, when
+    /// these are just two ways of filling the same selection.
+    private func shortcutRow(title: String, detail: String,
+                             action: @escaping () -> Void) -> some View {
+        Button {
+            action()
+            HapticEngine.light()
+        } label: {
+            HStack {
+                Text(title)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.accentColor)
+                Spacer()
+                Text(detail)
+                    .font(.system(size: 15))
+                    .foregroundColor(.secondary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
     // MARK: - Pack Header Row
     //
     // Three distinct zones:
     //   ① Checkbox button  — select/deselect all verses in this pack
-    //   ② Pack name text   — non-interactive (tapping does nothing)
-    //   ③ Chevron button   — the ONLY thing that expands/collapses
+    //   ② Pack name        — tap to expand/collapse
+    //   ③ Chevron          — same as ②, just the affordance for it
     //
-    // Removing the auto-select-on-expand so the chevron only expands.
+    // Tapping the row used to select the whole pack, which put "select 55 verses"
+    // and "look inside" one mis-tap apart, with only the checkbox distinguishing
+    // them. Now the row does the reversible thing and the checkbox does the
+    // committal one — the same split the verse rows use.
 
     private func packHeaderRow(_ pack: Pack) -> some View {
         let packVerseIds   = Set(pack.verses.map(\.id))
@@ -186,6 +291,7 @@ struct TestSetupView: View {
                 } else {
                     for verse in pack.verses { selectedVerseIds.insert(verse.id) }
                 }
+                HapticEngine.light()
             } label: {
                 Image(systemName: allSelected  ? "checkmark.circle.fill"
                                  : someSelected ? "minus.circle.fill"
@@ -197,19 +303,21 @@ struct TestSetupView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(allSelected ? "Deselect all verses in \(pack.name)" : "Select all verses in \(pack.name)")
 
-            // ② Pack name — tapping selects/deselects all verses (does NOT expand)
+            // ② + ③ Name and chevron — one expand target
             Button {
-                if allSelected {
-                    for verse in pack.verses { selectedVerseIds.remove(verse.id) }
-                } else {
-                    for verse in pack.verses { selectedVerseIds.insert(verse.id) }
-                }
+                if isExpanded { expandedPackIds.remove(pack.id) }
+                else          { expandedPackIds.insert(pack.id) }
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
+                        // One line, truncated. The 180-series names are long
+                        // enough to wrap, and a two-line row here makes the pack
+                        // list ragged for a tail everyone can already predict.
                         Text(pack.name)
                             .font(.system(size: 16, weight: .medium))
                             .foregroundColor(.primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                         Text(selectedInPack > 0
                              ? "\(selectedInPack) of \(pack.verses.count) verses"
                              : "\(pack.verses.count) verses")
@@ -217,25 +325,14 @@ struct TestSetupView: View {
                             .foregroundColor(.secondary)
                     }
                     Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .rotationEffect(isExpanded ? .degrees(90) : .zero)
+                        .frame(width: 44, height: 50)
                 }
                 .frame(maxHeight: .infinity)
                 .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            // ③ Chevron — only expansion trigger, no selection side-effect
-            Button {
-                if isExpanded {
-                    expandedPackIds.remove(pack.id)
-                } else {
-                    expandedPackIds.insert(pack.id)
-                }
-            } label: {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.secondary)
-                    .rotationEffect(isExpanded ? .degrees(90) : .zero)
-                    .frame(width: 44, height: 50)
             }
             .buttonStyle(.plain)
             .accessibilityLabel(isExpanded ? "Collapse \(pack.name)" : "Expand \(pack.name) to pick individual verses")
@@ -244,11 +341,19 @@ struct TestSetupView: View {
 
     // MARK: - Verse Row
 
+    /// One line: tick, card number, title, reference. Nothing to open.
+    ///
+    /// A verse row has exactly one job here — in or out of the quiz — so the
+    /// whole row does it. It used to expand to a panel holding the verse text and
+    /// two more buttons, which meant every row carried a disclosure chevron for a
+    /// drawer nobody wants open while picking a quiz. "Select all up to here"
+    /// moved to a swipe action: still one gesture away, costs no pixels.
     private func verseRow(_ verse: Verse) -> some View {
         let isSelected = selectedVerseIds.contains(verse.id)
         return Button {
             if isSelected { selectedVerseIds.remove(verse.id) }
             else          { selectedVerseIds.insert(verse.id) }
+            HapticEngine.light()
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
@@ -256,10 +361,19 @@ struct TestSetupView: View {
                     .foregroundStyle(isSelected ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(verse.title)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
+                    HStack(spacing: 6) {
+                        // The card's printed number — how the verse is referred to
+                        // out loud and how it's found in the booklet — so it leads.
+                        if let code = VerseNumbering.code(for: verse) {
+                            Text(code)
+                                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(verse.title)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.primary)
+                            .lineLimit(1)
+                    }
                     Text("\(verse.book) \(verse.reference)")
                         .font(.system(size: 12))
                         .foregroundColor(.secondary)
@@ -271,9 +385,86 @@ struct TestSetupView: View {
             .padding(.vertical, 2)
         }
         .buttonStyle(.plain)
+        .overlay(alignment: .trailing) { upToHereButton(verse) }
+        .dragSelectRow(id: verse.id, in: dragFrames)
         .accessibilityLabel("\(verse.title), \(verse.book) \(verse.reference)")
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    // MARK: - Span selection
+
+    /// Every visible verse up to and including `verse`, in catalogue order.
+    private func versesUpTo(_ verse: Verse) -> [Verse] {
+        let all = catalogue
+        guard let i = all.firstIndex(where: { $0.id == verse.id }) else { return [] }
+        return Array(all[...i])
+    }
+
+    /// Everything up to and including the learning cursor. Once every verse is
+    /// learnt there is no cursor, and the span is the whole catalogue.
+    private func versesUpToCurrent() -> [Verse] {
+        guard let current = learning.currentVerse else { return catalogue }
+        let all = catalogue
+        guard let i = all.firstIndex(where: { $0.srsKey == current.srsKey }) else { return [] }
+        return Array(all[...i])
+    }
+
+    /// Selects everything up to and including this verse, across the whole
+    /// catalogue rather than just this pack. Reaching, say, DEP 1 card 12 means
+    /// "everything I've covered so far" — the span you most want, and the most
+    /// tedious to tick by hand.
+    ///
+    /// A visible control because the swipe action alone was undiscoverable —
+    /// nobody finds a gesture they haven't been told about. Kept to a single
+    /// tertiary glyph at the trailing edge: on a list this long, anything with a
+    /// label would be thirty copies of the same sentence running down the page.
+    private func upToHereButton(_ verse: Verse) -> some View {
+        Button {
+            select(versesUpTo(verse))
+            HapticEngine.light()
+        } label: {
+            Image(systemName: "arrow.up.to.line")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .frame(width: 34, height: 36)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Select all verses up to \(verse.title)")
+    }
+
+    /// Applies a two-finger drag to whichever verse row is under the finger.
+    ///
+    /// The first row decides the direction for the whole drag — start on an
+    /// unselected verse and the run selects, start on a selected one and it
+    /// clears. Toggling each row on its own terms would leave a dragged-over run
+    /// alternating, which is never what anyone means.
+    ///
+    /// `dragVisited` stops a row flipping again when the finger wobbles back
+    /// over it.
+    private func handleDragSelect(at point: CGPoint, isFirst: Bool) {
+        guard let id = dragFrames.row(at: point) else { return }
+        if isFirst {
+            dragVisited.removeAll()
+            dragSelects = !selectedVerseIds.contains(id)
+        }
+        guard !dragVisited.contains(id) else { return }
+        dragVisited.insert(id)
+        if dragSelects { selectedVerseIds.insert(id) } else { selectedVerseIds.remove(id) }
+        HapticEngine.light()
+    }
+
+    /// Replaces the selection rather than adding to it.
+    ///
+    /// These read as "quiz me on X", so tapping Favourites after Up to Current
+    /// Verse has to leave you with the favourites — not with both sets unioned
+    /// and no indication that's what happened. Composing them was defensible in
+    /// the abstract and wrong in the hand: the shortcut appears to do nothing
+    /// when everything it would add is already selected, and there's no way to
+    /// subtract one preset back out again.
+    private func select(_ verses: [Verse]) {
+        selectedVerseIds = Set(verses.map(\.id))
     }
 
     // MARK: - Bottom Bar
@@ -431,13 +622,13 @@ struct TestSetupView: View {
                 if countFieldFocused { countReplaceAnchor = "\(newValue)" }
             }
             .onAppear { countDraft = "\(clampedCount)" }
+            // Just "Done" — a number pad has no return key, so something has to
+            // dismiss it. "Max" used to sit here too, duplicating the one in the
+            // bar below: that one deliberately keeps working with the keypad up
+            // (the field tracks the count whether or not it has focus), so the
+            // toolbar copy only ever covered the row it was copying.
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
-                    Button("Max (\(selectedCount))") {
-                        setCount(selectedCount)
-                        HapticEngine.light()
-                    }
-                    .disabled(selectedCount == 0)
                     Spacer()
                     Button("Done") { countFieldFocused = false }
                 }

--- a/scripture memory/Views/TestSetupView.swift
+++ b/scripture memory/Views/TestSetupView.swift
@@ -33,6 +33,14 @@ struct TestSetupView: View {
     /// swaps to a number-pad field.
     @State private var countDraft = ""
     @FocusState private var countFieldFocused: Bool
+    /// The value the field is showing that a keystroke should *replace* rather than
+    /// extend — set whenever the count arrives from somewhere other than typing
+    /// (focus, +/-, Max), cleared once a digit has replaced it.
+    ///
+    /// The field used to blank itself on focus to get the same effect, which left it
+    /// showing nothing while the stepper still held a value, so any +/- tap made
+    /// with the keypad up looked like it did nothing at all.
+    @State private var countReplaceAnchor: String? = nil
 
     private static let savedSessionKey = "lastTestSessionVerseIds"
     private static let quizCountKey    = "reviewSetupQuizCount"
@@ -286,7 +294,7 @@ struct TestSetupView: View {
             VStack(spacing: 4) {
                 HStack(spacing: 10) {
                     Button {
-                        if quizCount > 1 { quizCount -= 1 }
+                        setCount(clampedCount - 1)
                     } label: {
                         Image(systemName: "minus")
                             .font(.system(size: 13, weight: .semibold))
@@ -302,7 +310,7 @@ struct TestSetupView: View {
                     countField
 
                     Button {
-                        if quizCount < selectedCount { quizCount += 1 }
+                        setCount(clampedCount + 1)
                     } label: {
                         Image(systemName: "plus")
                             .font(.system(size: 13, weight: .semibold))
@@ -315,9 +323,25 @@ struct TestSetupView: View {
                     .opacity(clampedCount >= selectedCount ? 0.35 : 1)
                     .accessibilityLabel("More cards to quiz")
                 }
-                Text("cards to quiz")
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                // "Max" is the one count that's tedious to reach by stepping and
+                // annoying to type — quizzing everything you just selected.
+                HStack(spacing: 6) {
+                    Text("cards to quiz")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                    Button {
+                        setCount(selectedCount)
+                        HapticEngine.light()
+                    } label: {
+                        Text("Max")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(clampedCount >= selectedCount)
+                    .opacity(clampedCount >= selectedCount ? 0.35 : 1)
+                    .accessibilityLabel("Quiz all \(selectedCount) selected verses")
+                }
             }
 
             Spacer()
@@ -342,17 +366,18 @@ struct TestSetupView: View {
     /// The card count, tappable to type a value directly instead of stepping there
     /// one press at a time. Always a `TextField` (rather than a label that swaps for
     /// one on tap) so tapping it focuses an already-mounted responder and the keypad
-    /// opens on the first tap. While unfocused it renders the clamped count, so it
-    /// still tracks the +/- buttons and the selection.
+    /// opens on the first tap. It renders the live count whether or not it has
+    /// focus, so the +/- buttons and Max keep working with the keypad up.
     private var countField: some View {
         TextField("", text: $countDraft)
             .keyboardType(.numberPad)
             .multilineTextAlignment(.center)
             .font(.system(size: 22, weight: .bold, design: .monospaced))
             .focused($countFieldFocused)
-            .frame(minWidth: 44)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
+            // Fixed size: the field sits between the two stepper circles, and
+            // letting it grow with the digit count shunted them sideways every
+            // time the number crossed 10 or 100.
+            .frame(width: 58, height: 32)
             .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
             // Sanitise and commit on every keystroke, so what the field shows is
             // always exactly what Start will use.
@@ -363,8 +388,18 @@ struct TestSetupView: View {
             // And committing only when editing ended wasn't enough: tapping a pack
             // row doesn't resign focus, so the field could sit there reading "999"
             // while the session quietly still used the old number.
-            .onChange(of: countDraft) { _, newValue in
-                var digits = String(newValue.filter(\.isNumber).prefix(4))
+            .onChange(of: countDraft) { oldValue, newValue in
+                // First digit typed after the count arrived from elsewhere replaces
+                // it rather than extending it: tap the field showing 15, type "8",
+                // get 8 — not 158. Gated on the anchor still being what's on screen,
+                // so a +/- or Max tap made mid-edit isn't mistaken for that keystroke.
+                var incoming = newValue
+                if let anchor = countReplaceAnchor, oldValue == anchor,
+                   newValue.count > anchor.count, newValue.hasPrefix(anchor) {
+                    incoming = String(newValue.dropFirst(anchor.count))
+                    countReplaceAnchor = nil
+                }
+                var digits = String(incoming.filter(\.isNumber).prefix(4))
                 if let typed = Int(digits) {
                     let clamped = max(1, min(typed, max(1, selectedCount)))
                     // Rewrite the field too, so it can never display a count that's
@@ -378,18 +413,31 @@ struct TestSetupView: View {
             }
             .onChange(of: countFieldFocused) { _, focused in
                 if focused {
-                    countDraft = ""          // start clean — typing replaces, not appends
+                    // Keep the number visible while editing (it's what +/- and Max
+                    // drive); the next keystroke swaps it out.
+                    countDraft = "\(clampedCount)"
+                    countReplaceAnchor = "\(clampedCount)"
                 } else {
+                    countReplaceAnchor = nil
                     commitCountEdit()
                 }
             }
             .onChange(of: clampedCount) { _, newValue in
-                // +/- taps and selection changes while not editing.
-                if !countFieldFocused { countDraft = "\(newValue)" }
+                // Any count change that didn't come from typing — +/-, Max, or the
+                // selection shrinking under it. The field tracks it even while
+                // focused, so what's displayed is always what Start will use.
+                guard countDraft != "\(newValue)" else { return }
+                countDraft = "\(newValue)"
+                if countFieldFocused { countReplaceAnchor = "\(newValue)" }
             }
             .onAppear { countDraft = "\(clampedCount)" }
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
+                    Button("Max (\(selectedCount))") {
+                        setCount(selectedCount)
+                        HapticEngine.light()
+                    }
+                    .disabled(selectedCount == 0)
                     Spacer()
                     Button("Done") { countFieldFocused = false }
                 }
@@ -400,6 +448,17 @@ struct TestSetupView: View {
     }
 
     // MARK: - Actions
+
+    /// Single write path for the card count from anything that isn't typing (+/-,
+    /// Max). Pushes the clamped value into the field too, so the number on screen
+    /// and the number Start will use never drift apart — including while the
+    /// keypad is up.
+    private func setCount(_ value: Int) {
+        let clamped = max(1, min(value, max(1, selectedCount)))
+        quizCount  = clamped
+        countDraft = "\(clamped)"
+        countReplaceAnchor = countFieldFocused ? "\(clamped)" : nil
+    }
 
     /// Applies a typed card count, clamped to 1...selected. An empty or unparseable
     /// draft (tapped in, then out) falls back to the count already in effect.

--- a/scripture memory/Views/VerseSearch.swift
+++ b/scripture memory/Views/VerseSearch.swift
@@ -13,6 +13,7 @@ struct VerseSearchResult: Identifiable {
 
 // MARK: - Matching
 
+@MainActor
 enum VerseSearch {
 
     /// Cap on rows returned. A short query like "the" matches most of the library,
@@ -20,71 +21,153 @@ enum VerseSearch {
     /// walked and rendered for a result nobody scrolls to.
     static let resultLimit = 25
 
-    /// Case-insensitive substring match over reference, title and verse body,
-    /// scanned in pack order so results stay in the same sequence the user browses.
+    /// One verse, pre-lowercased for matching.
+    ///
+    /// Lowercasing is why search felt like it had a debounce on it: the old
+    /// matcher lowercased three fields of all ~490 verses on *every keystroke*,
+    /// inside `body`, on the main thread — roughly 1,500 fresh strings per
+    /// character typed, with the keystroke's frame waiting on all of it. Doing it
+    /// once per catalogue instead leaves the per-keystroke cost at a substring
+    /// scan over strings that already exist.
+    private struct Entry {
+        let reference: String     // "john 3:16"
+        let title:     String
+        let body:      String
+        let packIndex: Int
+        let verseIndex: Int
+    }
+
+    /// The built index, tagged with the pack set it was built from. Rebuilt only
+    /// when the catalogue itself changes (translation switch, pack reorder or
+    /// hide) — not when the query does.
+    private static var cached: (token: Int, entries: [Entry])?
+
+    /// Case-insensitive substring match over reference, title and verse body.
+    ///
+    /// Reference and title matches come first, then body matches, each group in
+    /// pack order. Searching "john 3:16" should lead with John 3:16 itself, not
+    /// with whichever verse happens to say "John" earliest in the library.
     static func results(for query: String, in packs: [Pack]) -> [VerseSearchResult] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !q.isEmpty else { return [] }
 
-        var results: [VerseSearchResult] = []
-        for pack in packs {
-            for (index, verse) in pack.verses.enumerated() {
-                let ref = "\(verse.book) \(verse.reference)".lowercased()
-                if ref.contains(q)
-                    || verse.title.lowercased().contains(q)
-                    || verse.verse.lowercased().contains(q) {
-                    results.append(VerseSearchResult(verse: verse, pack: pack, verseIndex: index))
-                    if results.count == resultLimit { return results }
-                }
+        let entries = index(for: packs)
+        var primary:   [VerseSearchResult] = []
+        var secondary: [VerseSearchResult] = []
+
+        for entry in entries {
+            let onReference = entry.reference.contains(q) || entry.title.contains(q)
+            if onReference {
+                primary.append(result(entry, in: packs))
+                if primary.count == resultLimit { return primary }
+            } else if secondary.count < resultLimit, entry.body.contains(q) {
+                secondary.append(result(entry, in: packs))
             }
         }
-        return results
+        return Array((primary + secondary).prefix(resultLimit))
+    }
+
+    /// Drop the built index. Call when verse *content* changes under a pack set
+    /// that still fingerprints the same — a remote catalog refresh, say, which can
+    /// rewrite verse text without changing any pack's name or size.
+    static func invalidate() { cached = nil }
+
+    private static func result(_ entry: Entry, in packs: [Pack]) -> VerseSearchResult {
+        let pack = packs[entry.packIndex]
+        return VerseSearchResult(verse: pack.verses[entry.verseIndex],
+                                 pack: pack, verseIndex: entry.verseIndex)
+    }
+
+    private static func index(for packs: [Pack]) -> [Entry] {
+        let token = fingerprint(packs)
+        if let cached, cached.token == token { return cached.entries }
+
+        var entries: [Entry] = []
+        entries.reserveCapacity(packs.reduce(0) { $0 + $1.verses.count })
+        for (packIndex, pack) in packs.enumerated() {
+            for (verseIndex, verse) in pack.verses.enumerated() {
+                entries.append(Entry(
+                    reference: "\(verse.book) \(verse.reference)".lowercased(),
+                    title:     verse.title.lowercased(),
+                    body:      verse.verse.lowercased(),
+                    packIndex: packIndex,
+                    verseIndex: verseIndex))
+            }
+        }
+        cached = (token, entries)
+        return entries
+    }
+
+    /// Cheap stand-in for "is this the same catalogue?" — pack names and sizes.
+    /// Hashing ~15 short strings beats rebuilding ~490 lowercased entries, and the
+    /// two things that change the pack set in practice (translation, pack
+    /// order/visibility) both move it.
+    private static func fingerprint(_ packs: [Pack]) -> Int {
+        var hasher = Hasher()
+        for pack in packs {
+            hasher.combine(pack.name)
+            hasher.combine(pack.verses.count)
+        }
+        return hasher.finalize()
     }
 }
 
 // MARK: - Results List
 
-/// The verse-search results list, shared by Home and Packs so both searches look
+/// The verse-search results rows, shared by Home and Packs so both searches look
 /// and behave identically.
+///
+/// Deliberately *not* wrapped in its own `ScrollView`: each screen owns a single
+/// scroll view whose content swaps between the screen's normal body and these
+/// rows. Two scroll views alternating under one `.searchable` left the navigation
+/// bar attached to whichever had been there first, which is what made a screen
+/// open already scrolled past its own title.
 struct VerseSearchResultsList: View {
     let query:    String
     let results:  [VerseSearchResult]
     let onSelect: (VerseSearchResult) -> Void
 
+    @ObservedObject private var favorites = FavoritesStore.shared
+
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                if results.isEmpty {
-                    ContentUnavailableView {
-                        Label("No Results", systemImage: "magnifyingglass")
-                    } description: {
-                        Text("No verses match \u{201C}\(query)\u{201D}.")
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 48)
-                } else {
-                    ForEach(results) { result in
-                        VStack(spacing: 0) {
-                            Button { onSelect(result) } label: { row(result) }
-                                .buttonStyle(.plain)
-                            Divider().padding(.leading, 16)
-                        }
+        LazyVStack(spacing: 0) {
+            if results.isEmpty {
+                ContentUnavailableView {
+                    Label("No Results", systemImage: "magnifyingglass")
+                } description: {
+                    Text("No verses match \u{201C}\(query)\u{201D}.")
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 48)
+            } else {
+                ForEach(results) { result in
+                    VStack(spacing: 0) {
+                        Button { onSelect(result) } label: { row(result) }
+                            .buttonStyle(.plain)
+                        Divider().padding(.leading, 16)
                     }
                 }
             }
-            .background(Color(.systemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: AppLayout.cardRadius, style: .continuous))
-            .padding(.horizontal, AppLayout.screenMargin)
-            .padding(.top, 8)
         }
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: AppLayout.cardRadius, style: .continuous))
+        .padding(.horizontal, AppLayout.screenMargin)
+        .padding(.top, 8)
     }
 
     private func row(_ result: VerseSearchResult) -> some View {
         HStack(spacing: 14) {
             VStack(alignment: .leading, spacing: 3) {
-                Text("\(result.verse.book) \(result.verse.reference)")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(.primary)
+                HStack(spacing: 6) {
+                    Text("\(result.verse.book) \(result.verse.reference)")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    if let pinned = result.verse.pinnedVersion {
+                        Text("(\(pinned))")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 Text(result.verse.title)
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.primary)
@@ -94,11 +177,17 @@ struct VerseSearchResultsList: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .multilineTextAlignment(.leading)
-                Text(result.pack.name)
+                Text(VerseNumbering.code(for: result.verse) ?? result.pack.name)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.tertiary)
             }
             Spacer()
+            if favorites.isFavorite(result.verse) {
+                Image(systemName: "star.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.yellow)
+                    .accessibilityLabel("Favourite")
+            }
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,164 @@
+# Managing verses outside the app
+
+The bundled JSON in `scripture memory/Resources/` is still the floor: it ships
+with the app, it's complete, and a fresh install reads it with no network at
+all. Supabase sits on top so a typo or a missing verse can be corrected without
+shipping a build through App Store review.
+
+Nothing here is active until you fill in the two Info.plist keys. Until then the
+app behaves exactly as it did before and never makes a request.
+
+## One-time setup
+
+1. Create a project at [supabase.com](https://supabase.com). (You'll need to do
+   this yourself — it's an account signup.)
+2. **SQL Editor → New query**, paste `schema.sql`, run it.
+3. **Project Settings → API Keys**, copy the *Project URL* and the
+   **publishable** key (`sb_publishable_…`) into `AppInfo.plist`:
+
+   ```xml
+   <key>SupabaseURL</key>
+   <string>https://yourproject.supabase.co</string>
+   <key>SupabaseAnonKey</key>
+   <string>sb_publishable_...</string>
+   ```
+
+   The publishable key is meant to ship in clients — it's what replaced the old
+   `anon` key. Row-level security (bottom of `schema.sql`) makes the catalog
+   world-readable and writable by nobody. The **secret** key (`sb_secret_…`,
+   formerly `service_role`) bypasses RLS and must never go in the app or in git.
+
+4. Seed it from the bundled JSON — run this yourself, so the secret key stays on
+   your machine:
+
+   ```bash
+   SUPABASE_URL=https://yourproject.supabase.co \
+   SUPABASE_SERVICE_KEY=<secret key> \
+   python3 Scripts/seed_supabase.py
+   ```
+
+## Editing a verse
+
+Supabase's **Table Editor** is the admin UI — no separate tool to build or host.
+
+Edit the row. That's it: a trigger publishes the change for you by bumping the
+catalog version, so there's no second step to forget.
+
+To release a set of related corrections **together** rather than one at a time,
+wrap them in a transaction — the version moves once, at commit:
+
+```sql
+begin;
+  update verses set verse = '...' where id = 1;
+  update verses set verse = '...' where id = 2;
+commit;
+```
+
+`select bump_catalog_version();` still exists as a manual override, for forcing
+clients to re-download when nothing in the tables actually changed.
+
+Sanity check, if you ever suspect an edit didn't go out:
+
+```sql
+select * from catalog_status;
+```
+
+`unpublished_edits` should always read 0. Anything else means the triggers
+aren't installed — re-run `schema.sql`.
+
+### When the change appears
+
+On the next launch, not immediately. The refresh runs at startup, writes a
+cache file, and stops — the running session keeps the catalog it started with.
+Printed card numbers, the search index, an in-flight quiz's verse list and the
+learning cursor's position are all computed once from the catalog and held for
+the life of the process; swapping it underneath them would renumber cards
+mid-quiz for a payoff nobody is waiting on. So: open the app, close it, open it
+again.
+
+## Adding and removing
+
+### The thing to understand first
+
+**Every card is two rows** — one per edition (`NIV84`, `NIV11`) — and the two
+must share a `card_uid`. That id is what user progress is filed under, so if the
+editions disagree about it, a user switching translation loses their history for
+that card. Nothing in the Table Editor shows you this.
+
+So don't add cards by hand. Use:
+
+```sql
+select add_card('DEP 2: Quiet Time', 7, 'Seek him early',
+                'Psalm', '63:1', 'O God, you are my God…');
+```
+
+It inserts into every edition of that pack with one shared id. Different text per
+translation:
+
+```sql
+select add_card('DEP 2: Quiet Time', 7, 'Seek him early', 'Psalm', '63:1',
+                p_verse_by_edition => '{"NIV84":"…","NIV11":"…"}'::jsonb);
+```
+
+Editing existing text *is* fine in the Table Editor — just remember a typo fix
+usually needs doing in both editions.
+
+**A pack.** Insert into `packs` **once per edition**, then its verses via
+`add_card`. A pack added to only one edition won't exist for users on the other
+translation.
+
+### Check yourself
+
+```sql
+select * from catalog_problems;
+```
+
+Empty means coherent. It reports packs present in only one edition, cards whose
+editions disagree on `card_uid`, and two verses claiming the same `sort_index`.
+Worth running after any structural change.
+
+New packs get the generic cover. The DEP, TMS 60, TMS 180 and 5 Assurances
+designs are matched by name in `PackCover`, and the series footers
+(`A-12 · Live the New Life`) come from a list in `CardFooter` — a new pack falls
+back to plain styling rather than breaking.
+
+**Removing** a verse or a pack works as you'd expect (packs cascade to their
+verses). Users who had progress on a deleted verse keep a harmless orphan entry.
+
+## Two things to be careful with
+
+**`verse_id` is not a database key.** It's the id the *app* persists progress
+against — quiz selections, submitted answers, review-complete flags all live on
+device keyed by it. Changing an existing verse's `verse_id` silently repoints a
+user's saved progress at a different verse. Adding a verse? Give it an unused
+id (the `Scripts/sync_verses.py` insertions start at 20001) rather than
+renumbering the pack around it.
+
+**Learning and SRS progress are keyed by pack name + book + reference**, not by
+`verse_id`. Renaming a pack or rewriting a reference orphans every user's
+progress for the verses in it. Fixing the verse *text* is free; changing what
+identifies the verse is not.
+
+## Keeping the two in sync
+
+The bundled JSON is the offline fallback, so it shouldn't drift far from what's
+hosted. `Scripts/seed_supabase.py --check` compares them and exits non-zero if
+they differ — worth running in CI.
+
+To go the other way (source of truth → JSON), `Scripts/sync_verses.py`
+reconciles the bundled files against the Navigators' published packs at
+tms.navigators.tech:
+
+```bash
+python3 Scripts/sync_verses.py audit    # report differences
+python3 Scripts/sync_verses.py patch    # apply them
+```
+
+Then re-run the seed to push the result up.
+
+## Widget note
+
+The widget extension has its own bundle and can't read the app's resources, so
+it ships a byte-copy of `verseData.json` and does **not** read the remote
+catalog. `sync_verses.py patch` re-mirrors that copy. A verse corrected remotely
+will show the old text in the widget until the next app release.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,381 @@
+-- Verse catalog schema for Scripture Memory.
+--
+-- Run once in the Supabase SQL editor (Dashboard → SQL Editor → New query).
+-- After it succeeds, seed the data with:
+--
+--     SUPABASE_URL=https://<project>.supabase.co \
+--     SUPABASE_SERVICE_KEY=<service_role key> \
+--     python3 Scripts/seed_supabase.py
+--
+-- Editing afterwards: the Table Editor is the admin UI. Change a verse row,
+-- then bump the version so clients notice:
+--
+--     select bump_catalog_version();
+--
+-- Clients read this with the *anon* key, which is publishable. The policies at
+-- the bottom are what make that safe: anyone may read, nobody may write. All
+-- writes go through the service_role key, which lives on your machine and in
+-- CI — never in the app.
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+
+create table if not exists packs (
+    id          bigint generated always as identity primary key,
+    -- Which bundled edition this pack belongs to: 'NIV84' or 'NIV11'. The two
+    -- are separate rows, not translations of one row, because they differ in
+    -- more than text — a card can be present in one and absent from the other.
+    edition     text    not null,
+    name        text    not null,
+    color       text    not null,
+    accent_text text    not null default '',
+    -- Display order within the edition. The app applies the user's own pack
+    -- ordering on top of this; this is the shipped default.
+    sort_index  integer not null,
+    unique (edition, name)
+);
+
+create table if not exists verses (
+    id         bigint generated always as identity primary key,
+    pack_id    bigint  not null references packs(id) on delete cascade,
+    -- The card's permanent identity, and what all user progress on device is
+    -- filed under. Identical in both editions. NEVER edit this: changing it
+    -- detaches every user's learnt/starred/scheduled state for that card. It is
+    -- deliberately meaningless so that nothing you *can* sensibly edit — the
+    -- pack's name, the book's spelling, the reference's punctuation — is load
+    -- bearing. Those are all now safe to change.
+    --
+    -- Nullable only so this file stays re-runnable against a database seeded
+    -- before the column existed; the seed script always populates it, and the
+    -- app ignores a catalog with any uid missing.
+    card_uid   text,
+    -- The id the *app* knows this verse by. Quiz selections, submitted answers
+    -- and review-complete flags are all persisted against it on device, so it
+    -- is authored data, not a generated key: changing it silently repoints a
+    -- user's saved progress at a different verse. Only unique within an
+    -- edition — the same card has different ids in NIV84 and NIV11.
+    verse_id   bigint  not null,
+    sort_index integer not null,
+    title      text    not null,
+    verse      text    not null,
+    book       text    not null,
+    reference  text    not null,
+    -- Lettered section, e.g. TMS 60's 'A'..'E'. Empty for packs that are one
+    -- straight run.
+    subpack    text    not null default '',
+    -- Translation override for a card printed in something other than its
+    -- pack's edition (a few DEP cards are KJV). NULL means "the pack's own".
+    version    text,
+    unique (pack_id, verse_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- Columns added after the first release
+-- ---------------------------------------------------------------------------
+--
+-- `create table if not exists` does nothing at all to a table that already
+-- exists — including adding columns declared above. Anything introduced after
+-- the first run has to be stated separately, and it has to come before the
+-- indexes and views that reference it. All of these are safe to re-run.
+
+alter table verses add column if not exists card_uid   text;
+alter table packs  add column if not exists updated_at timestamptz not null default now();
+alter table verses add column if not exists updated_at timestamptz not null default now();
+
+-- Defaults for the two columns you'd otherwise have to invent by hand.
+--
+-- Adding a verse in the Table Editor means filling a row without leaving these
+-- blank, and a blank card_uid is the single worst mistake available: the app
+-- refuses a catalog in which any verse lacks one, so one empty cell stops every
+-- device updating and says nothing about why. Generating both here means a new
+-- row only needs its text.
+create sequence if not exists verse_id_seq start with 30001;
+
+alter table verses alter column verse_id set default nextval('verse_id_seq');
+alter table verses alter column card_uid set default encode(gen_random_bytes(8), 'hex');
+
+-- Backfill anything inserted before the default existed, then make it a rule
+-- rather than a convention.
+update verses set card_uid = encode(gen_random_bytes(8), 'hex') where card_uid is null;
+alter table verses alter column card_uid set not null;
+
+create index if not exists verses_pack_sort_idx on verses (pack_id, sort_index);
+create index if not exists packs_edition_idx     on packs  (edition, sort_index);
+create index if not exists verses_card_uid_idx   on verses (card_uid);
+
+-- ---------------------------------------------------------------------------
+-- Change tracking
+-- ---------------------------------------------------------------------------
+--
+-- Clients only re-download when `catalog_meta.version` goes up, and that only
+-- happens when you call bump_catalog_version(). Which means a forgotten bump
+-- looks exactly like a successful edit: the row shows your new text, and no
+-- device ever sees it. These stamps make that visible instead of silent.
+
+create or replace function touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at := now();
+    return new;
+end;
+$$;
+
+drop trigger if exists packs_touch_updated_at on packs;
+create trigger packs_touch_updated_at
+    before update on packs
+    for each row execute function touch_updated_at();
+
+drop trigger if exists verses_touch_updated_at on verses;
+create trigger verses_touch_updated_at
+    before update on verses
+    for each row execute function touch_updated_at();
+
+-- Single-row table the client polls on launch. Fetching one integer to learn
+-- there is nothing to do is much cheaper than downloading ~490 verses to
+-- discover the same.
+create table if not exists catalog_meta (
+    id         integer     primary key default 1,
+    version    bigint      not null default 1,
+    updated_at timestamptz not null default now(),
+    constraint catalog_meta_singleton check (id = 1)
+);
+
+insert into catalog_meta (id, version) values (1, 1)
+on conflict (id) do nothing;
+
+-- Publish whatever is currently in the tables. Edits publish themselves (see
+-- Auto-publish below), so this is now a manual override — useful to force
+-- clients to re-download when nothing in the tables actually changed.
+create or replace function bump_catalog_version()
+returns bigint
+language sql
+as $$
+    update catalog_meta
+       set version = version + 1, updated_at = now()
+     where id = 1
+ returning version;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Auto-publish
+-- ---------------------------------------------------------------------------
+--
+-- Any edit to packs or verses publishes itself. Without this, editing a row in
+-- the Table Editor looked exactly like a successful change while reaching
+-- precisely nobody — the version never moved, so no client ever re-downloaded.
+--
+-- FOR EACH STATEMENT, not FOR EACH ROW: seeding inserts ~1,000 verses, and a
+-- per-row trigger would bump the version a thousand times to say one thing.
+--
+-- The cost of this convenience is that edits go out as you make them. To
+-- release a set of related changes together, wrap them in a transaction — one
+-- statement each, but a single visible version at the end:
+--
+--     begin;
+--       update verses set verse = '...' where id = 1;
+--       update verses set verse = '...' where id = 2;
+--     commit;
+
+-- `security definer` so the bump can't be blocked by row-level security on
+-- catalog_meta, which has no write policy by design. Today only the service
+-- role can write packs/verses and it bypasses RLS anyway; this keeps the
+-- trigger working if a narrower writer role is ever added, instead of failing
+-- the edit with a confusing permission error. `search_path` is pinned, which is
+-- the required companion to `security definer` — without it a caller could
+-- shadow `catalog_meta` with their own table and run this as the owner.
+create or replace function bump_catalog_version_from_edit()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+    update catalog_meta
+       set version = version + 1, updated_at = now()
+     where id = 1;
+    return null;
+end;
+$$;
+
+drop trigger if exists packs_bump_catalog_version on packs;
+create trigger packs_bump_catalog_version
+    after insert or update or delete or truncate on packs
+    for each statement execute function bump_catalog_version_from_edit();
+
+drop trigger if exists verses_bump_catalog_version on verses;
+create trigger verses_bump_catalog_version
+    after insert or update or delete or truncate on verses
+    for each statement execute function bump_catalog_version_from_edit();
+
+-- Sanity check: `select * from catalog_status;`
+--
+-- With auto-publish above, `unpublished_edits` should always read 0. If it ever
+-- doesn't, the triggers aren't installed — re-run this file — and the fallback
+-- is to publish by hand with `select bump_catalog_version();`.
+--
+-- Defined here, after catalog_meta, because a view can't reference a table that
+-- doesn't exist yet.
+create or replace view catalog_status as
+select
+    m.version                                            as published_version,
+    m.updated_at                                         as published_at,
+    greatest(
+        coalesce((select max(updated_at) from verses), m.updated_at),
+        coalesce((select max(updated_at) from packs),  m.updated_at)
+    )                                                    as last_edit_at,
+    (select count(*) from verses where updated_at > m.updated_at)
+  + (select count(*) from packs  where updated_at > m.updated_at)
+                                                         as unpublished_edits
+from catalog_meta m
+where m.id = 1;
+
+-- Run this view as whoever queries it, not as its owner.
+--
+-- Postgres 15+ creates views as SECURITY DEFINER by default, which Supabase's
+-- linter flags: the view would read packs/verses/catalog_meta with the owner's
+-- rights and skip the caller's row-level security. It changes nothing today —
+-- all three tables are publicly readable, so the view can't reveal a row anyone
+-- couldn't already select — but the day rows on verses or packs are restricted,
+-- this would silently keep counting all of them.
+alter view catalog_status set (security_invoker = on);
+
+-- ---------------------------------------------------------------------------
+-- Row-level security
+-- ---------------------------------------------------------------------------
+--
+-- Read-only to the world; writes only via service_role, which bypasses RLS.
+
+alter table packs        enable row level security;
+alter table verses       enable row level security;
+alter table catalog_meta enable row level security;
+
+drop policy if exists "catalog is publicly readable" on packs;
+create policy "catalog is publicly readable"
+    on packs for select to anon, authenticated using (true);
+
+drop policy if exists "catalog is publicly readable" on verses;
+create policy "catalog is publicly readable"
+    on verses for select to anon, authenticated using (true);
+
+drop policy if exists "catalog is publicly readable" on catalog_meta;
+create policy "catalog is publicly readable"
+    on catalog_meta for select to anon, authenticated using (true);
+
+-- The status view is for you, not for clients; it reads tables the anon role
+-- can already select from, so nothing is exposed that wasn't.
+grant select on catalog_status to anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Consistency check
+-- ---------------------------------------------------------------------------
+--
+-- `select * from catalog_problems;` — empty means the catalog is coherent.
+--
+-- Every card is two rows, one per edition, and they have to agree about which
+-- card they are. That's invisible in the Table Editor, and getting it wrong is
+-- silent: a card whose two editions carry different `card_uid`s loses the
+-- user's progress the moment they switch translation. This makes each of those
+-- mistakes a row you can see.
+
+-- Add one card to every edition of a pack in a single call.
+--
+--   select add_card('DEP 2: Quiet Time', 7, 'Seek him early',
+--                   'Psalm', '63:1', 'O God, you are my God...');
+--
+-- Doing this by hand means two inserts that must agree on `card_uid` — and the
+-- column's default generates a *different* random id per row, so the natural
+-- way to add a card is also the way to break it. One uid is minted here and
+-- shared, which is the whole point of the function.
+--
+-- Pass `p_verse_by_edition` to give each translation its own text:
+--   '{"NIV84": "...", "NIV11": "..."}'::jsonb
+create or replace function add_card(
+    p_pack_name text,
+    p_sort_index integer,
+    p_title text,
+    p_book text,
+    p_reference text,
+    p_verse text default null,
+    p_verse_by_edition jsonb default null,
+    p_subpack text default '',
+    p_version text default null
+) returns text
+language plpgsql
+as $$
+declare
+    new_uid text := encode(gen_random_bytes(8), 'hex');
+    pack record;
+    body text;
+begin
+    if p_verse is null and p_verse_by_edition is null then
+        raise exception 'give either p_verse or p_verse_by_edition';
+    end if;
+
+    for pack in select id, edition from packs where name = p_pack_name loop
+        body := coalesce(p_verse_by_edition ->> pack.edition, p_verse);
+        if body is null then
+            raise exception 'no verse text for edition %', pack.edition;
+        end if;
+        insert into verses (pack_id, card_uid, sort_index, title, verse,
+                            book, reference, subpack, version)
+        values (pack.id, new_uid, p_sort_index, p_title, body,
+                p_book, p_reference, p_subpack, p_version);
+    end loop;
+
+    if not found then
+        raise exception 'no pack named %', p_pack_name;
+    end if;
+    return new_uid;
+end;
+$$;
+
+create or replace view catalog_problems as
+    -- A pack added to one edition only. Users on the other never see it.
+    select 'pack missing from an edition'::text as problem,
+           (p.edition || ' / ' || p.name)::text as detail
+      from packs p
+     where not exists (select 1 from packs q
+                        where q.name = p.name and q.edition <> p.edition)
+
+    union all
+
+    -- The same passage carrying different ids in the two editions. This is the
+    -- one that costs users their progress.
+    --
+    -- Compares the *set* of ids per edition rather than counting distinct ids
+    -- across both, because three packs legitimately print the same passage on
+    -- two different cards (Acts 17:11 is DEP 3 cards 23 and 32) and those
+    -- rightly hold two ids. Whitespace is stripped from the reference first:
+    -- the editions disagree on `27:17, 19` versus `27:17,19`, which is only a
+    -- spelling of the same reference — and is exactly how the ids were minted.
+    select 'card_uid differs between editions'::text,
+           (t.name || ' / ' || t.book || ' ' || t.reference)::text
+      from (
+            select p.name,
+                   v.book,
+                   regexp_replace(v.reference, '\s', '', 'g') as reference,
+                   p.edition,
+                   array_agg(v.card_uid order by v.card_uid) as uids
+              from verses v
+              join packs p on p.id = v.pack_id
+             group by p.name, v.book, regexp_replace(v.reference, '\s', '', 'g'), p.edition
+           ) t
+     group by t.name, t.book, t.reference
+    having count(distinct t.uids) > 1
+
+    union all
+
+    -- Two verses claiming the same position in a pack: the card order becomes
+    -- whatever Postgres feels like, and the printed numbers drift.
+    select 'duplicate sort_index'::text,
+           (p.edition || ' / ' || p.name || ' #' || v.sort_index::text)::text
+      from verses v
+      join packs p on p.id = v.pack_id
+     group by p.edition, p.name, v.sort_index
+    having count(*) > 1;
+
+alter view catalog_problems set (security_invoker = on);
+grant select on catalog_problems to anon, authenticated;


### PR DESCRIPTION
Addresses the batch of user-reported issues, plus the data and identity problems they surfaced.

## Reported issues

- **Read mode is list-only** — the single-card view and its toggle are gone.
- **List counter was wrong at both ends.** It inverted the card layout to find whichever card sat under the middle of the viewport, but the viewport is taller than a card and can't scroll far enough to centre the first or last one. Now mapped off the scroll fraction through `ScrubberMath.index`, so it agrees with the fast-scroll thumb by construction.
- **Search felt debounced** because it lowercased three fields of ~490 verses *inside `body`*, on every keystroke — ~1,500 fresh strings per character, with the keystroke's frame waiting on it. Indexed once per catalogue.
- **Screens opened scrolled past their own title.** Two alternating `ScrollView`s under one `.searchable` left the nav bar attached to whichever mounted first. One scroll view per screen now.
- **Favourites** — pseudo-pack on the grid, in-pack filter, review and quiz support.
- **Quiz picker** — rows select, `Deselect All` in the nav bar, "up to here" spans, printed card numbers, two-finger drag-select.

## Data, reconciled against tms.navigators.tech

Its Next.js payload carries full pack contents and `?bibleVersion=` switches translation, so it works as the authoritative source. `Scripts/sync_verses.py` audits and patches against it.

- **4 verses missing** from TMS 180 restored, including Matthew 25:41 which hadn't been reported.
- **TMS 60 A-7/A-8 were swapped in NIV84** relative to both the printed source and the NIV11 edition — the same card had a different number depending on translation.
- **1 Thess 5:17 and Psalm 27:8** pinned to KJV with a `(KJV)` badge; those cards are printed in KJV whatever edition surrounds them.
- A title typo, and a stray `U+001A` that was invisible on the card but which the tokenizer counted as a word nobody could type.

## Card identity

Progress was keyed on `pack + book + reference`. Renaming a pack or restyling a reference silently orphaned it — one careless edit away, now that the catalog is editable from a web console. Every card now carries a permanent opaque `cardUid`, with a one-time migration of learnt / pinned / starred / SRS state (verified on a simulated pre-migration install).

Minting those ids surfaced that **three packs print the same passage on two different cards** (Acts 17:11 is DEP 3 cards 23 *and* 32). Under the old key each pair was one card: starring one starred both, and learning one skipped the other.

## Remote catalog

Supabase-backed with the bundled JSON as the offline floor, cached in the shared App Group so the widget reads the same file rather than its own stale copy. Edits auto-publish via a statement-level trigger and land on the next launch — deliberately not mid-session, since card numbers, the search index and an in-flight quiz's verse list are all computed once at startup.

`catalog_status` and `catalog_problems` make the silent failure modes visible; `add_card()` inserts into every edition with one shared id, which is the mistake the schema otherwise invites.

## Scoring

- **Punctuation-only tokens are no longer scored.** ~30 cards title themselves "Man - the sinner", and the dash counted as a missing word — so those cards could never come out perfect.
- **British and American spellings both accepted.** A fixed word list rather than a `-our -> -or` rule, which would misfire on *four*, *hour*, *pour*, *devour*.

## Covers

Rebuilt from photographs of the printed packs: colours sampled and white-balanced, the DEP/242 lockup positioned from measurements as a percentage of the card, plus a TMS 180 style and a *Lessons on Assurance*-inspired 5 Assurances design.

## Notes

- Excludes the `android/` directory, as requested.
- `AppInfo.plist` carries the Supabase **publishable** key, which is designed to ship in clients and is read-only by RLS. No secret key is in the repo.
- 83 tests pass; app builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)